### PR TITLE
fix: use node:22 image for namespace and remove custom blaxel image

### DIFF
--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -25,7 +25,7 @@ export function computeStats(values: number[]): Stats {
 }
 
 export async function runBenchmark(config: ProviderConfig): Promise<BenchmarkResult> {
-  const { name, iterations = 100, timeout = 120_000, requiredEnvVars } = config;
+  const { name, iterations = 100, timeout = 120_000, requiredEnvVars, sandboxOptions } = config;
 
   // Check if all required credentials are available
   const missingVars = requiredEnvVars.filter(v => !process.env[v]);
@@ -48,7 +48,7 @@ export async function runBenchmark(config: ProviderConfig): Promise<BenchmarkRes
     console.log(`  Iteration ${i + 1}/${iterations}...`);
 
     try {
-      const iterationResult = await runIteration(compute, timeout);
+      const iterationResult = await runIteration(compute, timeout, sandboxOptions);
       results.push(iterationResult);
       console.log(`    TTI: ${(iterationResult.ttiMs / 1000).toFixed(2)}s`);
     } catch (err) {
@@ -80,13 +80,13 @@ export async function runBenchmark(config: ProviderConfig): Promise<BenchmarkRes
   };
 }
 
-export async function runIteration(compute: any, timeout: number): Promise<TimingResult> {
+export async function runIteration(compute: any, timeout: number, sandboxOptions?: Record<string, any>): Promise<TimingResult> {
   let sandbox: any = null;
 
   try {
     const start = performance.now();
 
-    sandbox = await withTimeout(compute.sandbox.create(), timeout, 'Sandbox creation timed out');
+    sandbox = await withTimeout(compute.sandbox.create(sandboxOptions), timeout, 'Sandbox creation timed out');
 
     const result = await withTimeout(
       sandbox.runCommand('node -v'),

--- a/src/concurrent.ts
+++ b/src/concurrent.ts
@@ -6,7 +6,7 @@ interface ConcurrentConfig extends ProviderConfig {
 }
 
 export async function runConcurrentBenchmark(config: ConcurrentConfig): Promise<ConcurrentBenchmarkResult> {
-  const { name, concurrency, timeout = 120_000, requiredEnvVars } = config;
+  const { name, concurrency, timeout = 120_000, requiredEnvVars, sandboxOptions } = config;
 
   // Check if all required credentials are available
   const missingVars = requiredEnvVars.filter(v => !process.env[v]);
@@ -32,7 +32,7 @@ export async function runConcurrentBenchmark(config: ConcurrentConfig): Promise<
 
   // Fire all sandbox creations simultaneously — no awaiting between launches
   const promises = Array.from({ length: concurrency }, (_, i) =>
-    runIteration(compute, timeout)
+    runIteration(compute, timeout, sandboxOptions)
       .then(result => {
         console.log(`  Sandbox ${i + 1}/${concurrency}: TTI ${(result.ttiMs / 1000).toFixed(2)}s`);
         return result;

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -33,7 +33,7 @@ export const providers: ProviderConfig[] = [
   {
     name: 'blaxel',
     requiredEnvVars: ['BL_API_KEY', 'BL_WORKSPACE'],
-    createCompute: () => blaxel({ apiKey: process.env.BL_API_KEY!, workspace: process.env.BL_WORKSPACE!, image: 'blaxel/benchmark:latest', region: 'us-was-1' }),
+    createCompute: () => blaxel({ apiKey: process.env.BL_API_KEY!, workspace: process.env.BL_WORKSPACE!, region: 'us-was-1' }),
   },
   {
     name: 'just-bash',
@@ -69,6 +69,7 @@ export const providers: ProviderConfig[] = [
     name: 'namespace',
     requiredEnvVars: ['NSC_TOKEN'],
     createCompute: () => namespace({ token: process.env.NSC_TOKEN! }),
+    sandboxOptions: { image: 'node:22' },
   },
   {
     name: 'cloudflare',

--- a/src/staggered.ts
+++ b/src/staggered.ts
@@ -7,7 +7,7 @@ interface StaggeredConfig extends ProviderConfig {
 }
 
 export async function runStaggeredBenchmark(config: StaggeredConfig): Promise<StaggeredBenchmarkResult> {
-  const { name, concurrency, staggerDelayMs, timeout = 120_000, requiredEnvVars } = config;
+  const { name, concurrency, staggerDelayMs, timeout = 120_000, requiredEnvVars, sandboxOptions } = config;
 
   // Check if all required credentials are available
   const missingVars = requiredEnvVars.filter(v => !process.env[v]);
@@ -38,7 +38,7 @@ export async function runStaggeredBenchmark(config: StaggeredConfig): Promise<St
   for (let i = 0; i < concurrency; i++) {
     const launchedAt = performance.now() - wallStart;
 
-    const p = runIteration(compute, timeout)
+    const p = runIteration(compute, timeout, sandboxOptions)
       .then(result => {
         const readyAt = performance.now() - wallStart;
         rampProfile.push({ launchedAt, readyAt, ttiMs: result.ttiMs });

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface ProviderConfig {
   requiredEnvVars: string[];
   /** Creates a compute instance — either direct SDK or gateway-based */
   createCompute: () => any;
+  /** Options passed to sandbox.create() (e.g. { image: 'node:20' }) */
+  sandboxOptions?: Record<string, any>;
 }
 
 export interface TimingResult {


### PR DESCRIPTION
## Summary

- **Namespace**: Was failing because the default `ubuntu:latest` image has no Node.js. Added `sandboxOptions` support to pass `{ image: 'node:22' }` at `sandbox.create()` time.
- **Blaxel**: Removed the custom `blaxel/benchmark:latest` image so it falls back to the default image which includes Node.js (per blaxel team).
- **Generic plumbing**: Added `sandboxOptions` to `ProviderConfig` and threaded it through all benchmark modes (sequential, concurrent, staggered) so any provider can pass options to `sandbox.create()`.

## Changes

- `src/types.ts` — Added optional `sandboxOptions` field to `ProviderConfig`
- `src/benchmark.ts` — `runIteration()` accepts and forwards `sandboxOptions` to `sandbox.create()`
- `src/concurrent.ts` — Passes `sandboxOptions` through to `runIteration`
- `src/staggered.ts` — Passes `sandboxOptions` through to `runIteration`
- `src/providers.ts` — Namespace uses `{ image: 'node:22' }`, blaxel drops custom image