### PR TITLE
feat: change benchmark command to node -v

### DIFF
--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -89,7 +89,7 @@ export async function runIteration(compute: any, timeout: number): Promise<Timin
     sandbox = await withTimeout(compute.sandbox.create(), timeout, 'Sandbox creation timed out');
 
     await withTimeout(
-      sandbox.runCommand('echo "benchmark"'),
+      sandbox.runCommand('node -v'),
       30_000,
       'First command execution timed out'
     );


### PR DESCRIPTION
Changes the benchmark command from `echo "benchmark"` to `node -v`.

This verifies sandboxes can actually execute binaries. just-bash will fail (exit code 127 - command not found) since it doesn't support binaries, while real sandboxes with Node.js installed will pass.

**Why:** The old command only tested shell execution. The new command tests actual sandbox capability - binary execution, environment setup, etc.