### PR TITLE
feat: parallelize CI benchmarks across providers

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,9 +33,24 @@ permissions:
 
 jobs:
   bench:
-    name: Run Benchmarks
+    name: Bench ${{ matrix.provider }}
     runs-on: namespace-profile-default
-    timeout-minutes: 180
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        provider:
+          - e2b
+          - daytona
+          - blaxel
+          - just-bash
+          - modal
+          - vercel
+          - hopx
+          - codesandbox
+          - runloop
+          - namespace
+          - cloudflare
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -43,7 +58,7 @@ jobs:
           node-version: 24
           cache: 'npm'
       - run: npm ci
-      - name: Run benchmarks
+      - name: Run benchmark
         env:
           COMPUTESDK_API_KEY: ${{ secrets.COMPUTESDK_API_KEY }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
@@ -55,24 +70,49 @@ jobs:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          RAILWAY_API_KEY: ${{ secrets.RAILWAY_API_KEY }}
-          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
-          RAILWAY_ENVIRONMENT_ID: ${{ secrets.RAILWAY_ENVIRONMENT_ID }}
           NSC_TOKEN: ${{ secrets.NSC_TOKEN }}
-          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          RENDER_OWNER_ID: ${{ secrets.RENDER_OWNER_ID }}
-          HOPX_API_KEY: ${{ secrets.HOPX_API_KEY}}
-          CSB_API_KEY: ${{ secrets.CSB_API_KEY}}
-          RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY}}
+          HOPX_API_KEY: ${{ secrets.HOPX_API_KEY }}
+          CSB_API_KEY: ${{ secrets.CSB_API_KEY }}
+          RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
+          CLOUDFLARE_SANDBOX_URL: ${{ secrets.CLOUDFLARE_SANDBOX_URL }}
+          CLOUDFLARE_SANDBOX_SECRET: ${{ secrets.CLOUDFLARE_SANDBOX_SECRET }}
         run: |
           MODE_FLAG=""
           if [ -n "${{ github.event.inputs.mode }}" ]; then
             MODE_FLAG="--mode ${{ github.event.inputs.mode }}"
           fi
           npm run bench -- \
+            --provider ${{ matrix.provider }} \
             --iterations ${{ github.event.inputs.iterations || '100' }} \
             --concurrency ${{ github.event.inputs.concurrency || '100' }} \
             $MODE_FLAG
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: results-${{ matrix.provider }}
+          path: results/
+          retention-days: 7
+
+  collect:
+    name: Collect Results
+    runs-on: namespace-profile-default
+    needs: bench
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'npm'
+      - run: npm ci
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+          pattern: results-*
+      - name: Merge results
+        run: npx tsx src/merge-results.ts --input artifacts
       - run: npm run generate-svg
       - name: Commit and push
         run: |

--- a/src/merge-results.ts
+++ b/src/merge-results.ts
@@ -1,0 +1,113 @@
+/**
+ * Merge per-provider benchmark results into combined result files.
+ *
+ * Usage: tsx src/merge-results.ts --input <artifacts-dir>
+ *
+ * Reads all JSON files from the input directory (one per provider per mode),
+ * groups them by mode, merges results, computes composite scores, and writes
+ * combined files to results/<mode>/latest.json.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { computeCompositeScores } from './scoring.js';
+import { printResultsTable, writeResultsJson } from './table.js';
+import type { BenchmarkResult } from './types.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+const args = process.argv.slice(2);
+function getArgValue(flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}
+
+const inputDir = getArgValue('--input');
+if (!inputDir) {
+  console.error('Usage: tsx src/merge-results.ts --input <artifacts-dir>');
+  process.exit(1);
+}
+
+interface ResultFile {
+  version: string;
+  timestamp: string;
+  environment: Record<string, any>;
+  config: Record<string, any>;
+  results: BenchmarkResult[];
+}
+
+/** Map mode to results subdirectory name */
+function modeToDir(mode: string): string {
+  return `${mode}_tti`;
+}
+
+function main() {
+  // Find all JSON files recursively in the input directory
+  const jsonFiles: string[] = [];
+  function walk(dir: string) {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.json')) jsonFiles.push(full);
+    }
+  }
+  walk(inputDir!);
+
+  if (jsonFiles.length === 0) {
+    console.error(`No JSON files found in ${inputDir}`);
+    process.exit(1);
+  }
+
+  console.log(`Found ${jsonFiles.length} result files`);
+
+  // Group results by mode
+  const byMode: Record<string, { results: BenchmarkResult[]; meta: ResultFile }> = {};
+
+  for (const file of jsonFiles) {
+    const raw: ResultFile = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    for (const result of raw.results) {
+      // Determine mode from the file path or result
+      // File paths are like: <provider>-<mode>/results.json
+      const dirName = path.basename(path.dirname(file));
+      let mode = result.mode || 'sequential';
+      // Also try to infer from directory name
+      if (dirName.includes('sequential')) mode = 'sequential';
+      else if (dirName.includes('staggered')) mode = 'staggered';
+      else if (dirName.includes('burst')) mode = 'burst';
+
+      if (!byMode[mode]) {
+        byMode[mode] = { results: [], meta: raw };
+      }
+      byMode[mode].results.push(result);
+    }
+  }
+
+  // For each mode, compute scores, print table, and write combined results
+  for (const [mode, { results, meta }] of Object.entries(byMode)) {
+    console.log(`\nMerging ${results.length} provider results for mode: ${mode}`);
+
+    // Compute composite scores across all providers
+    computeCompositeScores(results);
+
+    // Print the combined table
+    printResultsTable(results);
+
+    // Write combined results
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const subDir = modeToDir(mode);
+    const resultsDir = path.resolve(ROOT, `results/${subDir}`);
+    fs.mkdirSync(resultsDir, { recursive: true });
+
+    const outPath = path.join(resultsDir, `${timestamp}.json`);
+    writeResultsJson(results, outPath);
+
+    // Copy to latest.json
+    const latestPath = path.join(resultsDir, 'latest.json');
+    fs.copyFileSync(outPath, latestPath);
+    console.log(`Copied latest: ${latestPath}`);
+  }
+}
+
+main();

