### PR TITLE
chore: pin computesdk dependencies with carot prefixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "computesdk-benchmarks",
       "version": "1.0.0",
       "dependencies": {
-        "@computesdk/blaxel": "latest",
-        "@computesdk/daytona": "latest",
-        "@computesdk/e2b": "latest",
-        "@computesdk/modal": "latest",
+        "@computesdk/blaxel": "^1.5.7",
+        "@computesdk/daytona": "^1.7.14",
+        "@computesdk/e2b": "^1.7.34",
+        "@computesdk/modal": "^1.8.29",
         "@computesdk/namespace": "^1.2.0",
-        "@computesdk/vercel": "latest",
-        "computesdk": "latest",
+        "@computesdk/vercel": "^1.7.13",
+        "computesdk": "^2.2.1",
         "dotenv": "^17.2.1"
       },
       "devDependencies": {
@@ -991,9 +991,9 @@
       }
     },
     "node_modules/@blaxel/core": {
-      "version": "0.2.65",
-      "resolved": "https://registry.npmjs.org/@blaxel/core/-/core-0.2.65.tgz",
-      "integrity": "sha512-Sf/OzMsKrkpp5EyaabcRJS0Hg1AjEK2qS3TyxZIbtGVuuybyACO23GEdnHTz2R752xxb9cECgDEc1nTyIQ4gjg==",
+      "version": "0.2.66",
+      "resolved": "https://registry.npmjs.org/@blaxel/core/-/core-0.2.66.tgz",
+      "integrity": "sha512-4LOcAlvAj7hchiTFktKpCzG6gl/WjfP9xRLWgX1+pmBoKAVAYPi2+44Lo+Z8WgD+IIdYD+6tpfLT8ki6/MD6CA==",
       "license": "MIT",
       "dependencies": {
         "@hey-api/client-fetch": "^0.10.0",
@@ -1031,12 +1031,12 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@computesdk/blaxel": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@computesdk/blaxel/-/blaxel-1.5.6.tgz",
-      "integrity": "sha512-OgKOnHoDT9FnEm2MHw9FDaKV/cxfXRvp/yTaMguq9XYzn6rr92ywdvwl0CvZWF9v7h1jvIdOn0okoi9JA9QA+g==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/@computesdk/blaxel/-/blaxel-1.5.7.tgz",
+      "integrity": "sha512-8uz/icPnlcyecgcJW9EgWfHYTiP7Vr5+EIN7v2+sA5GPNz1D4AwQJoKllk4qkb4q+zrOFSSKk2vYYCvSo0wnhw==",
       "license": "MIT",
       "dependencies": {
-        "@blaxel/core": "^0.2.42",
+        "@blaxel/core": "^0.2.66",
         "@computesdk/provider": "1.0.27",
         "computesdk": "2.2.1"
       }
@@ -4133,9 +4133,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.10.tgz",
-      "integrity": "sha512-kyWP5PAiMooEvGrA9jcD3IXF7ATu8+o7B3KCbPXid5se52NPqnOpM/r9qeW2heMnOekF4kqR1fXJqCYeCLKrZg==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
+      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "generate-svg": "tsx src/generate-svg.ts"
   },
   "dependencies": {
-    "@computesdk/blaxel": "latest",
-    "@computesdk/daytona": "latest",
-    "@computesdk/e2b": "latest",
-    "@computesdk/modal": "latest",
+    "@computesdk/blaxel": "^1.5.7",
+    "@computesdk/daytona": "^1.7.14",
+    "@computesdk/e2b": "^1.7.34",
+    "@computesdk/modal": "^1.8.29",
     "@computesdk/namespace": "^1.2.0",
-    "@computesdk/vercel": "latest",
-    "computesdk": "latest",
+    "@computesdk/vercel": "^1.7.13",
+    "computesdk": "^2.2.1",
     "dotenv": "^17.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Updates all `@computesdk/*` packages from using `"latest"` to using carot (`^`) prefixes with their current versions. This provides better version control while still allowing minor and patch updates.

## Changes

| Package | Before | After |
|---------|--------|-------|
| `@computesdk/blaxel` | `latest` | `^1.5.7` |
| `@computesdk/daytona` | `latest` | `^1.7.14` |
| `@computesdk/e2b` | `latest` | `^1.7.34` |
| `@computesdk/modal` | `latest` | `^1.8.29` |
| `@computesdk/vercel` | `latest` | `^1.7.13` |
| `computesdk` | `latest` | `^2.2.1` |

## Benefits

- **Reproducible builds**: Pinning to specific major versions prevents unexpected breaking changes
- **Security**: Allows patch updates for security fixes
- **Consistency**: All packages now follow the same versioning pattern (already used by `@computesdk/namespace`)