### PR TITLE
fix: log sandbox destroy failures and clean up leaked timers

### DIFF
--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -103,21 +103,29 @@ export async function runIteration(compute: any, timeout: number, sandboxOptions
     return { ttiMs };
   } finally {
     if (sandbox) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
       try {
         await Promise.race([
           sandbox.destroy(),
-          new Promise((_, reject) => setTimeout(() => reject(new Error('Destroy timeout')), 15_000)),
+          new Promise((_, reject) => {
+            timer = setTimeout(() => reject(new Error('Destroy timeout')), 15_000);
+          }),
         ]);
-      } catch {
-        // Ignore cleanup errors
+      } catch (err) {
+        console.warn(`    [cleanup] destroy failed: ${err instanceof Error ? err.message : String(err)}`);
+      } finally {
+        if (timer) clearTimeout(timer);
       }
     }
   }
 }
 
 export function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
   return Promise.race([
-    promise,
-    new Promise<T>((_, reject) => setTimeout(() => reject(new Error(message)), ms)),
+    promise.then(v => { clearTimeout(timer); return v; }),
+    new Promise<T>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), ms);
+    }),
   ]);
 }


### PR DESCRIPTION
## Summary

- **Log destroy failures** instead of silently swallowing them — when `sandbox.destroy()` fails or times out, we now print `[cleanup] destroy failed: <reason>` so we can see resource leaks in CI logs
- **Clean up timeout timers** in both `runIteration`'s destroy logic and the `withTimeout` helper — prevents leaked `setTimeout` handles from keeping the Node.js event loop alive

## Context

We're not observing daytona sandboxes being deleted after benchmarks. The silent `catch {}` in the destroy path means we have zero visibility into whether cleanup is actually working. This PR makes failures visible so we can diagnose whether `destroy()` is failing, timing out, or if the issue is upstream in `@computesdk/daytona`.