--- a/src/merge-results.ts
+++ b/src/merge-results.ts
@@ -3,7 +3,7 @@
  *
  * Usage: tsx src/merge-results.ts --input <artifacts-dir>
  *
- * Reads all JSON files from the input directory (one per provider per mode),
+ * Reads latest.json files from the input directory (one per provider per mode),
  * groups them by mode, merges results, computes composite scores, and writes
  * combined files to results/<mode>/latest.json.
  */
@@ -37,26 +37,38 @@ interface ResultFile {
   results: BenchmarkResult[];
 }
 
-/** Map mode to results subdirectory name */
+/** Map mode to results subdirectory name, matching run.ts logic */
 function modeToDir(mode: string): string {
-  return `${mode}_tti`;
+  switch (mode) {
+    case 'sequential': return 'sequential_tti';
+    case 'staggered': return 'staggered_tti';
+    case 'burst':
+    case 'concurrent': return 'burst_tti';
+    default: return `${mode}_tti`;
+  }
 }
 
-function main() {
-  // Find all JSON files recursively in the input directory
+/** Normalize mode name (concurrent -> burst) */
+function normalizeMode(mode: string): string {
+  return mode === 'concurrent' ? 'burst' : mode;
+}
+
+async function main() {
+  // Find only latest.json files recursively to avoid duplicates.
+  // Artifact layout: artifacts/results-<provider>/<mode>_tti/latest.json
   const jsonFiles: string[] = [];
   function walk(dir: string) {
     if (!fs.existsSync(dir)) return;
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) walk(full);
-      else if (entry.name.endsWith('.json')) jsonFiles.push(full);
+      else if (entry.name === 'latest.json') jsonFiles.push(full);
     }
   }
   walk(inputDir!);
 
   if (jsonFiles.length === 0) {
-    console.error(`No JSON files found in ${inputDir}`);
+    console.error(`No latest.json files found in ${inputDir}`);
     process.exit(1);
   }
 
@@ -68,11 +80,10 @@ function main() {
   for (const file of jsonFiles) {
     const raw: ResultFile = JSON.parse(fs.readFileSync(file, 'utf-8'));
     for (const result of raw.results) {
-      // Determine mode from the file path or result
-      // File paths are like: <provider>-<mode>/results.json
+      // Determine mode from the directory name (e.g. sequential_tti, burst_tti)
       const dirName = path.basename(path.dirname(file));
-      let mode = result.mode || 'sequential';
-      // Also try to infer from directory name
+      let mode = normalizeMode(result.mode || 'sequential');
+      // Infer from directory name if available
       if (dirName.includes('sequential')) mode = 'sequential';
       else if (dirName.includes('staggered')) mode = 'staggered';
       else if (dirName.includes('burst')) mode = 'burst';
@@ -85,7 +96,7 @@ function main() {
   }
 
   // For each mode, compute scores, print table, and write combined results
-  for (const [mode, { results, meta }] of Object.entries(byMode)) {
+  for (const [mode, { results }] of Object.entries(byMode)) {
     console.log(`\nMerging ${results.length} provider results for mode: ${mode}`);
 
     // Compute composite scores across all providers
@@ -101,7 +112,7 @@ function main() {
     fs.mkdirSync(resultsDir, { recursive: true });
 
     const outPath = path.join(resultsDir, `${timestamp}.json`);
-    writeResultsJson(results, outPath);
+    await writeResultsJson(results, outPath);
 
     // Copy to latest.json
     const latestPath = path.join(resultsDir, 'latest.json');
@@ -110,4 +121,7 @@ function main() {
   }
 }
 
-main();
+main().catch(err => {
+  console.error('Merge failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Split the single monolithic benchmark job into 11 parallel per-provider matrix jobs, reducing total wall clock from ~90min to ~20min
- Added `src/merge-results.ts` script to combine per-provider result artifacts, compute composite scores, and write merged `latest.json` files
- Added a `collect` job that downloads all artifacts, merges results, generates SVGs, and commits

## How it works

1. **`bench` job** — Matrix strategy runs all 11 providers in parallel with `fail-fast: false`. Each job runs `npm run bench -- --provider <name>` and uploads its `results/` directory as an artifact.
2. **`collect` job** — Runs after all bench jobs complete (`if: always()`). Downloads all artifacts, runs the merge script to combine results by mode, generates SVGs, and commits to the repo.

## Changes

- `.github/workflows/benchmarks.yml` — Replaced single job with matrix + collect pattern
- `src/merge-results.ts` — New script to merge per-provider JSON results