### PR TITLE
Add ISLO provider adapter and workload benchmark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,66 @@ Each benchmark creates a fresh sandbox, runs `echo "benchmark"`, and records wal
 
 <br>
 
+## Benchmark Your Workloads
+
+You can benchmark real project commands (for example setup + test/build) in addition to TTI.
+
+### 1) Use a workload file
+
+```bash
+npm run bench -- \
+  --provider namespace \
+  --iterations 3 \
+  --workload-file workloads/islo-frontend-build.json
+```
+
+Template file for custom repos: `workloads/islo-template.json`.
+
+### 2) Pass commands directly
+
+```bash
+npm run bench -- \
+  --provider e2b \
+  --iterations 3 \
+  --setup-cmd 'git clone --depth 1 https://github.com/your-org/your-repo.git /workspace/repo && cd /workspace/repo && npm ci' \
+  --workload-cmd 'cd /workspace/repo && npm test' \
+  --workload-name 'repo test run' \
+  --workload-timeout-ms 300000
+```
+
+### Workload flags
+
+- `--workload-file <path>` JSON file with `name`, `setupCommand`, `command`, `cwd`, `timeoutMs`
+- `--setup-cmd "<command>"` optional prep command
+- `--workload-cmd "<command>"` optional workload command
+- `--workload-name "<name>"` label shown in logs
+- `--workload-cwd "<path>"` working directory inside sandbox
+- `--workload-timeout-ms <ms>` timeout per setup/workload command
+
+Results still include standard TTI metrics, plus workload and total timing when workload mode is used.
+
+<br>
+
+## Evaluate ISLO.dev
+
+You can benchmark ISLO directly by adding `ISLO_*` vars to `.env` (see `env.example`) and running:
+
+```bash
+npm run bench:islo -- --iterations 5
+```
+
+To benchmark an ISLO-hosted workload:
+
+```bash
+npm run bench:islo -- \
+  --iterations 3 \
+  --workload-file workloads/islo-frontend-build.json
+```
+
+If your token is an operator/admin token, also set `ISLO_PUBLIC_TENANT_ID` (and optionally `ISLO_PUBLIC_USER_ID`) so requests are scoped to a tenant.
+
+<br>
+
 ## Transparency
 
 - 📖 **Open source** — All benchmark code is public

--- a/env.example
+++ b/env.example
@@ -27,6 +27,19 @@ NSC_TOKEN=your_nsc_token
 BL_API_KEY=your_bl_api_key
 BL_WORKSPACE=your_bl_workspace
 
+######### ISLO ########
+# Example: https://api.islo.dev
+ISLO_API_URL=your_islo_api_base_url
+ISLO_BEARER_TOKEN=your_islo_bearer_token
+# Optional for operator/admin tokens that require tenant impersonation
+ISLO_PUBLIC_TENANT_ID=
+ISLO_PUBLIC_USER_ID=
+# Optional VM overrides
+ISLO_IMAGE=docker.io/library/python:3.12-slim
+ISLO_VCPUS=2
+ISLO_MEMORY_MB=512
+ISLO_DISK_GB=10
+
 ######### RENDER ########
 RENDER_API_KEY=your_render_api_key
 RENDER_OWNER_ID=your_render_owner_id

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bench:daytona": "tsx src/run.ts --provider daytona",
     "bench:railway": "tsx src/run.ts --provider railway",
     "bench:namespace": "tsx src/run.ts --provider namespace",
+    "bench:islo": "tsx src/run.ts --provider islo",
     "bench:render": "tsx src/run.ts --provider render",
     "update-readme": "tsx src/update-readme.ts",
     "generate-svg": "tsx src/generate-svg.ts"

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -1,4 +1,10 @@
-import type { ProviderConfig, BenchmarkResult, TimingResult, Stats } from './types.js';
+import type {
+  ProviderConfig,
+  WorkloadConfig,
+  BenchmarkResult,
+  TimingResult,
+  Stats,
+} from './types.js';
 
 function computeStats(values: number[]): Stats {
   if (values.length === 0) return { min: 0, max: 0, median: 0, avg: 0 };
@@ -17,7 +23,10 @@ function computeStats(values: number[]): Stats {
   };
 }
 
