### PR TITLE
Include image and region parameters in blaxel setup

### DIFF
--- a/src/direct-providers.ts
+++ b/src/direct-providers.ts
@@ -26,7 +26,7 @@ export const directProviders: DirectBenchmarkConfig[] = [
   {
     name: 'blaxel',
     requiredEnvVars: ['BL_API_KEY', 'BL_WORKSPACE'],
-    createCompute: () => blaxel({ apiKey: process.env.BL_API_KEY!, workspace: process.env.BL_WORKSPACE! }),
+    createCompute: () => blaxel({ apiKey: process.env.BL_API_KEY!, workspace: process.env.BL_WORKSPACE!, image: "blaxel/benchmark:latest", region: "us-was-1" }),
   },
   {
     name: 'modal',


### PR DESCRIPTION
User can pick their region and default image, so it doesn't depend of the underlying SDK version.