### PR TITLE
feat: add islo provider benchmark target

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bench:daytona": "tsx src/run.ts --provider daytona",
     "bench:railway": "tsx src/run.ts --provider railway",
     "bench:namespace": "tsx src/run.ts --provider namespace",
+    "bench:islo": "tsx src/run.ts --provider islo",
     "bench:render": "tsx src/run.ts --provider render",
     "bench:hopx": "tsx src/run.ts --provider hopx",
     "bench:codesandbox": "tsx src/run.ts --provider codesandbox",

--- a/src/islo-provider.ts
+++ b/src/islo-provider.ts
@@ -1,0 +1,282 @@
+interface IsloComputeConfig {
+  baseUrl: string;
+  token: string;
+}
+
+interface IsloRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  durationMs: number;
+}
+
+interface IsloSandbox {
+  runCommand: (
+    command: string,
+    options?: { cwd?: string; timeout?: number; background?: boolean }
+  ) => Promise<IsloRunResult>;
+  destroy: () => Promise<void>;
+}
+
+interface IsloCompute {
+  sandbox: {
+    create: () => Promise<IsloSandbox>;
+  };
+}
+
+interface IsloCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export function createIsloCompute(config: IsloComputeConfig): IsloCompute {
+  const baseUrl = normalizeBaseUrl(config.baseUrl);
+  const headers = buildAuthHeaders(config.token);
+
+  return {
+    sandbox: {
+      create: async () => {
+        const requestedName = createSandboxName();
+        const created = await fetchJson(`${baseUrl}/sandboxes/`, {
+          method: 'POST',
+          headers: withJsonHeaders(headers),
+          body: JSON.stringify({ name: requestedName }),
+        });
+
+        const sandboxName =
+          created && typeof created.name === 'string' && created.name.trim().length > 0
+            ? created.name
+            : requestedName;
+
+        return createSandbox(baseUrl, headers, sandboxName);
+      },
+    },
+  };
+}
+
+function createSandbox(baseUrl: string, headers: Record<string, string>, sandboxName: string): IsloSandbox {
+  return {
+    runCommand: async (command, options) => {
+      const startedAt = performance.now();
+      const timeoutSeconds = options?.timeout ?? 300;
+      const timeoutMs = Math.max(1, Math.ceil(timeoutSeconds * 1000));
+
+      const result = await runCommandViaSse(baseUrl, headers, sandboxName, command, {
+        cwd: options?.cwd,
+        timeoutMs,
+      });
+
+      return {
+        ...result,
+        durationMs: performance.now() - startedAt,
+      };
+    },
+    destroy: async () => {
+      const response = await fetch(`${baseUrl}/sandboxes/${encodeURIComponent(sandboxName)}`, {
+        method: 'DELETE',
+        headers,
+      });
+
+      if (response.status === 404 || response.status === 410) {
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(`ISLO delete failed (${response.status}): ${await safeReadText(response)}`);
+      }
+    },
+  };
+}
+
+async function runCommandViaSse(
+  baseUrl: string,
+  headers: Record<string, string>,
+  sandboxName: string,
+  command: string,
+  options: { cwd?: string; timeoutMs: number }
+): Promise<IsloCommandResult> {
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), options.timeoutMs);
+
+  try {
+    const response = await fetch(
+      `${baseUrl}/sandboxes/${encodeURIComponent(sandboxName)}/exec/stream`,
+      {
+        method: 'POST',
+        headers: {
+          ...withJsonHeaders(headers),
+          Accept: 'text/event-stream',
+        },
+        body: JSON.stringify({
+          command: ['/bin/sh', '-lc', command],
+          ...(options.cwd ? { cwd: options.cwd } : {}),
+        }),
+        signal: controller.signal,
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`ISLO exec failed (${response.status}): ${await safeReadText(response)}`);
+    }
+
+    if (!response.body) {
+      throw new Error('ISLO exec stream missing response body');
+    }
+
+    return await parseSseResult(response.body);
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new Error('ISLO exec timed out');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+async function parseSseResult(body: ReadableStream<Uint8Array>): Promise<IsloCommandResult> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+
+  let stdout = '';
+  let stderr = '';
+  let exitCode: number | null = null;
+  let pendingError: string | null = null;
+
+  let buffer = '';
+  let currentEvent = 'message';
+  let dataLines: string[] = [];
+
+  const emitEvent = () => {
+    if (dataLines.length === 0) {
+      currentEvent = 'message';
+      return;
+    }
+
+    const payload = dataLines.join('\n');
+    switch (currentEvent) {
+      case 'stdout':
+        stdout += payload;
+        break;
+      case 'stderr':
+        stderr += payload;
+        break;
+      case 'exit': {
+        const parsed = parseInt(payload, 10);
+        if (Number.isInteger(parsed)) {
+          exitCode = parsed;
+        }
+        break;
+      }
+      case 'error':
+        pendingError = pendingError ? `${pendingError}\n${payload}` : payload;
+        break;
+      default:
+        break;
+    }
+
+    currentEvent = 'message';
+    dataLines = [];
+  };
+
+  const handleLine = (rawLine: string) => {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+
+    if (line === '') {
+      emitEvent();
+      return;
+    }
+
+    if (line.startsWith(':')) {
+      return;
+    }
+
+    if (line.startsWith('event:')) {
+      currentEvent = line.slice(6).trim();
+      return;
+    }
+
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trimStart());
+    }
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+
+    while (true) {
+      const newlineIndex = buffer.indexOf('\n');
+      if (newlineIndex === -1) {
+        break;
+      }
+      const line = buffer.slice(0, newlineIndex);
+      buffer = buffer.slice(newlineIndex + 1);
+      handleLine(line);
+    }
+  }
+
+  buffer += decoder.decode();
+  if (buffer.length > 0) {
+    handleLine(buffer);
+  }
+  emitEvent();
+
+  if (pendingError) {
+    throw new Error(`ISLO exec stream error: ${pendingError}`);
+  }
+
+  if (exitCode === null) {
+    throw new Error('ISLO exec stream ended without exit event');
+  }
+
+  return { stdout, stderr, exitCode };
+}
+
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+function buildAuthHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+function withJsonHeaders(headers: Record<string, string>): Record<string, string> {
+  return {
+    ...headers,
+    'Content-Type': 'application/json',
+  };
+}
+
+function createSandboxName(): string {
+  return `bench-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function fetchJson(url: string, init: RequestInit): Promise<any> {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    throw new Error(`ISLO request failed (${response.status}): ${await safeReadText(response)}`);
+  }
+
+  return response.json();
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    const text = (await response.text()).trim();
+    return text || '<empty response>';
+  } catch {
+    return '<failed to read response>';
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError';
+}

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -8,6 +8,7 @@ import { codesandbox } from '@computesdk/codesandbox';
 import { runloop } from '@computesdk/runloop';
 import { namespace } from '@computesdk/namespace';
 import { compute } from 'computesdk';
+import { createIsloCompute } from './islo-provider.js';
 import type { ProviderConfig } from './types.js';
 
 /**
@@ -42,6 +43,15 @@ export const providers: ProviderConfig[] = [
     name: 'vercel',
     requiredEnvVars: ['VERCEL_TOKEN', 'VERCEL_TEAM_ID', 'VERCEL_PROJECT_ID'],
     createCompute: () => vercel({ token: process.env.VERCEL_TOKEN!, teamId: process.env.VERCEL_TEAM_ID!, projectId: process.env.VERCEL_PROJECT_ID! }),
+  },
+  {
+    name: 'islo',
+    requiredEnvVars: ['ISLO_API_URL', 'ISLO_BEARER_TOKEN'],
+    createCompute: () =>
+      createIsloCompute({
+        baseUrl: process.env.ISLO_API_URL!,
+        token: process.env.ISLO_BEARER_TOKEN!,
+      }),
   },
   {
     name: 'hopx',


### PR DESCRIPTION
## Summary
- add a minimal `islo` provider adapter in `src/islo-provider.ts`
- register `islo` in `src/providers.ts`
- add `bench:islo` script

## Scope
- provider target wiring only
- no benchmark-core changes
- no workload mode or schema/output changes
- no results artifacts

## How To Run
Install CLI:
```bash
curl -fsSL https://islo.dev/install.sh | bash
```

Authenticate and run benchmark:
```bash
export ISLO_TOKEN_STORAGE=file
islo auth login
ISLO_API_URL=https://api.islo.dev \
ISLO_BEARER_TOKEN="$(jq -r '.session_token' ~/.islo/auth.json)" \
npm run bench:islo -- --iterations 5
```

Equivalent command:
```bash
ISLO_API_URL=https://api.islo.dev \
ISLO_BEARER_TOKEN="$(jq -r '.session_token' ~/.islo/auth.json)" \
npm run bench -- --provider islo --iterations 5
```

Expected behavior when env vars are missing:
- provider is marked `SKIPPED` with missing var reason

## Validation
- `npx tsc --noEmit`
- `npm run bench:islo -- --iterations 1` (skip path without env)
- real run validated locally with `ISLO_API_URL` + `ISLO_BEARER_TOKEN`