-export async function runBenchmark(config: ProviderConfig): Promise<BenchmarkResult> {
+export async function runBenchmark(
+  config: ProviderConfig,
+  workload?: WorkloadConfig
+): Promise<BenchmarkResult> {
   const { name, iterations = 10, timeout = 120_000, requiredEnvVars } = config;
 
   // Check if all required credentials are available
@@ -36,14 +45,24 @@ export async function runBenchmark(config: ProviderConfig): Promise<BenchmarkRes
   const results: TimingResult[] = [];
 
   console.log(`\n--- Benchmarking: ${name} (${iterations} iterations) ---`);
+  if (workload) {
+    console.log(`  Workload: ${workload.name}`);
+  }
 
   for (let i = 0; i < iterations; i++) {
     console.log(`  Iteration ${i + 1}/${iterations}...`);
 
     try {
-      const iterationResult = await runIteration(compute, timeout);
+      const iterationResult = await runIteration(compute, timeout, workload);
       results.push(iterationResult);
-      console.log(`    TTI: ${(iterationResult.ttiMs / 1000).toFixed(2)}s`);
+      const statusParts = [`TTI: ${(iterationResult.ttiMs / 1000).toFixed(2)}s`];
+      if (typeof iterationResult.workloadMs === 'number') {
+        statusParts.push(`Workload: ${(iterationResult.workloadMs / 1000).toFixed(2)}s`);
+      }
+      if (typeof iterationResult.totalMs === 'number') {
+        statusParts.push(`Total: ${(iterationResult.totalMs / 1000).toFixed(2)}s`);
+      }
+      console.log(`    ${statusParts.join(' | ')}`);
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       console.log(`    FAILED: ${error}`);
@@ -64,17 +83,31 @@ export async function runBenchmark(config: ProviderConfig): Promise<BenchmarkRes
     };
   }
 
+  const workloadValues = successful
+    .map(r => r.workloadMs)
+    .filter((value): value is number => typeof value === 'number');
+  const totalValues = successful
+    .map(r => r.totalMs)
+    .filter((value): value is number => typeof value === 'number');
+
   return {
     provider: name,
     iterations: results,
     summary: {
       ttiMs: computeStats(successful.map(r => r.ttiMs)),
+      ...(workloadValues.length > 0 ? { workloadMs: computeStats(workloadValues) } : {}),
+      ...(totalValues.length > 0 ? { totalMs: computeStats(totalValues) } : {}),
     },
   };
 }
 
-async function runIteration(compute: any, timeout: number): Promise<TimingResult> {
+async function runIteration(
+  compute: any,
+  timeout: number,
+  workload?: WorkloadConfig
+): Promise<TimingResult> {
   let sandbox: any = null;
+  const workloadTimeoutMs = workload?.timeoutMs ?? 300_000;
 
   try {
     const start = performance.now();
@@ -82,14 +115,55 @@ async function runIteration(compute: any, timeout: number): Promise<TimingResult
     sandbox = await withTimeout(compute.sandbox.create(), timeout, 'Sandbox creation timed out');
 
     await withTimeout(
-      sandbox.runCommand('echo "benchmark"'),
+      runCheckedCommand(
+        sandbox,
+        'echo "benchmark"',
+        { timeoutSeconds: 30 },
+        'First command execution failed'
+      ),
       30_000,
       'First command execution timed out'
     );
 
     const ttiMs = performance.now() - start;
 
-    return { ttiMs };
+    if (!workload?.setupCommand && !workload?.command) {
+      return { ttiMs };
+    }
+
+    const workloadStart = performance.now();
+    const timeoutSeconds = msToSeconds(workloadTimeoutMs);
+
+    if (workload.setupCommand) {
+      await withTimeout(
+        runCheckedCommand(
+          sandbox,
+          workload.setupCommand,
+          { cwd: workload.cwd, timeoutSeconds },
+          'Workload setup failed'
+        ),
+        workloadTimeoutMs,
+        'Workload setup timed out'
+      );
+    }
+
+    if (workload.command) {
+      await withTimeout(
+        runCheckedCommand(
+          sandbox,
+          workload.command,
+          { cwd: workload.cwd, timeoutSeconds },
+          'Workload command failed'
+        ),
+        workloadTimeoutMs,
+        'Workload command timed out'
+      );
+    }
+
+    const workloadMs = performance.now() - workloadStart;
+    const totalMs = performance.now() - start;
+
+    return { ttiMs, workloadMs, totalMs };
   } finally {
     if (sandbox) {
       try {
@@ -109,4 +183,37 @@ function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promi
     promise,
     new Promise<T>((_, reject) => setTimeout(() => reject(new Error(message)), ms)),
   ]);
+}
+
+async function runCheckedCommand(
+  sandbox: any,
+  command: string,
+  options: { cwd?: string; timeoutSeconds: number },
+  failurePrefix: string
+): Promise<void> {
+  const result = await sandbox.runCommand(command, {
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    timeout: options.timeoutSeconds,
+  });
+
+  if (result.exitCode !== 0) {
+    const stderr = result.stderr?.trim();
+    const stdout = result.stdout?.trim();
+    const detail = stderr || stdout;
+    if (detail) {
+      throw new Error(`${failurePrefix} (exit ${result.exitCode}): ${truncate(detail, 220)}`);
+    }
+    throw new Error(`${failurePrefix} (exit ${result.exitCode})`);
+  }
+}
+
+function msToSeconds(ms: number): number {
+  return Math.max(1, Math.ceil(ms / 1000));
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength - 3)}...`;
 }

--- a/src/islo-provider.ts
+++ b/src/islo-provider.ts
@@ -1,0 +1,307 @@
+interface IsloComputeConfig {
+  baseUrl: string;
+  token: string;
+  tenantPublicId?: string;
+  userPublicId?: string;
+  image?: string;
+  vcpus?: number;
+  memoryMb?: number;
+  diskGb?: number;
+}
+
+interface IsloRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  durationMs: number;
+}
+
+interface IsloSandbox {
+  runCommand: (
+    command: string,
+    options?: { cwd?: string; timeout?: number; background?: boolean }
+  ) => Promise<IsloRunResult>;
+  destroy: () => Promise<void>;
+}
+
+interface IsloCompute {
+  sandbox: {
+    create: () => Promise<IsloSandbox>;
+  };
+}
+
+interface IsloCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export function createIsloCompute(config: IsloComputeConfig): IsloCompute {
+  const baseUrl = normalizeBaseUrl(config.baseUrl);
+  const headers = buildAuthHeaders(config);
+
+  return {
+    sandbox: {
+      create: async () => {
+        const requestedName = createSandboxName();
+        const body = {
+          name: requestedName,
+          image: config.image ?? 'docker.io/library/python:3.12-slim',
+          vcpus: config.vcpus ?? 2,
+          memory_mb: config.memoryMb ?? 512,
+          disk_gb: config.diskGb ?? 10,
+        };
+
+        const created = await fetchJson(`${baseUrl}/sandboxes/`, {
+          method: 'POST',
+          headers: withJsonHeaders(headers),
+          body: JSON.stringify(body),
+        });
+
+        const sandboxName =
+          created && typeof created.name === 'string' && created.name.trim().length > 0
+            ? created.name
+            : requestedName;
+
+        return createSandbox(baseUrl, headers, sandboxName);
+      },
+    },
+  };
+}
+
+function createSandbox(baseUrl: string, headers: Record<string, string>, sandboxName: string): IsloSandbox {
+  return {
+    runCommand: async (command, options) => {
+      const startedAt = performance.now();
+      const timeoutSeconds = options?.timeout ?? 300;
+      const timeoutMs = Math.max(1, Math.ceil(timeoutSeconds * 1000));
+
+      const result = await runCommandViaSse(baseUrl, headers, sandboxName, command, {
+        cwd: options?.cwd,
+        timeoutMs,
+      });
+
+      return {
+        ...result,
+        durationMs: performance.now() - startedAt,
+      };
+    },
+    destroy: async () => {
+      const response = await fetch(`${baseUrl}/sandboxes/${encodeURIComponent(sandboxName)}`, {
+        method: 'DELETE',
+        headers,
+      });
+
+      if (response.status === 404 || response.status === 410) {
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(
+          `ISLO delete failed (${response.status}): ${await safeReadText(response)}`
+        );
+      }
+    },
+  };
+}
+
+async function runCommandViaSse(
+  baseUrl: string,
+  headers: Record<string, string>,
+  sandboxName: string,
+  command: string,
+  options: { cwd?: string; timeoutMs: number }
+): Promise<IsloCommandResult> {
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), options.timeoutMs);
+
+  try {
+    const response = await fetch(
+      `${baseUrl}/sandboxes/${encodeURIComponent(sandboxName)}/exec/stream`,
+      {
+        method: 'POST',
+        headers: {
+          ...withJsonHeaders(headers),
+          Accept: 'text/event-stream',
+        },
+        body: JSON.stringify({
+          command: ['/bin/sh', '-lc', command],
+          ...(options.cwd ? { cwd: options.cwd } : {}),
+        }),
+        signal: controller.signal,
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`ISLO exec failed (${response.status}): ${await safeReadText(response)}`);
+    }
+
+    if (!response.body) {
+      throw new Error('ISLO exec stream missing response body');
+    }
+
+    return await parseSseResult(response.body);
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new Error('ISLO exec timed out');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+async function parseSseResult(body: ReadableStream<Uint8Array>): Promise<IsloCommandResult> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+
+  let stdout = '';
+  let stderr = '';
+  let exitCode: number | null = null;
+  let pendingError: string | null = null;
+
+  let buffer = '';
+  let currentEvent = 'message';
+  let dataLines: string[] = [];
+
+  const emitEvent = () => {
+    if (dataLines.length === 0) {
+      currentEvent = 'message';
+      return;
+    }
+
+    const payload = dataLines.join('\n');
+    switch (currentEvent) {
+      case 'stdout':
+        stdout += payload;
+        break;
+      case 'stderr':
+        stderr += payload;
+        break;
+      case 'exit': {
+        const parsed = parseInt(payload, 10);
+        if (Number.isInteger(parsed)) {
+          exitCode = parsed;
+        }
+        break;
+      }
+      case 'error':
+        pendingError = pendingError ? `${pendingError}\n${payload}` : payload;
+        break;
+      default:
+        break;
+    }
+
+    currentEvent = 'message';
+    dataLines = [];
+  };
+
+  const handleLine = (rawLine: string) => {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+
+    if (line === '') {
+      emitEvent();
+      return;
+    }
+
+    if (line.startsWith(':')) {
+      return;
+    }
+
+    if (line.startsWith('event:')) {
+      currentEvent = line.slice(6).trim();
+      return;
+    }
+
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trimStart());
+    }
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+
+    while (true) {
+      const newlineIndex = buffer.indexOf('\n');
+      if (newlineIndex === -1) {
+        break;
+      }
+      const line = buffer.slice(0, newlineIndex);
+      buffer = buffer.slice(newlineIndex + 1);
+      handleLine(line);
+    }
+  }
+
+  buffer += decoder.decode();
+  if (buffer.length > 0) {
+    handleLine(buffer);
+  }
+  emitEvent();
+
+  if (pendingError) {
+    throw new Error(`ISLO exec stream error: ${pendingError}`);
+  }
+
+  if (exitCode === null) {
+    throw new Error('ISLO exec stream ended without exit event');
+  }
+
+  return { stdout, stderr, exitCode };
+}
+
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+function buildAuthHeaders(config: IsloComputeConfig): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${config.token}`,
+  };
+
+  if (config.tenantPublicId) {
+    headers['X-Public-Tenant-Id'] = config.tenantPublicId;
+  }
+  if (config.userPublicId) {
+    headers['X-Public-User-Id'] = config.userPublicId;
+  }
+
+  return headers;
+}
+
+function withJsonHeaders(headers: Record<string, string>): Record<string, string> {
+  return {
+    ...headers,
+    'Content-Type': 'application/json',
+  };
+}
+
+function createSandboxName(): string {
+  return `bench-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function fetchJson(url: string, init: RequestInit): Promise<any> {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    throw new Error(`ISLO request failed (${response.status}): ${await safeReadText(response)}`);
+  }
+
+  return response.json();
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    const text = (await response.text()).trim();
+    return text || '<empty response>';
+  } catch {
+    return '<failed to read response>';
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -4,6 +4,7 @@ import { blaxel } from '@computesdk/blaxel';
 import { modal } from '@computesdk/modal';
 import { vercel } from '@computesdk/vercel';
 import { compute } from 'computesdk';
+import { createIsloCompute } from './islo-provider.js';
 import type { ProviderConfig } from './types.js';
 
 /**
@@ -38,6 +39,21 @@ export const providers: ProviderConfig[] = [
     name: 'vercel',
     requiredEnvVars: ['VERCEL_TOKEN', 'VERCEL_TEAM_ID', 'VERCEL_PROJECT_ID'],
     createCompute: () => vercel({ token: process.env.VERCEL_TOKEN!, teamId: process.env.VERCEL_TEAM_ID!, projectId: process.env.VERCEL_PROJECT_ID! }),
+  },
+  {
+    name: 'islo',
+    requiredEnvVars: ['ISLO_API_URL', 'ISLO_BEARER_TOKEN'],
+    createCompute: () =>
+      createIsloCompute({
+        baseUrl: process.env.ISLO_API_URL!,
+        token: process.env.ISLO_BEARER_TOKEN!,
+        tenantPublicId: process.env.ISLO_PUBLIC_TENANT_ID,
+        userPublicId: process.env.ISLO_PUBLIC_USER_ID,
+        image: process.env.ISLO_IMAGE,
+        vcpus: parseOptionalInt(process.env.ISLO_VCPUS),
+        memoryMb: parseOptionalInt(process.env.ISLO_MEMORY_MB),
+        diskGb: parseOptionalInt(process.env.ISLO_DISK_GB),
+      }),
   },
   // --- Automatic mode (via ComputeSDK gateway) ---
   {
@@ -77,3 +93,11 @@ export const providers: ProviderConfig[] = [
   //   },
   // },
 ];
+
+function parseOptionalInt(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = parseInt(value, 10);
+  return Number.isInteger(parsed) ? parsed : undefined;
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 import { runBenchmark } from './benchmark.js';
 import { printResultsTable, writeResultsJson } from './table.js';
 import { providers } from './providers.js';
-import type { BenchmarkResult } from './types.js';
+import type { BenchmarkResult, WorkloadConfig } from './types.js';
 
 // Load .env from the benchmarking root
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -13,7 +13,7 @@ config({ path: path.resolve(__dirname, '../.env') });
 // Parse CLI args
 const args = process.argv.slice(2);
 const providerFilter = getArgValue(args, '--provider');
-const iterations = parseInt(getArgValue(args, '--iterations') || '10', 10);
+const iterations = parsePositiveInt(getArgValue(args, '--iterations') || '10', '--iterations');
 
 function getArgValue(args: string[], flag: string): string | undefined {
   const idx = args.indexOf(flag);
@@ -21,8 +21,13 @@ function getArgValue(args: string[], flag: string): string | undefined {
 }
 
 async function main() {
+  const workload = await resolveWorkloadConfig(args);
+
   console.log('ComputeSDK Sandbox Provider Benchmarks');
   console.log(`Iterations per provider: ${iterations}`);
+  if (workload) {
+    console.log(`Workload: ${workload.name}`);
+  }
   console.log(`Date: ${new Date().toISOString()}\n`);
 
   // Filter providers if --provider flag is set
@@ -40,7 +45,7 @@ async function main() {
 
   // Run benchmarks sequentially to avoid resource contention
   for (const providerConfig of toRun) {
-    const result = await runBenchmark({ ...providerConfig, iterations });
+    const result = await runBenchmark({ ...providerConfig, iterations }, workload);
     results.push(result);
   }
 
@@ -50,7 +55,65 @@ async function main() {
   // Write JSON results
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   const outPath = path.resolve(__dirname, `../results/${timestamp}.json`);
-  await writeResultsJson(results, outPath);
+  await writeResultsJson(results, outPath, {
+    iterations,
+    timeoutMs: 120_000,
+    ...(providerFilter ? { providerFilter } : {}),
+    ...(workload ? { workload } : {}),
+  });
+}
+
+async function resolveWorkloadConfig(args: string[]): Promise<WorkloadConfig | undefined> {
+  const workloadFilePath = getArgValue(args, '--workload-file');
+  let fileConfig: Partial<WorkloadConfig> = {};
+
+  if (workloadFilePath) {
+    const fs = await import('fs/promises');
+    const absolutePath = path.isAbsolute(workloadFilePath)
+      ? workloadFilePath
+      : path.resolve(__dirname, '..', workloadFilePath);
+
+    const raw = await fs.readFile(absolutePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error(`Invalid workload file: ${workloadFilePath}`);
+    }
+    fileConfig = parsed as Partial<WorkloadConfig>;
+  }
+
+  const setupCommand = getArgValue(args, '--setup-cmd') ?? fileConfig.setupCommand;
+  const command = getArgValue(args, '--workload-cmd') ?? fileConfig.command;
+
+  if (!setupCommand && !command) {
+    return undefined;
+  }
+
+  const timeoutArg = getArgValue(args, '--workload-timeout-ms');
+  const timeoutMs = timeoutArg
+    ? parsePositiveInt(timeoutArg, '--workload-timeout-ms')
+    : fileConfig.timeoutMs;
+  if (typeof timeoutMs === 'number' && timeoutMs <= 0) {
+    throw new Error('--workload-timeout-ms must be greater than 0');
+  }
+
+  const name = getArgValue(args, '--workload-name') ?? fileConfig.name ?? 'custom-workload';
+  const cwd = getArgValue(args, '--workload-cwd') ?? fileConfig.cwd;
+
+  return {
+    name,
+    ...(setupCommand ? { setupCommand } : {}),
+    ...(command ? { command } : {}),
+    ...(cwd ? { cwd } : {}),
+    ...(typeof timeoutMs === 'number' ? { timeoutMs } : {}),
+  };
+}
+
+function parsePositiveInt(value: string, flagName: string): number {
+  const parsed = parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flagName} must be a positive integer`);
+  }
+  return parsed;
 }
 
 main().catch(err => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,9 +11,26 @@ export interface ProviderConfig {
   createCompute: () => any;
 }
 
+export interface WorkloadConfig {
+  /** Human-readable workload name */
+  name: string;
+  /** Optional command to prepare dependencies or code */
+  setupCommand?: string;
+  /** Optional command that represents the workload under test */
+  command?: string;
+  /** Working directory for setup/workload commands */
+  cwd?: string;
+  /** Per-command timeout in milliseconds */
+  timeoutMs?: number;
+}
+
 export interface TimingResult {
   /** Total time from start to first successful code execution */
   ttiMs: number;
+  /** Time spent running setup + workload command(s), when configured */
+  workloadMs?: number;
+  /** Total time from sandbox creation start through workload completion */
+  totalMs?: number;
   /** Error message if this iteration failed */
   error?: string;
 }
@@ -30,6 +47,8 @@ export interface BenchmarkResult {
   iterations: TimingResult[];
   summary: {
     ttiMs: Stats;
+    workloadMs?: Stats;
+    totalMs?: Stats;
   };
   skipped?: boolean;
   skipReason?: string;

--- a/workloads/islo-frontend-build.json
+++ b/workloads/islo-frontend-build.json
@@ -1,0 +1,6 @@
+{
+  "name": "islo-frontend-build",
+  "setupCommand": "git clone --depth 1 https://github.com/islo-labs/islo-frontend.git /workspace/islo-frontend && cd /workspace/islo-frontend && npm ci",
+  "command": "cd /workspace/islo-frontend && npm run build",
+  "timeoutMs": 300000
+}

--- a/workloads/islo-template.json
+++ b/workloads/islo-template.json
@@ -1,0 +1,6 @@
+{
+  "name": "islo-template",
+  "setupCommand": "git clone --depth 1 https://github.com/your-org/your-repo.git /workspace/repo && cd /workspace/repo && npm ci",
+  "command": "cd /workspace/repo && npm test",
+  "timeoutMs": 300000
+}


### PR DESCRIPTION
## Summary
- add a direct `islo` provider so the benchmark harness can evaluate ISLO.dev with the same create/run/destroy lifecycle used for other providers
- add optional workload benchmarking (`setup + command`) in addition to existing TTI
- add workload config files and docs for quick ISLO workload runs

## Why
This enables benchmarking ISLO.dev similarly to other providers in this repository while keeping the existing TTI methodology and output structure.

## Included changes
- `src/islo-provider.ts`: adapter for ISLO API (`/sandboxes`, `/exec/stream`, delete)
- `src/providers.ts`: register `islo` provider and env wiring
- `src/run.ts`, `src/benchmark.ts`, `src/table.ts`, `src/types.ts`: workload mode + metrics (`workloadMs`, `totalMs`)
- `package.json`: add `bench:islo` script
- `env.example`, `README.md`: ISLO setup and run instructions
- `workloads/`: starter workload JSON files

## Validation
- `npm ci`
- `npx tsc --noEmit`
- `npm run bench:islo -- --iterations 1` (expected `SKIPPED` without ISLO env vars)
