### PR TITLE
fix: make daytona sandboxes ephemeral

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -30,6 +30,7 @@ export const providers: ProviderConfig[] = [
     name: 'daytona',
     requiredEnvVars: ['DAYTONA_API_KEY'],
     createCompute: () => daytona({ apiKey: process.env.DAYTONA_API_KEY! }),
+    sandboxOptions: { autoStopInterval: 15, autoDeleteInterval: 0 },
   },
   {
     name: 'blaxel',


### PR DESCRIPTION
## Summary

- Set `autoStopInterval: 15` (minutes) and `autoDeleteInterval: 0` (delete on stop) for daytona sandboxes
- Makes sandboxes ephemeral so they auto-cleanup instead of accumulating after benchmark runs
- Uses `sandboxOptions` plumbing added in #25

Per daytona team's suggestion to avoid cleanup issues.