### PR TITLE
Add pricing comparison table for sandbox providers

### DIFF
--- a/.github/workflows/pricing-svg.yml
+++ b/.github/workflows/pricing-svg.yml
@@ -1,0 +1,32 @@
+name: Pricing SVG
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pricing.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    name: Generate Pricing SVG
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run generate-pricing-svg
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pricing.svg
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: update pricing SVG [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ![Burst TTI](./burst_tti.svg)
 
+![Pricing Comparison](./pricing.svg)
+
 [![Benchmarks](https://github.com/computesdk/benchmarks/actions/workflows/benchmarks.yml/badge.svg)](https://github.com/computesdk/benchmarks/actions/workflows/benchmarks.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
@@ -79,7 +81,7 @@ Sponsors enable independent benchmark infrastructure. **Sponsors cannot influenc
 - [ ] 10,000 concurrent sandbox stress test
 - [ ] Cold start vs warm start metrics
 - [ ] Multi-region testing
-- [ ] Cost-per-sandbox-minute
+- [x] Cost-per-sandbox-minute
 
 <br>
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "generate-svg": "tsx src/generate-svg.ts",
     "generate-svg:sequential": "tsx src/generate-svg.ts --mode sequential",
     "generate-svg:staggered": "tsx src/generate-svg.ts --mode staggered",
-    "generate-svg:burst": "tsx src/generate-svg.ts --mode burst"
+    "generate-svg:burst": "tsx src/generate-svg.ts --mode burst",
+    "generate-pricing-svg": "tsx src/generate-pricing-svg.ts"
   },
   "dependencies": {
     "@computesdk/blaxel": "^1.6.0",

--- a/pricing.json
+++ b/pricing.json
@@ -1,0 +1,714 @@
+{
+  "meta": {
+    "version": "1.0",
+    "last_updated": "2026-03-16",
+    "normalization_basis": "1 vCPU + 2 GB RAM / hour",
+    "notes": "Rates sourced from official pricing pages. Confidence field indicates data quality: exact = from official pricing page, estimated = back-calculated from bundled tier, unknown = not published."
+  },
+  "providers": [
+    {
+      "id": "e2b",
+      "benchmark": {
+        "score": 68.4,
+        "success_rate": "100/100",
+        "status": "ok",
+        "cold_start_ms": 150
+      },
+      "pricing": {
+        "model": "per_second",
+        "cpu": {
+          "rate": 0.000014,
+          "unit": "vCPU-sec",
+          "confidence": "exact"
+        },
+        "memory": {
+          "rate": 0.0000045,
+          "unit": "GiB-sec",
+          "bundled_with_cpu": false,
+          "confidence": "exact"
+        },
+        "storage": {
+          "included_gb": 10,
+          "overage_rate": null,
+          "overage_unit": null,
+          "confidence": "exact",
+          "notes": "10 GiB on Hobby, 20 GiB on Pro. No published overage rate. Paused sandboxes: no charge."
+        },
+        "egress": {
+          "rate": null,
+          "free_gb_per_month": null,
+          "confidence": "unknown"
+        },
+        "normalized": {
+          "cpu_per_vcpu_hr": 0.0504,
+          "memory_per_gib_hr": 0.0162,
+          "total_1vcpu_2gb_hr": 0.0828,
+          "confidence": "exact"
+        }
+      },
+      "plans": [
+        {
+          "name": "hobby",
+          "base_fee_per_month": 0,
+          "credits": 100,
+          "one_time_credit": true,
+          "requires_cc": false,
+          "max_session_hr": 1,
+          "max_concurrent_sandboxes": 20
+        },
+        {
+          "name": "pro",
+          "base_fee_per_month": 150,
+          "credits": 0,
+          "one_time_credit": false,
+          "requires_cc": true,
+          "max_session_hr": 24,
+          "max_concurrent_sandboxes": 100
+        },
+        {
+          "name": "enterprise",
+          "base_fee_per_month": null,
+          "credits": null,
+          "one_time_credit": false,
+          "requires_cc": true,
+          "max_session_hr": null,
+          "max_concurrent_sandboxes": null
+        }
+      ],
+      "free_credits": 100,
+      "isolation": "firecracker_microvm",
+      "notes": "Paused sandboxes incur zero charges. Pro unlocks 24-hr sessions and 100 concurrent sandboxes."
+    },
+    {
+      "id": "blaxel",
+      "benchmark": {
+        "score": 60.5,
+        "success_rate": "71/100",
+        "status": "ok",
+        "cold_start_ms": 25
+      },
+      "pricing": {
+        "model": "per_second",
+        "cpu": {
+          "rate": null,
+          "unit": null,
+          "bundled_with_memory": true,
+          "confidence": "exact",
+          "notes": "CPU allocated based on RAM tier. 2 GB RAM = 1 vCPU."
+        },
+        "memory": {
+          "rate": 0.0000115,
+          "unit": "GB-sec",
+          "bundled_with_cpu": true,
+          "confidence": "exact",
+          "notes": "Billed as combined CPU+RAM rate per GB-sec. Auto-suspend after 15s inactivity; no charge during standby."
+        },
+        "storage": {
+          "volumes_rate": 0.12,
+          "volumes_unit": "GB-month",
+          "snapshot_rate": 0.20,
+          "snapshot_unit": "GB-month",
+          "image_rate": 0.045,
+          "image_unit": "GB-month",
+          "included_gb": null,
+          "confidence": "exact"
+        },
+        "egress": {
+          "rate": null,
+          "free_gb_per_month": null,
+          "confidence": "unknown"
+        },
+        "normalized": {
+          "cpu_per_vcpu_hr": 0.0504,
+          "memory_per_gib_hr": 0.0414,
+          "total_1vcpu_2gb_hr": 0.0828,
+          "confidence": "exact",
+          "notes": "XS tier: 2 GB RAM -> 1 vCPU. $0.0000115/GB-sec x 2 GB x 3600s."
+        }
+      },
+      "plans": [
+        {
+          "name": "pay_as_you_go",
+          "base_fee_per_month": 0,
+          "credits": 200,
+          "one_time_credit": false,
+          "requires_cc": false
+        },
+        {
+          "name": "enterprise",
+          "base_fee_per_month": null,
+          "credits": null,
+          "one_time_credit": false,
+          "requires_cc": true
+        }
+      ],
+      "free_credits": 200,
+      "isolation": "microvm",
+      "notes": "Perpetual standby — sandboxes persist indefinitely. 25ms resume from standby. No charge during standby, only storage."
+    },
+    {
+      "id": "modal",
+      "benchmark": {
+        "score": 55.9,
+        "success_rate": "99/100",
+        "status": "ok",
+        "cold_start_ms": 2000
+      },
+      "pricing": {
+        "model": "per_second",
+        "cpu": {
+          "rate": 0.00003942,
+          "unit": "core-sec",
+          "notes": "1 physical core = 2 vCPU. Sandbox non-preemptible rate = 3x base serverless rate of $0.0000131/core-sec. Regional multipliers 1.25x-2.5x apply on top.",
+          "confidence": "exact"
+        },
+        "memory": {
+          "rate": 0.00000672,
+          "unit": "GiB-sec",
+          "bundled_with_cpu": false,
+          "confidence": "exact",
+          "notes": "Sandbox rate. Standard function rate is $0.00000222/GiB-sec."
+        },
+        "storage": {
+          "included_gb": null,
+          "overage_rate": 0,
+          "overage_unit": "GB-month",
+          "confidence": "semi_official",
+          "notes": "Volumes currently free. May change. Ephemeral disk billed indirectly via memory at 20:1 ratio."
+        },
+        "egress": {
+          "rate": 0,
+          "free_gb_per_month": null,
+          "confidence": "semi_official",
+          "notes": "Egress free per official statements."
+        },
+        "normalized": {
+          "cpu_per_vcpu_hr": 0.07096,
+          "memory_per_gib_hr": 0.02419,
+          "total_1vcpu_2gb_hr": 0.11914,
+          "confidence": "exact",
+          "notes": "$0.00003942/core-sec / 2 vCPU x 3600s for CPU. Sandbox non-preemptible rate."
+        }
+      },
+      "plans": [
+        {
+          "name": "starter",
+          "base_fee_per_month": 0,
+          "credits": 30,
+          "one_time_credit": false,
+          "requires_cc": false,
+          "max_containers": 100,
+          "max_gpu_concurrency": 10
+        },
+        {
+          "name": "team",
+          "base_fee_per_month": 250,
+          "credits": 100,
+          "one_time_credit": false,
+          "requires_cc": true,
+          "max_containers": 1000,
+          "max_gpu_concurrency": 50
+        },
+        {
+          "name": "enterprise",
+          "base_fee_per_month": null,
+          "credits": null,
+          "one_time_credit": false,
+          "requires_cc": true,
+          "max_containers": null,
+          "max_gpu_concurrency": null
+        }
+      ],
+      "free_credits": 30,
+      "isolation": "gvisor",
+      "notes": "GPU support available. Regional multipliers (1.25x-2.5x) and non-preemptible multiplier (3x) compound. Startup credits up to $25K for eligible startups."
+    },
+    {
+      "id": "namespace",
+      "benchmark": {
+        "score": 43.7,
+        "success_rate": "100/100",
+        "status": "ok",
+        "cold_start_ms": null
+      },
+      "pricing": {
+        "model": "per_minute",
+        "cpu": {
+          "prepaid_rate": 0.001,
+          "overage_rate": 0.0015,
+          "unit": "unit-min",
+          "notes": "1 unit = 1 vCPU x 1 min (Linux). Windows 2x multiplier, macOS 10x multiplier.",
+          "confidence": "exact"
+        },
+        "memory": {
+          "rate": null,
+          "unit": null,
+          "bundled_with_cpu": true,
+          "confidence": "exact",
+          "notes": "Standard shape: 1 vCPU + 2 GB RAM per unit-min. Memory not separately billed."
+        },
+        "storage": {
+          "cache_volume_rate": 0.0048,
+          "cache_volume_unit": "GB-day",
+          "cache_snapshot_rate": 0.002,
+          "cache_snapshot_unit": "GB-hr",
+          "container_registry_rate": 0.20,
+          "container_registry_unit": "GB-month",
+          "confidence": "exact"
+        },
+        "egress": {
+          "rate": null,
+          "free_gb_per_month": null,
+          "confidence": "unknown",
+          "notes": "Not published. Likely included."
+        },
+        "normalized": {
+          "cpu_per_vcpu_hr": 0.09,
+          "memory_per_gib_hr": 0.03,
+          "total_1vcpu_2gb_hr": 0.09,
+          "confidence": "exact",
+          "notes": "PAYG overage rate: $0.0015/unit-min x 60 min. CPU+memory bundled so total = CPU rate."
+        }
+      },
+      "plans": [
+        {
+          "name": "developer",
+          "base_fee_per_month": 0,
+          "unit_minutes_included": null,
+          "docker_builds_included": null,
+          "billing": "pay_as_you_go"
+        },
+        {
+          "name": "team",
+          "base_fee_per_month": 100,
+          "unit_minutes_included": 100000,
+          "docker_builds_included": 1000
+        },
+        {
+          "name": "business",
+          "base_fee_per_month": 250,
+          "unit_minutes_included": 250000,
+          "docker_builds_included": 2500
+        },
+        {
+          "name": "enterprise",
+          "base_fee_per_month": null,
+          "unit_minutes_included": null,
+          "docker_builds_included": null
+        }
+      ],
+      "free_credits": null,
+      "isolation": "vm",
+      "notes": "Primarily a CI/CD runner platform, not a pure AI sandbox. macOS on Apple M4 Pro available. SOC2 Type II."
+    },
+    {
+      "id": "vercel",
+      "benchmark": {
+        "score": 25.9,
+        "success_rate": "33/100",
+        "status": "ok",
+        "cold_start_ms": null
+      },
+      "pricing": {
+        "model": "active_cpu",
+        "cpu": {
+          "rate": 0.128,
+          "unit": "active-CPU-hr",
+          "confidence": "exact",
+          "notes": "Active CPU only. I/O wait time (LLM calls, network, DB queries) not billed. Effective cost much lower for I/O-heavy workloads."
+        },
+        "memory": {
+          "rate": 0.0106,
+          "unit": "GB-hr",
+          "bundled_with_cpu": false,
+          "billing": "wall_clock",
+          "confidence": "exact",
+          "notes": "Provisioned memory, billed wall-clock regardless of CPU activity. 2 GB per vCPU."
+        },
+        "storage": {
+          "included_gb": 15,
+          "overage_rate": 0.08,
+          "overage_unit": "GB-month",
+          "confidence": "exact",
+          "notes": "Snapshots included. 15 GB free on Hobby."
+        },
+        "egress": {
+          "rate": 0.15,
+          "unit": "GB",
+          "free_gb_per_month": 20,
+          "confidence": "exact",
+          "notes": "20 GB free on Hobby plan. Currently US East (iad1) only."
+        },
+        "normalized": {
+          "cpu_per_vcpu_hr": 0.128,
+          "memory_per_gib_hr": 0.0106,
+          "total_1vcpu_2gb_hr": 0.1492,
+          "confidence": "exact",
+          "notes": "1 vCPU x $0.128 active + 2 GB x $0.0106 wall-clock. CPU component assumes 100% utilization — actual cost lower for I/O-bound workloads."
+        }
+      },
+      "plans": [
+        {
+          "name": "hobby",
+          "base_fee_per_month": 0,
+          "credits": null,
+          "requires_cc": false,
+          "max_session_hr": 0.75,
+          "max_concurrent_sandboxes": 10,
+          "included_cpu_hr": 5,
+          "included_memory_gb_hr": 420,
+          "included_network_gb": 20,
+          "included_creations": 5000
+        },
+        {
+          "name": "pro",
+          "base_fee_per_month": 20,
+          "credits": 20,
+          "requires_cc": true,
+          "max_session_hr": 5,
+          "max_concurrent_sandboxes": 2000
+        },
+        {
+          "name": "enterprise",
+          "base_fee_per_month": null,
+          "credits": null,
+          "requires_cc": true,
+          "max_session_hr": 5,
+          "max_concurrent_sandboxes": 2000
+        }
+      ],
+      "free_credits": null,
+      "isolation": "firecracker_microvm",
+      "notes": "Currently US East (iad1) only. Beta. Sandbox creation rate-limited by vCPU allocation per minute."
+    },
+    {
+      "id": "runloop",
+      "benchmark": {
+        "score": 9.9,
+        "success_rate": "100/100",
+        "status": "ok",
+        "cold_start_ms": 2000
+      },
+      "pricing": {
+        "model": "per_second",
+        "cpu": {
+          "rate": 0.00003,
+          "unit": "CPU-sec",
+          "confidence": "exact"
+        },
+        "memory": {
+          "rate": 0.000007,
+          "unit": "GB-sec",
+          "bundled_with_cpu": false,
+          "confidence": "exact"
+        },
+        "storage": {
+          "active_rate": 0.00034236,
+          "active_unit": "GB-hr",
+          "snapshot_rate": 0.000072,
+          "snapshot_unit": "GB-hr",
+          "free_gb": 100,
+          "confidence": "exact",
+          "notes": "Basic plan: 100 GB free. Pro plan: 1 TB free. Active storage ~$0.247/GB-month."
+        },
+        "egress": {
+          "rate": null,
+          "free_gb_per_month": null,
+          "confidence": "unknown"
+        },
+        "normalized": {
+          "cpu_per_vcpu_hr": 0.108,
+          "memory_per_gib_hr": 0.0252,
+          "total_1vcpu_2gb_hr": 0.1584,
+          "confidence": "exact",
+          "notes": "1 vCPU x $0.108 + 2 GB x $0.0252."
+        }
+      },
+      "plans": [
+        {
+          "name": "basic",
+          "base_fee_per_month": 0,
+          "credits": 25,
+          "one_time_credit": false,
+          "storage_included_gb": 100
+        },
+        {
+          "name": "pro",
+          "base_fee_per_month": 250,
+          "credits": null,
+          "storage_included_gb": 1000
+        },
+        {
+          "name": "enterprise",
+          "base_fee_per_month": null,
+          "credits": null,
+          "storage_included_gb": null
+        }
+      ],
+      "free_credits": 25,
+      "isolation": "microvm",
+      "notes": "SOC2 certified. Built-in benchmarking tools. VPC deployment available. Founded by ex-Google/Stripe engineers."
+    },
+    {
+      "id": "codesandbox",
+      "benchmark": {
+        "score": 9.7,
+        "success_rate": "82/100",
+        "status": "ok",
+        "cold_start_ms": 500
+      },
+      "pricing": {
+        "model": "per_hour_credits",
+        "cpu": {
+          "rate": null,
+          "unit": null,
+          "bundled_with_memory": true,
+          "confidence": "estimated",
+          "notes": "VM-hour pricing bundles CPU and memory. 1 credit = $0.015. On-demand: $0.1486/hr."
+        },
+        "memory": {
+          "rate": null,
+          "unit": null,
+          "bundled_with_cpu": true,
+          "confidence": "estimated"
+        },
+        "vm_tiers": [
+          { "name": "nano",  "vcpu": 2,  "ram_gb": 4,   "rate_per_hr": 0.1486 },
+          { "name": "micro", "vcpu": 4,  "ram_gb": 8,   "rate_per_hr": 0.2972 },
+          { "name": "small", "vcpu": 8,  "ram_gb": 16,  "rate_per_hr": 0.5944 },
+          { "name": "medium","vcpu": 16, "ram_gb": 32,  "rate_per_hr": 1.1888 },
+          { "name": "large", "vcpu": 32, "ram_gb": 64,  "rate_per_hr": 2.3776 },
+          { "name": "xlarge","vcpu": 64, "ram_gb": 128, "rate_per_hr": 4.7552 }
+        ],
+        "storage": {
+          "included_gb_per_vm": 20,
+          "overage_rate": null,
+          "confidence": "exact",
+          "notes": "20 GB per VM included. No published overage rate."
+        },
+        "egress": {
+          "rate": null,
+          "free_gb_per_month": null,
+          "confidence": "unknown"
+        },
+        "normalized": {
+          "cpu_per_vcpu_hr": 0.075,
+          "memory_per_gib_hr": 0.037,
+          "total_1vcpu_2gb_hr": 0.1486,
+          "confidence": "estimated",
+          "notes": "No 1 vCPU + 2 GB tier. Using Nano (2 vCPU + 4 GB) as closest match at $0.1486/hr. Actual 1vCPU+2GB cost would be ~$0.074 if offered."
+        }
+      },
+      "plans": [
+        {
+          "name": "build",
+          "base_fee_per_month": 0,
+          "vm_credits_hr_per_month": 40,
+          "max_members": 5,
+          "max_concurrent_vms": 10
+        },
+        {
+          "name": "pro",
+          "base_fee_per_month": 9,
+          "vm_credits_hr_per_month": 60,
+          "max_members": 20
+        },
+        {
+          "name": "scale",
+          "base_fee_per_month": 170,
+          "vm_credits_hr_per_month": 160,
+          "max_concurrent_vms": 250
+        }
+      ],
+      "free_credits": null,
+      "isolation": "microvm",
+      "notes": "Now part of Together AI. VM cloning and forking supported. TypeScript /JavaScript SDK only."
+    },
+    {
+      "id": "hopx",
+      "benchmark": {
+        "score": 2.9,
+        "success_rate": "66/100",
+        "status": "ok",
+        "cold_start_ms": 100
+      },
+      "pricing": {
+        "model": "per_second",
+        "cpu": {
+          "rate": 0.000014,
+          "unit": "vCPU-sec",
+          "confidence": "exact",
+          "notes": "Identical to e2b rates."
+        },
+        "memory": {
+          "rate": 0.0000045,
+          "unit": "GiB-sec",
+          "bundled_with_cpu": false,
+          "confidence": "exact"
+        },
+        "storage": {
+          "rate": 0.00000003,
+          "unit": "GiB-sec",
+          "included_gb": null,
+          "confidence": "exact",
+          "notes": "~$0.078/GiB-month. Within $200 free credit."
+        },
+        "egress": {
+          "rate": null,
+          "free_gb_per_month": null,
+          "confidence": "unknown"
+        },
+        "normalized": {
+          "cpu_per_vcpu_hr": 0.0504,
+          "memory_per_gib_hr": 0.0162,
+          "total_1vcpu_2gb_hr": 0.0828,
+          "confidence": "exact",
+          "notes": "Identical to e2b normalization."
+        }
+      },
+      "plans": [
+        {
+          "name": "pay_as_you_go",
+          "base_fee_per_month": 0,
+          "credits": 200,
+          "requires_cc": false
+        }
+      ],
+      "free_credits": 200,
+      "isolation": "firecracker_microvm",
+      "notes": "Built by Bunnyshell. Early stage — no subscription tiers yet. Mirrors e2b pricing exactly."
+    },
+    {
+      "id": "cloudflare",
+      "benchmark": {
+        "score": 2.5,
+        "success_rate": "9/100",
+        "status": "ok",
+        "cold_start_ms": 2000
+      },
+      "pricing": {
+        "model": "active_cpu_per_10ms",
+        "cpu": {
+          "rate": 0.00002,
+          "unit": "vCPU-sec",
+          "billing": "active_only",
+          "confidence": "exact",
+          "notes": "Active CPU usage only, billed per 10ms intervals."
+        },
+        "memory": {
+          "rate": 0.0000025,
+          "unit": "GiB-sec",
+          "billing": "provisioned",
+          "bundled_with_cpu": false,
+          "confidence": "exact",
+          "notes": "Provisioned (wall-clock), not active. Cheapest memory rate in the field."
+        },
+        "storage": {
+          "rate": 0.00000007,
+          "unit": "GB-sec",
+          "billing": "provisioned",
+          "persistence": false,
+          "free_gb_hr_per_month": 200,
+          "confidence": "exact",
+          "notes": "Ephemeral only — all state lost when sandbox sleeps. No persistent storage available."
+        },
+        "egress": {
+          "rate": 0.025,
+          "unit": "GB",
+          "regional_rates": {
+            "north_america": 0.025,
+            "europe": 0.025,
+            "other": 0.05
+          },
+          "free_gb_per_month": 500,
+          "confidence": "exact",
+          "notes": "500 GB - 1 TB free per month depending on region."
+        },
+        "normalized": {
+          "cpu_per_vcpu_hr": 0.072,
+          "memory_per_gib_hr": 0.009,
+          "total_1vcpu_2gb_hr": 0.09,
+          "confidence": "exact",
+          "notes": "1 vCPU x $0.072 active + 2 GiB x $0.009 provisioned."
+        }
+      },
+      "plans": [
+        {
+          "name": "workers_free",
+          "base_fee_per_month": 0,
+          "sandboxes_available": false,
+          "notes": "Sandboxes require Workers Paid."
+        },
+        {
+          "name": "workers_paid",
+          "base_fee_per_month": 5,
+          "sandboxes_available": true,
+          "included_memory_gb_hr": 25,
+          "included_disk_gb_hr": 200,
+          "included_vcpu_min": 375
+        }
+      ],
+      "free_credits": null,
+      "isolation": "container",
+      "notes": "Currently in public beta. No persistent storage — state lost on sleep. Requires $5/mo Workers Paid base. 9/100 benchmark success rate suggests significant reliability issues."
+    },
+    {
+      "id": "daytona",
+      "benchmark": {
+        "score": null,
+        "success_rate": "0/100",
+        "status": "failed",
+        "cold_start_ms": 90
+      },
+      "pricing": {
+        "model": "per_second",
+        "cpu": {
+          "rate": 0.000014,
+          "unit": "vCPU-sec",
+          "confidence": "estimated",
+          "notes": "Back-calculated from $0.067/hr for 1vCPU+1GiB. Same rate as e2b."
+        },
+        "memory": {
+          "rate": 0.0000045,
+          "unit": "GiB-sec",
+          "bundled_with_cpu": false,
+          "confidence": "exact",
+          "notes": "First 5 GiB free. Same rate as e2b and hopx."
+        },
+        "storage": {
+          "rate": 0.00000003,
+          "unit": "GiB-sec",
+          "free_gib": 5,
+          "archive_rate": null,
+          "confidence": "exact",
+          "notes": "Stopped sandboxes: disk-only charges. Auto-archive after 7 days to cheaper object storage. Archive rate not published."
+        },
+        "egress": {
+          "rate": 0,
+          "free_gb_per_month": null,
+          "confidence": "exact",
+          "notes": "Included free. Tier 1 accounts restricted to whitelisted services only (GitHub, package registries). Full internet requires higher tier."
+        },
+        "normalized": {
+          "cpu_per_vcpu_hr": 0.0504,
+          "memory_per_gib_hr": 0.0162,
+          "total_1vcpu_2gb_hr": 0.0828,
+          "confidence": "estimated",
+          "notes": "CPU back-calculated. Memory exact. Same total as e2b and hopx."
+        }
+      },
+      "plans": [
+        {
+          "name": "pay_as_you_go",
+          "base_fee_per_month": 0,
+          "credits": 200,
+          "requires_cc": false,
+          "startup_credits_available": 50000
+        }
+      ],
+      "free_credits": 200,
+      "isolation": "docker_oci",
+      "notes": "Failed benchmark run. Raised $24M Series A Feb 2026. Docker/OCI containers by default (not microVMs). Optional Kata Containers for stronger isolation. Sub-90ms cold starts from warm pool. Auto-stop at 15min idle."
+    }
+  ]
+}

--- a/pricing.svg
+++ b/pricing.svg
@@ -1,0 +1,173 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="712" viewBox="0 0 1200 712">
+  <defs>
+    <linearGradient id="headerGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f6f8fa;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <style>
+    .bg { fill: #ffffff; }
+    .header-bg { fill: url(#headerGrad); }
+    .table-header-bg { fill: #f6f8fa; }
+    .table-header { font: 600 12px 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; fill: #57606a; text-transform: uppercase; letter-spacing: 0.5px; }
+    .row { font: 14px 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; fill: #24292f; }
+    .rank { font-weight: 700; fill: #57606a; }
+    .rank-1 { fill: #d4a000; }
+    .rank-2 { fill: #8a8a8a; }
+    .rank-3 { fill: #a0522d; }
+    .provider { font-weight: 600; fill: #0969da; }
+    .cost { font-weight: 700; font-size: 15px; }
+    .value { font-weight: 700; font-size: 15px; }
+    .fast { fill: #1a7f37; }
+    .medium { fill: #9a6700; }
+    .slow { fill: #cf222e; }
+    .status { fill: #57606a; }
+    .divider { stroke: #d0d7de; stroke-width: 1; }
+    .border { stroke: #d0d7de; stroke-width: 1; fill: none; }
+    .timestamp { font: 11px 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; fill: #57606a; }
+    .title { font: bold 28px 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; fill: #24292f; }
+    .subtitle { font: 14px 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; fill: #57606a; }
+    .logo { fill: #24292f; }
+    .confidence-exact { fill: #1a7f37; }
+    .confidence-estimated { fill: #9a6700; }
+    .confidence-unknown { fill: #cf222e; }
+  </style>
+
+  <!-- Background -->
+  <rect class="bg" width="1200" height="712"/>
+
+  <!-- Logo (black square with white C) -->
+  <g transform="translate(24, 24)">
+    <rect width="60" height="60" fill="#000000"/>
+    <g transform="scale(0.035) translate(0, 0)">
+      <path fill="#ffffff" d="M1036.26,1002.28h237.87l-.93,19.09c-8.38,110.32-49.81,198.3-123.82,262.07-73.09,63.31-170.84,95.43-290.48,95.43-130.81,0-235.55-44.69-311.43-133.6-74.48-87.98-112.65-209.48-112.65-361.23v-60.51c0-96.83,17.7-183.41,51.68-257.43,34.91-74.95,85.19-133.61,149.89-173.63,64.7-40.04,140.12-60.52,225.3-60.52,117.77,0,214.13,32.12,286.29,95.9,72.62,63.3,114.98,153.61,126.15,267.67l1.86,19.08h-238.34l-.93-15.83c-4.65-59.11-20.95-101.94-47.95-127.08-27-25.6-69.83-38.17-127.08-38.17-61.91,0-107.06,20.95-137.33,65.17-31.65,45.15-47.94,117.77-48.87,215.53v74.48c0,102.41,15.36,177.83,45.62,223.91,28.86,44.22,74.01,65.63,137.79,65.63,58.19,0,101.48-12.57,128.95-38.17,26.99-25.14,43.29-66.1,47.48-121.5l.93-16.3Z"/>
+    </g>
+  </g>
+
+  <!-- Title -->
+  <text class="title" x="100" y="55">Pricing Comparison</text>
+  <text class="subtitle" x="100" y="78">Normalized to 1 vCPU + 2 GB RAM / hour — sorted by value score</text>
+
+  <!-- Sponsor -->
+  <text font-size="11" font-family="Inter, SF Pro Display, sans-serif" fill="#8c959f" x="1100" y="32" text-anchor="middle" letter-spacing="1">SPONSORED BY</text>
+  <image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASkAAABMCAYAAAAx10HfAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAqkSURBVHgB7Z3vdds6EsXv2/O+rztYpIJNKghTwcYVrFxBnAoiVxC7gigVxKnAfBXEr4JgO9CrYB/GHB4zsiQOSEACpPs7B4eJBf4nLgeDwRAghJCC+Q2EEGLAOdeExX9Cea1/egzlzgeQEYoUIWQvQZwuwuJbKM2OKrdBpz4iE7NEKhz8NTplrYWr3KpPyDZCW3kwVBOr5B6FEY79pyxGqo0KVdjOIiz+i/08bm7nd8xDzL4GhJAxGkOdrygMFRZnqHod6n4PAtPu2xwm6MU/QAghuxmzfIa8RwYoUoSQfbhMdc1QpAghRUORIoTs4zGibhanP0WKELKPO2M9H0qLDFCkCCE70dG6G0PVj7nCeyhShJC9BO1ZhsUVOmtpkzaUNznju+bGSRFCzoAgQquwWGn0ucRHrrs/+zUyQ5EihJhRUWpxQNjdI4QUzbmJlAMhpCrOrbv3JfSp353SJONwPg6d+LrBn9daeh4P4TsoHfWnOC3y77UuvVZZh+sUExd0FPSe976hTdpTm0Q/V6SenGcoG7fx74dwj2VIVR5Ga8Ndl9DIB05LyTzRYPtDuo11WFfO14fyHd2DfLDz0eO+wATmNDjd7yKUt+iu1+gxhHV6n8sf6K5TEaKluZxkHp3Mj7sYqSvnIMctE5bv595rFcUxsrWRk88npQ/qdSifMB15WN/hSOg5fEB3HpMa+wYeXZDefY637qBBydJhHq9ij1H3/wlpMnT4UG50dGsy4Zj+b6h2tbkfzUIg5+IwnVn5njTNTDNS7UZDFfZtR34fa4cv2trJ+6RE3fXiWSNniyLcWLmpks9niTQC9bTZUD6jsypjZrnv32iHPNBSFjiwD1DEabD/Bmlw6NwEP0OxWq7zdxpeTHouXzD/Ol7r8TeokHNynC9REdrgfyCtOL3YDbrYlzlWZrehrgHL8TY4MNqgpTGnFKcXuwnlhyZ6zIp2r1JfSxfKt0MKbSrORqS0v+xRAfqQSoM71AO11EY+CT1eSS+bS0zH9i0NeoHD8DmFqO9icO8d0iP356E2oWKcVGFkfkj3sQi7/oxpzPWZTOKI12qZUahyX8unfOXq56wCilR5HKXBK9exfovBCNpBOaJA9eQQKvEPLpAfh87XVQWcFlMQOpKziFilH2r+jpfhIA5dd/Et4rqN8vC+iqh/rK7DVIeyx8tpHQ7decRaFyJUfyacXNsY6vT3uR/u3xUvNcZ7eSGN5CQvglkiFU7yFnm+FnNZQ1BdBqxvZnlAZbTy1hKboj4IcfhaRvLESHkf0fAaQ53N4NJZqAXTRKxiul5y3uhCPRrYER9V7riz/vjvt7ULtWYbxB+7XMcWhTPXkuojeFNTTX85FdpAnKGqDyUqal4fbPE5yToWIZSH3SpSlnsljesKCdBu3jJilRbGT5mpMN9HxiZJnWvkGz0WcVruE0H9rT92ORarb7ERgfOFz0agT6ocLFaOR6RA/bKyPV6siXCsHvqFEuMHknO9jL1eGlApAYXeuMqnTI5oCZC8jhGRUFd6NzEvhAUKhyJVDo2hzk2CCPElbF2vBoWhVtTCWP0+toEP0escI1Sp46dGI7h3oSLbGqv/G4VDkSoAHVEbexOv/cypGYI2Wou/r0F5WK0oH8rsz36rUFmtkg9Ih58qUAMsKX+FBoVDkSoDy+jMH0iHZVsO5dEY66WwOJ/Q0S+Lf+4iYZDkJWaix215GTkUDkMQyqEd+T3VMLeVf6Eg1Np0hqptCotzA/FtvTfUaxD3CahtpMy8IC+jUeGUbnQqUc8BRaoA1Nl5i7IobYTVIhLCVyRGrBLXpboZa/AN5t/HlMefSuyOCrt758lb1IfJwZvBiuqxdJFTOKFbpMM6aOBQMLSkzowJgZCl0BjqtMiHdLf/OVJnbrzRY+Jul8cJQJE6EXR4/umfeH4z9kvxL/VRydUFykY4pFMOLvyCOqJb5OV/SEvRQZpW5opULudqdQ0pN4OpD9JV6+drXQzKKWM9v9p9MB7kBZNFyj3n286BbPfQo1nFMcgw0Oc0P1ecsV7tloMHecEcS0p8G7ne4DLN4GcwsZOP1NSAS5/T/FzwqJuT6J6l5vcJFpHDc5L9ns30EVNw+PWNudLYmD8jtut9Bakn9qH+F8ly6UAIebKkJP5kTgIssXYmz5EaorPPZQZ3bz0sEEeLClJP7EIFShK50XoiRJnrOBfLZYFESIyLWnZT09hWyyDTZEqB8oNln9PpL3RD6QucHhT3E2SuSOX4TNQKZyhSiBcoGcmSIXePX7vbT2UkuVuD0xQphxOJsibPpPiCcVKkcT2H/JwH2s11xuqrUO78eWUutZ4rLakThMGcZWBNQXKVaNqHQ11YX4a5QmKe0OypY0LYljxZt0YoUkcmYnb/jU83L82hIqTRh+skQjUmELnnJH4xHENMojxigBOMj09jrLdCOorPxrgFS5fvtcv04UvdrqU7yVinxFCkjo8z1EndhWhQH9+N9d4jDwtDnfWZ+QoPAkXq+FjmP3okQp30NTqYV8Z6H1yekRfLp9uyTXA+ZyhS50euz4NnRUMqWkPVfkpRMjS9jTNUvQdJDkXq+Fh8GEn8LBGNrVSsXb5r/f7cbNQXtTRWb0GSQ5E6PpYcQq/nftctrC/WxRIVo2mWvbH6p7lOdO02fjNWXzH0IA8UqePjjfUmd9NUoG5xGlg/1SSi/qAhHtHoej9gtzytx0UiYZzU8RE/hmUakHRhZPTI3BjUEpBtbxvxGos7ulAne89jCSNXOr9zMwvHLnqhWsH4mavB3NEF7NzRijLhDXXcxnNXrEi9wzSqi1HRQMUWtka3VOH5ui8ljVoB0pAXuzf1NO9yn3UmjXWYHUPEsZThdflgp1g51i7wQopeZ/FryXn4we8Ond9vSnJBj8q70QfE0j4dNrKyFClSteeEmoCku2mMdRfoGtzwS8Qe3c29GCz3IfVX6ITMoTJU2OULxbEphhqkjxF7lyJN0ZnQYtyCfwF9UgWg011axNHnPJey0KU1Krrv+lQbeKjX7Nh+oCt28+yomEc/cxSpcpAuzCHeyMM5gFWnZw7nscTxhCrVZO9zIzq901yRqi1y2aFQ9I0svricQnWnDbvfpzjtPSpGz+cShzsPH8obCtQ09JmLerHMFSnLVIEi2BwxKBEdPcs1i/5j2P62AMfqZ+3rgy/nkdsylP284fy8ecRawHNFqtEo5qLRoL4qpoMMhKpFGlp0Det2x/48DtPAs+I7Fui6zalFpEXnIL+kkzwNKlSvYHjOZXRPbmiM+SVdPLGgnP5/qVaKvGX+QnlIjqFm428t4iaDehyQXjg0yZqMwMXO7O8dlDeWkVLdn4wYLtE537dFarc7Vrd0GQ9meWg3bDVIkSz33yEeuYYi3Pc+zWizpY2lvk5r4379yO9yHcbaS4tIBs+5w+7nDr9hAhrw9oDMmRAzIDft0lcW4qA3UYqIVZ8Lyg2qeC0yxaZFF3jJN76ilnSD7pptu359jni5fiIURQSuko5JIiWoUP1EXc7zj7u6PYSQMpnsk5oa83BkWhBCqmKu49wyg78k2AUipDIYzEkIKRqKFCGkaChShJCioUgRQoqGIkUIKRqKFCGkaChShJCioUgRQoqGIkUIKRqKFCGkaP4GW0SrVLGLFBIAAAAASUVORK5CYII=" x="1074" y="42" width="52" height="52" preserveAspectRatio="xMidYMid meet"/>
+
+  <!-- Table header background -->
+  <rect class="table-header-bg" y="134" width="1200" height="44"/>
+
+  <!-- Table header text -->
+  <text class="table-header" x="40" y="162">#</text>
+  <text class="table-header" x="80" y="162">Provider</text>
+  <text class="table-header" x="260" y="162">Cost / hr</text>
+  <text class="table-header" x="460" y="162">Benchmark</text>
+  <text class="table-header" x="660" y="162">Billing</text>
+  <text class="table-header" x="860" y="162">Value Score</text>
+  <text class="table-header" x="1020" y="162">Confidence</text>
+
+  <!-- Row 1: e2b -->
+  <text class="rank rank-1" x="40" y="208">1</text>
+  <text class="row provider" x="80" y="208">E2B</text>
+  <text class="row cost fast" x="260" y="208">$0.0828</text>
+  <text class="row" x="460" y="208">68.4 (100/100)</text>
+  <text class="row" x="660" y="208">Per-second</text>
+  <text class="row value fast" x="860" y="208">63.3</text>
+  <text class="row confidence-exact" x="1020" y="208">exact</text>
+  <line class="divider" x1="24" y1="222" x2="1176" y2="222"/>
+
+  <!-- Row 2: blaxel -->
+  <text class="rank rank-2" x="40" y="252">2</text>
+  <text class="row provider" x="80" y="252">Blaxel</text>
+  <text class="row cost fast" x="260" y="252">$0.0828</text>
+  <text class="row" x="460" y="252">60.5 (71/100)</text>
+  <text class="row" x="660" y="252">Per-second</text>
+  <text class="row value medium" x="860" y="252">59.5</text>
+  <text class="row confidence-exact" x="1020" y="252">exact</text>
+  <line class="divider" x1="24" y1="266" x2="1176" y2="266"/>
+
+  <!-- Row 3: namespace -->
+  <text class="rank rank-3" x="40" y="296">3</text>
+  <text class="row provider" x="80" y="296">Namespace</text>
+  <text class="row cost fast" x="260" y="296">$0.0900</text>
+  <text class="row" x="460" y="296">43.7 (100/100)</text>
+  <text class="row" x="660" y="296">Per-minute</text>
+  <text class="row value medium" x="860" y="296">49.0</text>
+  <text class="row confidence-exact" x="1020" y="296">exact</text>
+  <line class="divider" x1="24" y1="310" x2="1176" y2="310"/>
+
+  <!-- Row 4: modal -->
+  <text class="rank" x="40" y="340">4</text>
+  <text class="row provider" x="80" y="340">Modal</text>
+  <text class="row cost medium" x="260" y="340">$0.1191</text>
+  <text class="row" x="460" y="340">55.9 (99/100)</text>
+  <text class="row" x="660" y="340">Per-second</text>
+  <text class="row value medium" x="860" y="340">47.5</text>
+  <text class="row confidence-exact" x="1020" y="340">exact</text>
+  <line class="divider" x1="24" y1="354" x2="1176" y2="354"/>
+
+  <!-- Row 5: vercel -->
+  <text class="rank" x="40" y="384">5</text>
+  <text class="row provider" x="80" y="384">Vercel</text>
+  <text class="row cost slow" x="260" y="384">$0.1492</text>
+  <text class="row" x="460" y="384">25.9 (33/100)</text>
+  <text class="row" x="660" y="384">Active CPU</text>
+  <text class="row value slow" x="860" y="384">25.6</text>
+  <text class="row confidence-exact" x="1020" y="384">exact</text>
+  <line class="divider" x1="24" y1="398" x2="1176" y2="398"/>
+
+  <!-- Row 6: codesandbox -->
+  <text class="rank" x="40" y="428">6</text>
+  <text class="row provider" x="80" y="428">Codesandbox</text>
+  <text class="row cost slow" x="260" y="428">$0.1486</text>
+  <text class="row" x="460" y="428">9.7 (82/100)</text>
+  <text class="row" x="660" y="428">Per-hour</text>
+  <text class="row value slow" x="860" y="428">15.8</text>
+  <text class="row confidence-estimated" x="1020" y="428">estimated</text>
+  <line class="divider" x1="24" y1="442" x2="1176" y2="442"/>
+
+  <!-- Row 7: runloop -->
+  <text class="rank" x="40" y="472">7</text>
+  <text class="row provider" x="80" y="472">Runloop</text>
+  <text class="row cost slow" x="260" y="472">$0.1584</text>
+  <text class="row" x="460" y="472">9.9 (100/100)</text>
+  <text class="row" x="660" y="472">Per-second</text>
+  <text class="row value slow" x="860" y="472">14.3</text>
+  <text class="row confidence-exact" x="1020" y="472">exact</text>
+  <line class="divider" x1="24" y1="486" x2="1176" y2="486"/>
+
+  <!-- Row 8: hopx -->
+  <text class="rank" x="40" y="516">8</text>
+  <text class="row provider" x="80" y="516">Hopx</text>
+  <text class="row cost fast" x="260" y="516">$0.0828</text>
+  <text class="row" x="460" y="516">2.9 (66/100)</text>
+  <text class="row" x="660" y="516">Per-second</text>
+  <text class="row value slow" x="860" y="516">13.0</text>
+  <text class="row confidence-exact" x="1020" y="516">exact</text>
+  <line class="divider" x1="24" y1="530" x2="1176" y2="530"/>
+
+  <!-- Row 9: cloudflare -->
+  <text class="rank" x="40" y="560">9</text>
+  <text class="row provider" x="80" y="560">Cloudflare</text>
+  <text class="row cost fast" x="260" y="560">$0.0900</text>
+  <text class="row" x="460" y="560">2.5 (9/100)</text>
+  <text class="row" x="660" y="560">Active CPU</text>
+  <text class="row value slow" x="860" y="560">11.7</text>
+  <text class="row confidence-exact" x="1020" y="560">exact</text>
+  <line class="divider" x1="24" y1="574" x2="1176" y2="574"/>
+
+  <!-- Row 10: daytona -->
+  <text class="rank" x="40" y="604">10</text>
+  <text class="row provider" x="80" y="604">Daytona</text>
+  <text class="row cost fast" x="260" y="604">$0.0828</text>
+  <text class="row" x="460" y="604">-- (0/100)</text>
+  <text class="row" x="660" y="604">Per-second</text>
+  <text class="row value status" x="860" y="604">--</text>
+  <text class="row confidence-estimated" x="1020" y="604">estimated</text>
+
+  <!-- Timestamp -->
+  <text class="timestamp" x="1176" y="674" text-anchor="end">Last updated: Mar 15, 2026</text>
+
+  <!-- Footnotes -->
+  <text class="timestamp" x="24" y="688">Cost = 1 vCPU + 2 GB RAM per hour (normalized). Value Score = sqrt(benchmark score x cost efficiency).</text>
+  <text class="timestamp" x="24" y="702">Confidence: exact = official pricing page, estimated = back-calculated from bundled tier.</text>
+
+</svg>

--- a/src/generate-pricing-svg.ts
+++ b/src/generate-pricing-svg.ts
@@ -1,0 +1,313 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const PRICING_PATH = path.join(ROOT, 'pricing.json');
+const SPONSORS_DIR = path.join(ROOT, 'sponsors');
+
+// ComputeSDK logo - the "C" path (same as generate-svg.ts)
+const LOGO_C_PATH = `M1036.26,1002.28h237.87l-.93,19.09c-8.38,110.32-49.81,198.3-123.82,262.07-73.09,63.31-170.84,95.43-290.48,95.43-130.81,0-235.55-44.69-311.43-133.6-74.48-87.98-112.65-209.48-112.65-361.23v-60.51c0-96.83,17.7-183.41,51.68-257.43,34.91-74.95,85.19-133.61,149.89-173.63,64.7-40.04,140.12-60.52,225.3-60.52,117.77,0,214.13,32.12,286.29,95.9,72.62,63.3,114.98,153.61,126.15,267.67l1.86,19.08h-238.34l-.93-15.83c-4.65-59.11-20.95-101.94-47.95-127.08-27-25.6-69.83-38.17-127.08-38.17-61.91,0-107.06,20.95-137.33,65.17-31.65,45.15-47.94,117.77-48.87,215.53v74.48c0,102.41,15.36,177.83,45.62,223.91,28.86,44.22,74.01,65.63,137.79,65.63,58.19,0,101.48-12.57,128.95-38.17,26.99-25.14,43.29-66.1,47.48-121.5l.93-16.3Z`;
+
+interface PricingProvider {
+  id: string;
+  benchmark: {
+    score: number | null;
+    success_rate: string;
+    status: string;
+    cold_start_ms: number | null;
+  };
+  pricing: {
+    model: string;
+    normalized: {
+      total_1vcpu_2gb_hr: number;
+      confidence: string;
+      notes?: string;
+    };
+  };
+  free_credits: number | null;
+  isolation: string;
+}
+
+interface PricingData {
+  meta: {
+    version: string;
+    last_updated: string;
+    normalization_basis: string;
+  };
+  providers: PricingProvider[];
+}
+
+/**
+ * Load sponsor logo from the sponsors/ directory.
+ */
+function loadSponsorImage(): { dataUri: string; name: string } | null {
+  if (!fs.existsSync(SPONSORS_DIR)) return null;
+
+  const files = fs.readdirSync(SPONSORS_DIR)
+    .filter(f => /\.(png|jpe?g|svg)$/i.test(f))
+    .sort();
+
+  if (files.length === 0) return null;
+
+  const file = files[0];
+  const ext = path.extname(file).toLowerCase();
+  const mimeTypes: Record<string, string> = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.svg': 'image/svg+xml',
+  };
+  const mime = mimeTypes[ext] || 'image/png';
+  const raw = fs.readFileSync(path.join(SPONSORS_DIR, file));
+  const b64 = raw.toString('base64');
+  const name = path.basename(file, ext);
+
+  return { dataUri: `data:${mime};base64,${b64}`, name };
+}
+
+function formatProviderName(s: string): string {
+  if (s.toLowerCase() === 'e2b') return 'E2B';
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function formatCost(cost: number): string {
+  return `$${cost.toFixed(4)}`;
+}
+
+function formatBillingModel(model: string): string {
+  const labels: Record<string, string> = {
+    'per_second': 'Per-second',
+    'per_minute': 'Per-minute',
+    'active_cpu': 'Active CPU',
+    'active_cpu_per_10ms': 'Active CPU',
+    'per_hour_credits': 'Per-hour',
+  };
+  return labels[model] || model;
+}
+
+/**
+ * Compute a value score that combines cost efficiency and benchmark performance.
+ *
+ * Value score = benchmarkScore * costEfficiency
+ *
+ * Cost efficiency is scored on a 0-100 scale where:
+ *   - $0.00/hr = 100 (free)
+ *   - $0.20/hr = 0 (ceiling)
+ *
+ * The two are multiplied and normalized to 0-100.
+ */
+function computeValueScore(benchmarkScore: number | null, costPerHr: number): number | null {
+  if (benchmarkScore === null || benchmarkScore === 0) return null;
+
+  const COST_CEILING = 0.20; // $/hr — anything at or above this scores 0 for cost
+  const costScore = Math.max(0, 100 * (1 - costPerHr / COST_CEILING));
+
+  // Geometric mean gives balanced weight to both dimensions
+  return Math.round(Math.sqrt(benchmarkScore * costScore) * 10) / 10;
+}
+
+/**
+ * Get color class for cost — lower is better (green).
+ */
+function costColorClass(cost: number): string {
+  if (cost <= 0.09) return 'fast';    // green — cheap
+  if (cost <= 0.12) return 'medium';  // yellow — moderate
+  return 'slow';                       // red — expensive
+}
+
+/**
+ * Get color class for value score — higher is better.
+ */
+function valueColorClass(score: number | null): string {
+  if (score === null) return 'status';
+  if (score >= 60) return 'fast';
+  if (score >= 40) return 'medium';
+  return 'slow';
+}
+
+function generatePricingSVG(data: PricingData): string {
+  const sponsorImage = loadSponsorImage();
+
+  // Sort providers by value score (highest first), null scores last
+  const providers = data.providers.map(p => ({
+    ...p,
+    valueScore: computeValueScore(
+      p.benchmark.score,
+      p.pricing.normalized.total_1vcpu_2gb_hr
+    ),
+  }));
+
+  providers.sort((a, b) => {
+    if (a.valueScore === null && b.valueScore === null) return 0;
+    if (a.valueScore === null) return 1;
+    if (b.valueScore === null) return -1;
+    return b.valueScore - a.valueScore;
+  });
+
+  const rowHeight = 44;
+  const headerHeight = 110;
+  const tableHeaderHeight = 44;
+  const padding = 24;
+  const width = 1200;
+  const tableTop = headerHeight + padding;
+  const tableBottom = tableTop + tableHeaderHeight + (providers.length * rowHeight);
+  const footnoteHeight = 40;
+  const height = tableBottom + padding + 30 + footnoteHeight;
+
+  // Column positions
+  const cols = {
+    rank: 40,
+    provider: 80,
+    cost: 260,
+    benchmark: 460,
+    billing: 660,
+    value: 860,
+    confidence: 1020,
+  };
+
+  const title = 'Pricing Comparison';
+  const subtitle = `Normalized to ${data.meta.normalization_basis} — sorted by value score`;
+
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <defs>
+    <linearGradient id="headerGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f6f8fa;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <style>
+    .bg { fill: #ffffff; }
+    .header-bg { fill: url(#headerGrad); }
+    .table-header-bg { fill: #f6f8fa; }
+    .table-header { font: 600 12px 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; fill: #57606a; text-transform: uppercase; letter-spacing: 0.5px; }
+    .row { font: 14px 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; fill: #24292f; }
+    .rank { font-weight: 700; fill: #57606a; }
+    .rank-1 { fill: #d4a000; }
+    .rank-2 { fill: #8a8a8a; }
+    .rank-3 { fill: #a0522d; }
+    .provider { font-weight: 600; fill: #0969da; }
+    .cost { font-weight: 700; font-size: 15px; }
+    .value { font-weight: 700; font-size: 15px; }
+    .fast { fill: #1a7f37; }
+    .medium { fill: #9a6700; }
+    .slow { fill: #cf222e; }
+    .status { fill: #57606a; }
+    .divider { stroke: #d0d7de; stroke-width: 1; }
+    .border { stroke: #d0d7de; stroke-width: 1; fill: none; }
+    .timestamp { font: 11px 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; fill: #57606a; }
+    .title { font: bold 28px 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; fill: #24292f; }
+    .subtitle { font: 14px 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; fill: #57606a; }
+    .logo { fill: #24292f; }
+    .confidence-exact { fill: #1a7f37; }
+    .confidence-estimated { fill: #9a6700; }
+    .confidence-unknown { fill: #cf222e; }
+  </style>
+
+  <!-- Background -->
+  <rect class="bg" width="${width}" height="${height}"/>
+
+  <!-- Logo (black square with white C) -->
+  <g transform="translate(${padding}, 24)">
+    <rect width="60" height="60" fill="#000000"/>
+    <g transform="scale(0.035) translate(0, 0)">
+      <path fill="#ffffff" d="${LOGO_C_PATH}"/>
+    </g>
+  </g>
+
+  <!-- Title -->
+  <text class="title" x="${padding + 76}" y="55">${title}</text>
+  <text class="subtitle" x="${padding + 76}" y="78">${subtitle}</text>
+${sponsorImage ? `
+  <!-- Sponsor -->
+  <text font-size="11" font-family="Inter, SF Pro Display, sans-serif" fill="#8c959f" x="1100" y="32" text-anchor="middle" letter-spacing="1">SPONSORED BY</text>
+  <image href="${sponsorImage.dataUri}" x="1074" y="42" width="52" height="52" preserveAspectRatio="xMidYMid meet"/>
+` : ''}
+  <!-- Table header background -->
+  <rect class="table-header-bg" y="${tableTop}" width="${width}" height="${tableHeaderHeight}"/>
+
+  <!-- Table header text -->
+  <text class="table-header" x="${cols.rank}" y="${tableTop + 28}">#</text>
+  <text class="table-header" x="${cols.provider}" y="${tableTop + 28}">Provider</text>
+  <text class="table-header" x="${cols.cost}" y="${tableTop + 28}">Cost / hr</text>
+  <text class="table-header" x="${cols.benchmark}" y="${tableTop + 28}">Benchmark</text>
+  <text class="table-header" x="${cols.billing}" y="${tableTop + 28}">Billing</text>
+  <text class="table-header" x="${cols.value}" y="${tableTop + 28}">Value Score</text>
+  <text class="table-header" x="${cols.confidence}" y="${tableTop + 28}">Confidence</text>
+`;
+
+  providers.forEach((p, i) => {
+    const y = tableTop + tableHeaderHeight + (i * rowHeight) + 30;
+    const rank = i + 1;
+
+    const cost = p.pricing.normalized.total_1vcpu_2gb_hr;
+    const benchScore = p.benchmark.score !== null ? p.benchmark.score.toFixed(1) : '--';
+    const valueScore = p.valueScore !== null ? p.valueScore.toFixed(1) : '--';
+    const billing = formatBillingModel(p.pricing.model);
+    const confidence = p.pricing.normalized.confidence;
+
+    // Rank styling
+    let rankClass = 'rank';
+    if (rank === 1) rankClass = 'rank rank-1';
+    else if (rank === 2) rankClass = 'rank rank-2';
+    else if (rank === 3) rankClass = 'rank rank-3';
+
+    // Confidence styling
+    let confidenceClass = 'status';
+    if (confidence === 'exact') confidenceClass = 'confidence-exact';
+    else if (confidence === 'estimated') confidenceClass = 'confidence-estimated';
+
+    svg += `
+  <!-- Row ${rank}: ${p.id} -->
+  <text class="${rankClass}" x="${cols.rank}" y="${y}">${rank}</text>
+  <text class="row provider" x="${cols.provider}" y="${y}">${formatProviderName(p.id)}</text>
+  <text class="row cost ${costColorClass(cost)}" x="${cols.cost}" y="${y}">${formatCost(cost)}</text>
+  <text class="row" x="${cols.benchmark}" y="${y}">${benchScore} (${p.benchmark.success_rate})</text>
+  <text class="row" x="${cols.billing}" y="${y}">${billing}</text>
+  <text class="row value ${valueColorClass(p.valueScore)}" x="${cols.value}" y="${y}">${valueScore}</text>
+  <text class="row ${confidenceClass}" x="${cols.confidence}" y="${y}">${confidence}</text>
+`;
+
+    if (i < providers.length - 1) {
+      const lineY = tableTop + tableHeaderHeight + ((i + 1) * rowHeight);
+      svg += `  <line class="divider" x1="${padding}" y1="${lineY}" x2="${width - padding}" y2="${lineY}"/>
+`;
+    }
+  });
+
+  const date = new Date(data.meta.last_updated).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  svg += `
+  <!-- Timestamp -->
+  <text class="timestamp" x="${width - padding}" y="${height - 38}" text-anchor="end">Last updated: ${date}</text>
+
+  <!-- Footnotes -->
+  <text class="timestamp" x="${padding}" y="${height - 24}">Cost = 1 vCPU + 2 GB RAM per hour (normalized). Value Score = sqrt(benchmark score x cost efficiency).</text>
+  <text class="timestamp" x="${padding}" y="${height - 10}">Confidence: exact = official pricing page, estimated = back-calculated from bundled tier.</text>
+
+</svg>`;
+
+  return svg;
+}
+
+function main() {
+  if (!fs.existsSync(PRICING_PATH)) {
+    console.error(`pricing.json not found at ${PRICING_PATH}`);
+    process.exit(1);
+  }
+
+  const raw = fs.readFileSync(PRICING_PATH, 'utf-8');
+  const data: PricingData = JSON.parse(raw);
+
+  const svg = generatePricingSVG(data);
+  const outputPath = path.join(ROOT, 'pricing.svg');
+  fs.writeFileSync(outputPath, svg);
+  console.log(`Pricing SVG written to ${outputPath}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds a **pricing comparison SVG table** alongside the existing benchmark TTI tables
- Normalized cost data for 10 providers at **1 vCPU + 2 GB RAM / hour**
- Introduces a **Value Score** combining benchmark performance with cost efficiency

## What's included

| File | Purpose |
|------|---------|
| `pricing.json` | Source of truth — per-provider rates, billing models, confidence levels |
| `src/generate-pricing-svg.ts` | SVG generator matching existing table style |
| `pricing.svg` | Generated output (auto-committed, not hand-edited) |
| `.github/workflows/pricing-svg.yml` | Regenerates SVG when `pricing.json` changes on main |

## Table columns

**Provider** · **Cost/hr** (normalized) · **Benchmark Score** (from sequential TTI) · **Billing Model** · **Value Score** · **Confidence**

## Value Score

```
valueScore = sqrt(benchmarkScore × costEfficiency)
costEfficiency = 100 × (1 − costPerHr / $0.20)
```

Geometric mean ensures a provider must be both cheap *and* fast to rank well.

## Pricing data confidence

- **exact** — sourced directly from official pricing page
- **estimated** — back-calculated from bundled tier pricing
- **unknown** — not published

## Regeneration

The pricing SVG auto-regenerates via GitHub Actions when `pricing.json` is pushed to main. Manual dispatch also available. Runs on `ubuntu-latest` (no secrets needed, no benchmark infra required).

Checks off the **Cost-per-sandbox-minute** roadmap item.