### PR TITLE
fix: check exit code to catch command failures

### DIFF
--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -88,11 +88,15 @@ export async function runIteration(compute: any, timeout: number): Promise<Timin
 
     sandbox = await withTimeout(compute.sandbox.create(), timeout, 'Sandbox creation timed out');
 
-    await withTimeout(
+    const result = await withTimeout(
       sandbox.runCommand('node -v'),
       30_000,
       'First command execution timed out'
-    );
+    ) as { exitCode: number; stderr?: string };
+
+    if (result.exitCode !== 0) {
+      throw new Error(`Command failed with exit code ${result.exitCode}: ${result.stderr || 'Unknown error'}`);
+    }
 
     const ttiMs = performance.now() - start;
 


### PR DESCRIPTION
The benchmark was only catching thrown exceptions, but the just-bash provider wrapper returns results with exit codes instead of throwing.

**Problem:** just-bash doesn't support binaries like `node`, so `node -v` returns exit code 127. But the old code only checked for thrown exceptions, not exit codes. This made just-bash appear to pass when it should fail.

**Fix:** Check `result.exitCode !== 0` and throw an error if the command failed.

This ensures providers that can't actually run code (like just-bash) properly fail instead of showing fake TTI times.