### PR TITLE
fix: add process.exit(0) to prevent hanging after benchmarks complete

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -131,7 +131,9 @@ async function main() {
   console.log('\nAll tests complete.');
 }
 
-main().catch(err => {
+main().then(() => {
+  process.exit(0);
+}).catch(err => {
   console.error('Benchmark failed:', err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

- Add explicit `process.exit(0)` after `main()` resolves in `src/run.ts`
- The codesandbox SDK leaves open handles (HTTP keep-alive connections) that prevent Node.js from exiting naturally
- This caused the CI job to hang until the 60-minute timeout killed it (observed in run #23065457093)
- The error path already had `process.exit(1)`, so this just adds the matching success path

## Changes

One-line change in `src/run.ts`: `main().catch(...)` -> `main().then(() => process.exit(0)).catch(...)`