### PR TITLE
fix: prevent duplicate providers in merged benchmark results

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -58,6 +58,8 @@ jobs:
           node-version: 24
           cache: 'npm'
       - run: npm ci
+      - name: Clear stale results from checkout
+        run: rm -rf results/
       - name: Run benchmark
         env:
           COMPUTESDK_API_KEY: ${{ secrets.COMPUTESDK_API_KEY }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           name: results-${{ matrix.provider }}
           path: results/
+          if-no-files-found: ignore
           retention-days: 7
 
   collect:

--- a/src/merge-results.ts
+++ b/src/merge-results.ts
@@ -74,11 +74,12 @@ async function main() {
 
   console.log(`Found ${jsonFiles.length} result files`);
 
-  // Group results by mode
-  const byMode: Record<string, { results: BenchmarkResult[]; meta: ResultFile }> = {};
+  // Group results by mode, tracking source file size to detect stale multi-provider files
+  const byMode: Record<string, { results: { result: BenchmarkResult; fromSingleProvider: boolean }[] }> = {};
 
   for (const file of jsonFiles) {
     const raw: ResultFile = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    const fromSingleProvider = raw.results.length === 1;
     for (const result of raw.results) {
       // Determine mode from the directory name (e.g. sequential_tti, burst_tti)
       const dirName = path.basename(path.dirname(file));
@@ -89,22 +90,25 @@ async function main() {
       else if (dirName.includes('burst')) mode = 'burst';
 
       if (!byMode[mode]) {
-        byMode[mode] = { results: [], meta: raw };
+        byMode[mode] = { results: [] };
       }
-      byMode[mode].results.push(result);
+      byMode[mode].results.push({ result, fromSingleProvider });
     }
   }
 
   // For each mode, deduplicate by provider and compute scores
   for (const [mode, { results }] of Object.entries(byMode)) {
-    // Deduplicate by provider name, keeping the last-seen result.
-    // This handles the case where a cancelled/failed job uploads stale
-    // results from git checkout that contain all providers.
-    const seen = new Map<string, BenchmarkResult>();
-    for (const result of results) {
-      seen.set(result.provider, result);
+    // Deduplicate by provider name. Prefer results from single-provider files
+    // (fresh per-job results) over multi-provider files (stale combined results
+    // from a previous run that were checked out by git).
+    const seen = new Map<string, { result: BenchmarkResult; fromSingleProvider: boolean }>();
+    for (const entry of results) {
+      const existing = seen.get(entry.result.provider);
+      if (!existing || (entry.fromSingleProvider && !existing.fromSingleProvider)) {
+        seen.set(entry.result.provider, entry);
+      }
     }
-    const deduped = Array.from(seen.values());
+    const deduped = Array.from(seen.values()).map(e => e.result);
 
     if (deduped.length !== results.length) {
       console.log(`\nMerging ${deduped.length} provider results for mode: ${mode} (deduplicated from ${results.length})`);

--- a/src/merge-results.ts
+++ b/src/merge-results.ts
@@ -95,15 +95,28 @@ async function main() {
     }
   }
 
-  // For each mode, compute scores, print table, and write combined results
+  // For each mode, deduplicate by provider and compute scores
   for (const [mode, { results }] of Object.entries(byMode)) {
-    console.log(`\nMerging ${results.length} provider results for mode: ${mode}`);
+    // Deduplicate by provider name, keeping the last-seen result.
+    // This handles the case where a cancelled/failed job uploads stale
+    // results from git checkout that contain all providers.
+    const seen = new Map<string, BenchmarkResult>();
+    for (const result of results) {
+      seen.set(result.provider, result);
+    }
+    const deduped = Array.from(seen.values());
+
+    if (deduped.length !== results.length) {
+      console.log(`\nMerging ${deduped.length} provider results for mode: ${mode} (deduplicated from ${results.length})`);
+    } else {
+      console.log(`\nMerging ${deduped.length} provider results for mode: ${mode}`);
+    }
 
     // Compute composite scores across all providers
-    computeCompositeScores(results);
+    computeCompositeScores(deduped);
 
     // Print the combined table
-    printResultsTable(results);
+    printResultsTable(deduped);
 
     // Write combined results
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
@@ -112,7 +125,7 @@ async function main() {
     fs.mkdirSync(resultsDir, { recursive: true });
 
     const outPath = path.join(resultsDir, `${timestamp}.json`);
-    await writeResultsJson(results, outPath);
+    await writeResultsJson(deduped, outPath);
 
     // Copy to latest.json
     const latestPath = path.join(resultsDir, 'latest.json');


### PR DESCRIPTION
## Summary

Fixes a bug where cancelled or failed matrix jobs would upload stale `latest.json` files from `git checkout` that contained results for all providers from the previous combined run, causing duplicates in the merged output.

## Changes

- **`.github/workflows/benchmarks.yml`** -- Added `rm -rf results/` step before running each provider benchmark to clear stale data from checkout
- **`src/merge-results.ts`** -- Added deduplication by provider name as a safety net, keeping the last-seen result per provider per mode

## No impact on historical results

The `rm -rf` only runs in the ephemeral CI runner workspace. Historical timestamped JSON files committed to git are unaffected -- each run continues to create new timestamped files as before.