### PR TITLE
Add Est. 25% CPU column for utilization-based providers

### DIFF
--- a/pricing.svg
+++ b/pricing.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="712" viewBox="0 0 1200 712">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="726" viewBox="0 0 1200 726">
   <defs>
     <linearGradient id="headerGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#f6f8fa;stop-opacity:1" />
@@ -34,7 +34,7 @@
   </style>
 
   <!-- Background -->
-  <rect class="bg" width="1200" height="712"/>
+  <rect class="bg" width="1200" height="726"/>
 
   <!-- Logo (black square with white C) -->
   <g transform="translate(24, 24)">
@@ -58,116 +58,128 @@
   <!-- Table header text -->
   <text class="table-header" x="40" y="162">#</text>
   <text class="table-header" x="80" y="162">Provider</text>
-  <text class="table-header" x="260" y="162">Cost / hr</text>
-  <text class="table-header" x="460" y="162">Benchmark</text>
-  <text class="table-header" x="660" y="162">Billing</text>
-  <text class="table-header" x="860" y="162">Value Score</text>
-  <text class="table-header" x="1020" y="162">Confidence</text>
+  <text class="table-header" x="230" y="162">Cost / hr</text>
+  <text class="table-header" x="370" y="162">Est. 25% CPU</text>
+  <text class="table-header" x="510" y="162">Benchmark</text>
+  <text class="table-header" x="680" y="162">Billing</text>
+  <text class="table-header" x="840" y="162">Value Score</text>
+  <text class="table-header" x="1000" y="162">Confidence</text>
 
   <!-- Row 1: daytona -->
   <text class="rank rank-1" x="40" y="208">1</text>
   <text class="row provider" x="80" y="208">Daytona</text>
-  <text class="row cost fast" x="260" y="208">$0.0828</text>
-  <text class="row" x="460" y="208">97.1 (100/100)</text>
-  <text class="row" x="660" y="208">Per-second</text>
-  <text class="row value fast" x="860" y="208">75.4</text>
-  <text class="row confidence-exact" x="1020" y="208">exact</text>
+  <text class="row cost fast" x="230" y="208">$0.0828</text>
+  <text class="row cost status" x="370" y="208">--</text>
+  <text class="row" x="510" y="208">97.1 (100/100)</text>
+  <text class="row" x="680" y="208">Per-second</text>
+  <text class="row value fast" x="840" y="208">75.4</text>
+  <text class="row confidence-exact" x="1000" y="208">exact</text>
   <line class="divider" x1="24" y1="222" x2="1176" y2="222"/>
 
   <!-- Row 2: e2b -->
   <text class="rank rank-2" x="40" y="252">2</text>
   <text class="row provider" x="80" y="252">E2B</text>
-  <text class="row cost fast" x="260" y="252">$0.0828</text>
-  <text class="row" x="460" y="252">95.4 (100/100)</text>
-  <text class="row" x="660" y="252">Per-second</text>
-  <text class="row value fast" x="860" y="252">74.8</text>
-  <text class="row confidence-exact" x="1020" y="252">exact</text>
+  <text class="row cost fast" x="230" y="252">$0.0828</text>
+  <text class="row cost status" x="370" y="252">--</text>
+  <text class="row" x="510" y="252">95.4 (100/100)</text>
+  <text class="row" x="680" y="252">Per-second</text>
+  <text class="row value fast" x="840" y="252">74.8</text>
+  <text class="row confidence-exact" x="1000" y="252">exact</text>
   <line class="divider" x1="24" y1="266" x2="1176" y2="266"/>
 
-  <!-- Row 3: hopx -->
+  <!-- Row 3: namespace -->
   <text class="rank rank-3" x="40" y="296">3</text>
-  <text class="row provider" x="80" y="296">Hopx</text>
-  <text class="row cost fast" x="260" y="296">$0.0828</text>
-  <text class="row" x="460" y="296">88.5 (100/100)</text>
-  <text class="row" x="660" y="296">Per-second</text>
-  <text class="row value fast" x="860" y="296">72.0</text>
-  <text class="row confidence-exact" x="1020" y="296">exact</text>
+  <text class="row provider" x="80" y="296">Namespace</text>
+  <text class="row cost fast" x="230" y="296">$0.0600</text>
+  <text class="row cost status" x="370" y="296">--</text>
+  <text class="row" x="510" y="296">79.1 (100/100)</text>
+  <text class="row" x="680" y="296">Per-minute</text>
+  <text class="row value fast" x="840" y="296">74.4</text>
+  <text class="row confidence-exact" x="1000" y="296">exact</text>
   <line class="divider" x1="24" y1="310" x2="1176" y2="310"/>
 
-  <!-- Row 4: blaxel -->
+  <!-- Row 4: hopx -->
   <text class="rank" x="40" y="340">4</text>
-  <text class="row provider" x="80" y="340">Blaxel</text>
-  <text class="row cost fast" x="260" y="340">$0.0828</text>
-  <text class="row" x="460" y="340">88.1 (100/100)</text>
-  <text class="row" x="660" y="340">Per-second</text>
-  <text class="row value fast" x="860" y="340">71.8</text>
-  <text class="row confidence-exact" x="1020" y="340">exact</text>
+  <text class="row provider" x="80" y="340">Hopx</text>
+  <text class="row cost fast" x="230" y="340">$0.0828</text>
+  <text class="row cost status" x="370" y="340">--</text>
+  <text class="row" x="510" y="340">88.5 (100/100)</text>
+  <text class="row" x="680" y="340">Per-second</text>
+  <text class="row value fast" x="840" y="340">72.0</text>
+  <text class="row confidence-exact" x="1000" y="340">exact</text>
   <line class="divider" x1="24" y1="354" x2="1176" y2="354"/>
 
-  <!-- Row 5: namespace -->
+  <!-- Row 5: blaxel -->
   <text class="rank" x="40" y="384">5</text>
-  <text class="row provider" x="80" y="384">Namespace</text>
-  <text class="row cost fast" x="260" y="384">$0.0900</text>
-  <text class="row" x="460" y="384">79.1 (100/100)</text>
-  <text class="row" x="660" y="384">Per-minute</text>
-  <text class="row value fast" x="860" y="384">65.9</text>
-  <text class="row confidence-exact" x="1020" y="384">exact</text>
+  <text class="row provider" x="80" y="384">Blaxel</text>
+  <text class="row cost fast" x="230" y="384">$0.0828</text>
+  <text class="row cost status" x="370" y="384">--</text>
+  <text class="row" x="510" y="384">88.1 (100/100)</text>
+  <text class="row" x="680" y="384">Per-second</text>
+  <text class="row value fast" x="840" y="384">71.8</text>
+  <text class="row confidence-exact" x="1000" y="384">exact</text>
   <line class="divider" x1="24" y1="398" x2="1176" y2="398"/>
 
   <!-- Row 6: cloudflare -->
   <text class="rank" x="40" y="428">6</text>
   <text class="row provider" x="80" y="428">Cloudflare</text>
-  <text class="row cost fast" x="260" y="428">$0.0900</text>
-  <text class="row" x="460" y="428">77.2 (100/100)</text>
-  <text class="row" x="660" y="428">Active CPU</text>
-  <text class="row value fast" x="860" y="428">65.1</text>
-  <text class="row confidence-exact" x="1020" y="428">exact</text>
+  <text class="row cost fast" x="230" y="428">$0.0900</text>
+  <text class="row cost fast" x="370" y="428">$0.0360</text>
+  <text class="row" x="510" y="428">77.2 (100/100)</text>
+  <text class="row" x="680" y="428">Active CPU</text>
+  <text class="row value fast" x="840" y="428">65.1</text>
+  <text class="row confidence-exact" x="1000" y="428">exact</text>
   <line class="divider" x1="24" y1="442" x2="1176" y2="442"/>
 
   <!-- Row 7: modal -->
   <text class="rank" x="40" y="472">7</text>
   <text class="row provider" x="80" y="472">Modal</text>
-  <text class="row cost medium" x="260" y="472">$0.1191</text>
-  <text class="row" x="460" y="472">58.8 (99/100)</text>
-  <text class="row" x="660" y="472">Per-second</text>
-  <text class="row value medium" x="860" y="472">48.7</text>
-  <text class="row confidence-exact" x="1020" y="472">exact</text>
+  <text class="row cost medium" x="230" y="472">$0.1191</text>
+  <text class="row cost status" x="370" y="472">--</text>
+  <text class="row" x="510" y="472">58.8 (99/100)</text>
+  <text class="row" x="680" y="472">Per-second</text>
+  <text class="row value medium" x="840" y="472">48.7</text>
+  <text class="row confidence-exact" x="1000" y="472">exact</text>
   <line class="divider" x1="24" y1="486" x2="1176" y2="486"/>
 
   <!-- Row 8: vercel -->
   <text class="rank" x="40" y="516">8</text>
   <text class="row provider" x="80" y="516">Vercel</text>
-  <text class="row cost slow" x="260" y="516">$0.1492</text>
-  <text class="row" x="460" y="516">79.5 (98/100)</text>
-  <text class="row" x="660" y="516">Active CPU</text>
-  <text class="row value medium" x="860" y="516">44.9</text>
-  <text class="row confidence-exact" x="1020" y="516">exact</text>
+  <text class="row cost slow" x="230" y="516">$0.1492</text>
+  <text class="row cost fast" x="370" y="516">$0.0532</text>
+  <text class="row" x="510" y="516">79.5 (98/100)</text>
+  <text class="row" x="680" y="516">Active CPU</text>
+  <text class="row value medium" x="840" y="516">44.9</text>
+  <text class="row confidence-exact" x="1000" y="516">exact</text>
   <line class="divider" x1="24" y1="530" x2="1176" y2="530"/>
 
   <!-- Row 9: codesandbox -->
   <text class="rank" x="40" y="560">9</text>
   <text class="row provider" x="80" y="560">Codesandbox</text>
-  <text class="row cost slow" x="260" y="560">$0.1486</text>
-  <text class="row" x="460" y="560">74.8 (100/100)</text>
-  <text class="row" x="660" y="560">Per-hour</text>
-  <text class="row value medium" x="860" y="560">43.8</text>
-  <text class="row confidence-estimated" x="1020" y="560">estimated</text>
+  <text class="row cost slow" x="230" y="560">$0.1486</text>
+  <text class="row cost status" x="370" y="560">--</text>
+  <text class="row" x="510" y="560">74.8 (100/100)</text>
+  <text class="row" x="680" y="560">Per-hour</text>
+  <text class="row value medium" x="840" y="560">43.8</text>
+  <text class="row confidence-estimated" x="1000" y="560">estimated</text>
   <line class="divider" x1="24" y1="574" x2="1176" y2="574"/>
 
   <!-- Row 10: runloop -->
   <text class="rank" x="40" y="604">10</text>
   <text class="row provider" x="80" y="604">Runloop</text>
-  <text class="row cost slow" x="260" y="604">$0.1584</text>
-  <text class="row" x="460" y="604">84.6 (100/100)</text>
-  <text class="row" x="660" y="604">Per-second</text>
-  <text class="row value medium" x="860" y="604">41.9</text>
-  <text class="row confidence-exact" x="1020" y="604">exact</text>
+  <text class="row cost slow" x="230" y="604">$0.1584</text>
+  <text class="row cost status" x="370" y="604">--</text>
+  <text class="row" x="510" y="604">84.6 (100/100)</text>
+  <text class="row" x="680" y="604">Per-second</text>
+  <text class="row value medium" x="840" y="604">41.9</text>
+  <text class="row confidence-exact" x="1000" y="604">exact</text>
 
   <!-- Timestamp -->
-  <text class="timestamp" x="1176" y="674" text-anchor="end">Last updated: Mar 16, 2026</text>
+  <text class="timestamp" x="1176" y="688" text-anchor="end">Last updated: Mar 15, 2026</text>
 
   <!-- Footnotes -->
   <text class="timestamp" x="24" y="688">Cost = 1 vCPU + 2 GB RAM per hour (normalized). Value Score = sqrt(benchmark score x cost efficiency).</text>
-  <text class="timestamp" x="24" y="702">Confidence: exact = official pricing page, estimated = back-calculated from bundled tier.</text>
+  <text class="timestamp" x="24" y="702">Est. 25% CPU = estimated cost at 25% CPU utilization. Applies to active-CPU billing only (Vercel, Cloudflare). Memory is always wall-clock.</text>
+  <text class="timestamp" x="24" y="716">Confidence: exact = official pricing page, estimated = back-calculated from bundled tier.</text>
 
 </svg>

--- a/pricing.svg
+++ b/pricing.svg
@@ -58,108 +58,98 @@
   <!-- Table header text -->
   <text class="table-header" x="40" y="162">#</text>
   <text class="table-header" x="80" y="162">Provider</text>
-  <text class="table-header" x="230" y="162">Cost / hr</text>
-  <text class="table-header" x="370" y="162">Est. 25% CPU</text>
-  <text class="table-header" x="510" y="162">Benchmark</text>
-  <text class="table-header" x="680" y="162">Billing</text>
+  <text class="table-header" x="260" y="162">Eff. Cost / hr</text>
+  <text class="table-header" x="460" y="162">Benchmark</text>
+  <text class="table-header" x="660" y="162">Billing</text>
   <text class="table-header" x="840" y="162">Value Score</text>
   <text class="table-header" x="1000" y="162">Confidence</text>
 
-  <!-- Row 1: daytona -->
+  <!-- Row 1: cloudflare -->
   <text class="rank rank-1" x="40" y="208">1</text>
-  <text class="row provider" x="80" y="208">Daytona</text>
-  <text class="row cost fast" x="230" y="208">$0.0828</text>
-  <text class="row cost status" x="370" y="208">--</text>
-  <text class="row" x="510" y="208">97.1 (100/100)</text>
-  <text class="row" x="680" y="208">Per-second</text>
-  <text class="row value fast" x="840" y="208">75.4</text>
+  <text class="row provider" x="80" y="208">Cloudflare</text>
+  <text class="row cost fast" x="260" y="208">~$0.0360</text>
+  <text class="row" x="460" y="208">77.2 (100/100)</text>
+  <text class="row" x="660" y="208">Active CPU</text>
+  <text class="row value fast" x="840" y="208">79.5</text>
   <text class="row confidence-exact" x="1000" y="208">exact</text>
   <line class="divider" x1="24" y1="222" x2="1176" y2="222"/>
 
-  <!-- Row 2: e2b -->
+  <!-- Row 2: vercel -->
   <text class="rank rank-2" x="40" y="252">2</text>
-  <text class="row provider" x="80" y="252">E2B</text>
-  <text class="row cost fast" x="230" y="252">$0.0828</text>
-  <text class="row cost status" x="370" y="252">--</text>
-  <text class="row" x="510" y="252">95.4 (100/100)</text>
-  <text class="row" x="680" y="252">Per-second</text>
-  <text class="row value fast" x="840" y="252">74.8</text>
+  <text class="row provider" x="80" y="252">Vercel</text>
+  <text class="row cost fast" x="260" y="252">~$0.0532</text>
+  <text class="row" x="460" y="252">79.5 (98/100)</text>
+  <text class="row" x="660" y="252">Active CPU</text>
+  <text class="row value fast" x="840" y="252">76.4</text>
   <text class="row confidence-exact" x="1000" y="252">exact</text>
   <line class="divider" x1="24" y1="266" x2="1176" y2="266"/>
 
-  <!-- Row 3: namespace -->
+  <!-- Row 3: daytona -->
   <text class="rank rank-3" x="40" y="296">3</text>
-  <text class="row provider" x="80" y="296">Namespace</text>
-  <text class="row cost fast" x="230" y="296">$0.0600</text>
-  <text class="row cost status" x="370" y="296">--</text>
-  <text class="row" x="510" y="296">79.1 (100/100)</text>
-  <text class="row" x="680" y="296">Per-minute</text>
-  <text class="row value fast" x="840" y="296">74.4</text>
+  <text class="row provider" x="80" y="296">Daytona</text>
+  <text class="row cost fast" x="260" y="296">$0.0828</text>
+  <text class="row" x="460" y="296">97.1 (100/100)</text>
+  <text class="row" x="660" y="296">Per-second</text>
+  <text class="row value fast" x="840" y="296">75.4</text>
   <text class="row confidence-exact" x="1000" y="296">exact</text>
   <line class="divider" x1="24" y1="310" x2="1176" y2="310"/>
 
-  <!-- Row 4: hopx -->
+  <!-- Row 4: e2b -->
   <text class="rank" x="40" y="340">4</text>
-  <text class="row provider" x="80" y="340">Hopx</text>
-  <text class="row cost fast" x="230" y="340">$0.0828</text>
-  <text class="row cost status" x="370" y="340">--</text>
-  <text class="row" x="510" y="340">88.5 (100/100)</text>
-  <text class="row" x="680" y="340">Per-second</text>
-  <text class="row value fast" x="840" y="340">72.0</text>
+  <text class="row provider" x="80" y="340">E2B</text>
+  <text class="row cost fast" x="260" y="340">$0.0828</text>
+  <text class="row" x="460" y="340">95.4 (100/100)</text>
+  <text class="row" x="660" y="340">Per-second</text>
+  <text class="row value fast" x="840" y="340">74.8</text>
   <text class="row confidence-exact" x="1000" y="340">exact</text>
   <line class="divider" x1="24" y1="354" x2="1176" y2="354"/>
 
-  <!-- Row 5: blaxel -->
+  <!-- Row 5: namespace -->
   <text class="rank" x="40" y="384">5</text>
-  <text class="row provider" x="80" y="384">Blaxel</text>
-  <text class="row cost fast" x="230" y="384">$0.0828</text>
-  <text class="row cost status" x="370" y="384">--</text>
-  <text class="row" x="510" y="384">88.1 (100/100)</text>
-  <text class="row" x="680" y="384">Per-second</text>
-  <text class="row value fast" x="840" y="384">71.8</text>
+  <text class="row provider" x="80" y="384">Namespace</text>
+  <text class="row cost fast" x="260" y="384">$0.0600</text>
+  <text class="row" x="460" y="384">79.1 (100/100)</text>
+  <text class="row" x="660" y="384">Per-minute</text>
+  <text class="row value fast" x="840" y="384">74.4</text>
   <text class="row confidence-exact" x="1000" y="384">exact</text>
   <line class="divider" x1="24" y1="398" x2="1176" y2="398"/>
 
-  <!-- Row 6: cloudflare -->
+  <!-- Row 6: hopx -->
   <text class="rank" x="40" y="428">6</text>
-  <text class="row provider" x="80" y="428">Cloudflare</text>
-  <text class="row cost fast" x="230" y="428">$0.0900</text>
-  <text class="row cost fast" x="370" y="428">$0.0360</text>
-  <text class="row" x="510" y="428">77.2 (100/100)</text>
-  <text class="row" x="680" y="428">Active CPU</text>
-  <text class="row value fast" x="840" y="428">65.1</text>
+  <text class="row provider" x="80" y="428">Hopx</text>
+  <text class="row cost fast" x="260" y="428">$0.0828</text>
+  <text class="row" x="460" y="428">88.5 (100/100)</text>
+  <text class="row" x="660" y="428">Per-second</text>
+  <text class="row value fast" x="840" y="428">72.0</text>
   <text class="row confidence-exact" x="1000" y="428">exact</text>
   <line class="divider" x1="24" y1="442" x2="1176" y2="442"/>
 
-  <!-- Row 7: modal -->
+  <!-- Row 7: blaxel -->
   <text class="rank" x="40" y="472">7</text>
-  <text class="row provider" x="80" y="472">Modal</text>
-  <text class="row cost medium" x="230" y="472">$0.1191</text>
-  <text class="row cost status" x="370" y="472">--</text>
-  <text class="row" x="510" y="472">58.8 (99/100)</text>
-  <text class="row" x="680" y="472">Per-second</text>
-  <text class="row value medium" x="840" y="472">48.7</text>
+  <text class="row provider" x="80" y="472">Blaxel</text>
+  <text class="row cost fast" x="260" y="472">$0.0828</text>
+  <text class="row" x="460" y="472">88.1 (100/100)</text>
+  <text class="row" x="660" y="472">Per-second</text>
+  <text class="row value fast" x="840" y="472">71.8</text>
   <text class="row confidence-exact" x="1000" y="472">exact</text>
   <line class="divider" x1="24" y1="486" x2="1176" y2="486"/>
 
-  <!-- Row 8: vercel -->
+  <!-- Row 8: modal -->
   <text class="rank" x="40" y="516">8</text>
-  <text class="row provider" x="80" y="516">Vercel</text>
-  <text class="row cost slow" x="230" y="516">$0.1492</text>
-  <text class="row cost fast" x="370" y="516">$0.0532</text>
-  <text class="row" x="510" y="516">79.5 (98/100)</text>
-  <text class="row" x="680" y="516">Active CPU</text>
-  <text class="row value medium" x="840" y="516">44.9</text>
+  <text class="row provider" x="80" y="516">Modal</text>
+  <text class="row cost medium" x="260" y="516">$0.1191</text>
+  <text class="row" x="460" y="516">58.8 (99/100)</text>
+  <text class="row" x="660" y="516">Per-second</text>
+  <text class="row value medium" x="840" y="516">48.7</text>
   <text class="row confidence-exact" x="1000" y="516">exact</text>
   <line class="divider" x1="24" y1="530" x2="1176" y2="530"/>
 
   <!-- Row 9: codesandbox -->
   <text class="rank" x="40" y="560">9</text>
   <text class="row provider" x="80" y="560">Codesandbox</text>
-  <text class="row cost slow" x="230" y="560">$0.1486</text>
-  <text class="row cost status" x="370" y="560">--</text>
-  <text class="row" x="510" y="560">74.8 (100/100)</text>
-  <text class="row" x="680" y="560">Per-hour</text>
+  <text class="row cost slow" x="260" y="560">$0.1486</text>
+  <text class="row" x="460" y="560">74.8 (100/100)</text>
+  <text class="row" x="660" y="560">Per-hour</text>
   <text class="row value medium" x="840" y="560">43.8</text>
   <text class="row confidence-estimated" x="1000" y="560">estimated</text>
   <line class="divider" x1="24" y1="574" x2="1176" y2="574"/>
@@ -167,10 +157,9 @@
   <!-- Row 10: runloop -->
   <text class="rank" x="40" y="604">10</text>
   <text class="row provider" x="80" y="604">Runloop</text>
-  <text class="row cost slow" x="230" y="604">$0.1584</text>
-  <text class="row cost status" x="370" y="604">--</text>
-  <text class="row" x="510" y="604">84.6 (100/100)</text>
-  <text class="row" x="680" y="604">Per-second</text>
+  <text class="row cost slow" x="260" y="604">$0.1584</text>
+  <text class="row" x="460" y="604">84.6 (100/100)</text>
+  <text class="row" x="660" y="604">Per-second</text>
   <text class="row value medium" x="840" y="604">41.9</text>
   <text class="row confidence-exact" x="1000" y="604">exact</text>
 
@@ -178,8 +167,8 @@
   <text class="timestamp" x="1176" y="688" text-anchor="end">Last updated: Mar 15, 2026</text>
 
   <!-- Footnotes -->
-  <text class="timestamp" x="24" y="688">Cost = 1 vCPU + 2 GB RAM per hour (normalized). Value Score = sqrt(benchmark score x cost efficiency).</text>
-  <text class="timestamp" x="24" y="702">Est. 25% CPU = estimated cost at 25% CPU utilization. Applies to active-CPU billing only (Vercel, Cloudflare). Memory is always wall-clock.</text>
+  <text class="timestamp" x="24" y="688">Eff. Cost = effective cost for 1 vCPU + 2 GB RAM / hr. Active-CPU providers (~) estimated at 25% utilization. Value Score = sqrt(benchmark x cost efficiency).</text>
+  <text class="timestamp" x="24" y="702">Active-CPU billing (Vercel, Cloudflare): CPU charged only during execution, memory always wall-clock. Wall-clock providers: full rate shown.</text>
   <text class="timestamp" x="24" y="716">Confidence: exact = official pricing page, estimated = back-calculated from bundled tier.</text>
 
 </svg>

--- a/src/generate-pricing-svg.ts
+++ b/src/generate-pricing-svg.ts
@@ -13,6 +13,12 @@ const SPONSORS_DIR = path.join(ROOT, 'sponsors');
 // ComputeSDK logo - the "C" path (same as generate-svg.ts)
 const LOGO_C_PATH = `M1036.26,1002.28h237.87l-.93,19.09c-8.38,110.32-49.81,198.3-123.82,262.07-73.09,63.31-170.84,95.43-290.48,95.43-130.81,0-235.55-44.69-311.43-133.6-74.48-87.98-112.65-209.48-112.65-361.23v-60.51c0-96.83,17.7-183.41,51.68-257.43,34.91-74.95,85.19-133.61,149.89-173.63,64.7-40.04,140.12-60.52,225.3-60.52,117.77,0,214.13,32.12,286.29,95.9,72.62,63.3,114.98,153.61,126.15,267.67l1.86,19.08h-238.34l-.93-15.83c-4.65-59.11-20.95-101.94-47.95-127.08-27-25.6-69.83-38.17-127.08-38.17-61.91,0-107.06,20.95-137.33,65.17-31.65,45.15-47.94,117.77-48.87,215.53v74.48c0,102.41,15.36,177.83,45.62,223.91,28.86,44.22,74.01,65.63,137.79,65.63,58.19,0,101.48-12.57,128.95-38.17,26.99-25.14,43.29-66.1,47.48-121.5l.93-16.3Z`;
 
+/** Active-CPU billing models where CPU is only charged during utilization */
+const ACTIVE_CPU_MODELS = ['active_cpu', 'active_cpu_per_10ms'];
+
+/** Default assumed CPU utilization for I/O-bound workloads */
+const ESTIMATED_CPU_UTILIZATION = 0.25;
+
 interface PricingProvider {
   id: string;
   benchmark: {
@@ -24,6 +30,8 @@ interface PricingProvider {
   pricing: {
     model: string;
     normalized: {
+      cpu_per_vcpu_hr: number;
+      memory_per_gib_hr: number;
       total_1vcpu_2gb_hr: number;
       confidence: string;
       notes?: string;
@@ -31,6 +39,21 @@ interface PricingProvider {
   };
   free_credits: number | null;
   isolation: string;
+}
+
+/**
+ * Compute the estimated cost at 25% CPU utilization for active-CPU providers.
+ * For wall-clock providers, returns null (not applicable).
+ *
+ * Formula: (cpu_rate * utilization) + (memory_rate * 2 GB)
+ * Memory is always wall-clock even for active-CPU providers.
+ */
+function computeEstimatedCost(provider: PricingProvider): number | null {
+  if (!ACTIVE_CPU_MODELS.includes(provider.pricing.model)) return null;
+
+  const cpuCost = provider.pricing.normalized.cpu_per_vcpu_hr * ESTIMATED_CPU_UTILIZATION;
+  const memCost = provider.pricing.normalized.memory_per_gib_hr * 2; // 2 GB
+  return cpuCost + memCost;
 }
 
 interface PricingData {
@@ -193,18 +216,19 @@ function generatePricingSVG(data: PricingData): string {
   const width = 1200;
   const tableTop = headerHeight + padding;
   const tableBottom = tableTop + tableHeaderHeight + (providers.length * rowHeight);
-  const footnoteHeight = 40;
+  const footnoteHeight = 54;
   const height = tableBottom + padding + 30 + footnoteHeight;
 
   // Column positions
   const cols = {
     rank: 40,
     provider: 80,
-    cost: 260,
-    benchmark: 460,
-    billing: 660,
-    value: 860,
-    confidence: 1020,
+    cost: 230,
+    estCost: 370,
+    benchmark: 510,
+    billing: 680,
+    value: 840,
+    confidence: 1000,
   };
 
   const title = 'Pricing Comparison';
@@ -271,6 +295,7 @@ ${sponsorImage ? `
   <text class="table-header" x="${cols.rank}" y="${tableTop + 28}">#</text>
   <text class="table-header" x="${cols.provider}" y="${tableTop + 28}">Provider</text>
   <text class="table-header" x="${cols.cost}" y="${tableTop + 28}">Cost / hr</text>
+  <text class="table-header" x="${cols.estCost}" y="${tableTop + 28}">Est. 25% CPU</text>
   <text class="table-header" x="${cols.benchmark}" y="${tableTop + 28}">Benchmark</text>
   <text class="table-header" x="${cols.billing}" y="${tableTop + 28}">Billing</text>
   <text class="table-header" x="${cols.value}" y="${tableTop + 28}">Value Score</text>
@@ -282,6 +307,7 @@ ${sponsorImage ? `
     const rank = i + 1;
 
     const cost = p.pricing.normalized.total_1vcpu_2gb_hr;
+    const estCost = computeEstimatedCost(p);
     const benchScore = p.benchmark.score !== null ? p.benchmark.score.toFixed(1) : '--';
     const valueScore = p.valueScore !== null ? p.valueScore.toFixed(1) : '--';
     const billing = formatBillingModel(p.pricing.model);
@@ -298,11 +324,16 @@ ${sponsorImage ? `
     if (confidence === 'exact') confidenceClass = 'confidence-exact';
     else if (confidence === 'estimated') confidenceClass = 'confidence-estimated';
 
+    // Estimated cost display
+    const estCostDisplay = estCost !== null ? formatCost(estCost) : '--';
+    const estCostClass = estCost !== null ? costColorClass(estCost) : 'status';
+
     svg += `
   <!-- Row ${rank}: ${p.id} -->
   <text class="${rankClass}" x="${cols.rank}" y="${y}">${rank}</text>
   <text class="row provider" x="${cols.provider}" y="${y}">${formatProviderName(p.id)}</text>
   <text class="row cost ${costColorClass(cost)}" x="${cols.cost}" y="${y}">${formatCost(cost)}</text>
+  <text class="row cost ${estCostClass}" x="${cols.estCost}" y="${y}">${estCostDisplay}</text>
   <text class="row" x="${cols.benchmark}" y="${y}">${benchScore} (${p.benchmark.success_rate})</text>
   <text class="row" x="${cols.billing}" y="${y}">${billing}</text>
   <text class="row value ${valueColorClass(p.valueScore)}" x="${cols.value}" y="${y}">${valueScore}</text>
@@ -327,7 +358,8 @@ ${sponsorImage ? `
   <text class="timestamp" x="${width - padding}" y="${height - 38}" text-anchor="end">Last updated: ${date}</text>
 
   <!-- Footnotes -->
-  <text class="timestamp" x="${padding}" y="${height - 24}">Cost = 1 vCPU + 2 GB RAM per hour (normalized). Value Score = sqrt(benchmark score x cost efficiency).</text>
+  <text class="timestamp" x="${padding}" y="${height - 38}">Cost = 1 vCPU + 2 GB RAM per hour (normalized). Value Score = sqrt(benchmark score x cost efficiency).</text>
+  <text class="timestamp" x="${padding}" y="${height - 24}">Est. 25% CPU = estimated cost at 25% CPU utilization. Applies to active-CPU billing only (Vercel, Cloudflare). Memory is always wall-clock.</text>
   <text class="timestamp" x="${padding}" y="${height - 10}">Confidence: exact = official pricing page, estimated = back-calculated from bundled tier.</text>
 
 </svg>`;

--- a/src/generate-pricing-svg.ts
+++ b/src/generate-pricing-svg.ts
@@ -56,6 +56,15 @@ function computeEstimatedCost(provider: PricingProvider): number | null {
   return cpuCost + memCost;
 }
 
+/**
+ * Get the effective cost for a provider.
+ * For active-CPU providers, uses estimated 25% CPU utilization.
+ * For wall-clock providers, uses the full normalized cost.
+ */
+function getEffectiveCost(provider: PricingProvider): number {
+  return computeEstimatedCost(provider) ?? provider.pricing.normalized.total_1vcpu_2gb_hr;
+}
+
 interface PricingData {
   meta: {
     version: string;
@@ -194,13 +203,15 @@ function generatePricingSVG(data: PricingData): string {
   const sponsorImage = loadSponsorImage();
 
   // Sort providers by value score (highest first), null scores last
-  const providers = data.providers.map(p => ({
-    ...p,
-    valueScore: computeValueScore(
-      p.benchmark.score,
-      p.pricing.normalized.total_1vcpu_2gb_hr
-    ),
-  }));
+  const providers = data.providers.map(p => {
+    const effCost = getEffectiveCost(p);
+    return {
+      ...p,
+      effectiveCost: effCost,
+      isActiveCpu: ACTIVE_CPU_MODELS.includes(p.pricing.model),
+      valueScore: computeValueScore(p.benchmark.score, effCost),
+    };
+  });
 
   providers.sort((a, b) => {
     if (a.valueScore === null && b.valueScore === null) return 0;
@@ -223,10 +234,9 @@ function generatePricingSVG(data: PricingData): string {
   const cols = {
     rank: 40,
     provider: 80,
-    cost: 230,
-    estCost: 370,
-    benchmark: 510,
-    billing: 680,
+    cost: 260,
+    benchmark: 460,
+    billing: 660,
     value: 840,
     confidence: 1000,
   };
@@ -294,8 +304,7 @@ ${sponsorImage ? `
   <!-- Table header text -->
   <text class="table-header" x="${cols.rank}" y="${tableTop + 28}">#</text>
   <text class="table-header" x="${cols.provider}" y="${tableTop + 28}">Provider</text>
-  <text class="table-header" x="${cols.cost}" y="${tableTop + 28}">Cost / hr</text>
-  <text class="table-header" x="${cols.estCost}" y="${tableTop + 28}">Est. 25% CPU</text>
+  <text class="table-header" x="${cols.cost}" y="${tableTop + 28}">Eff. Cost / hr</text>
   <text class="table-header" x="${cols.benchmark}" y="${tableTop + 28}">Benchmark</text>
   <text class="table-header" x="${cols.billing}" y="${tableTop + 28}">Billing</text>
   <text class="table-header" x="${cols.value}" y="${tableTop + 28}">Value Score</text>
@@ -306,12 +315,14 @@ ${sponsorImage ? `
     const y = tableTop + tableHeaderHeight + (i * rowHeight) + 30;
     const rank = i + 1;
 
-    const cost = p.pricing.normalized.total_1vcpu_2gb_hr;
-    const estCost = computeEstimatedCost(p);
+    const cost = p.effectiveCost;
     const benchScore = p.benchmark.score !== null ? p.benchmark.score.toFixed(1) : '--';
     const valueScore = p.valueScore !== null ? p.valueScore.toFixed(1) : '--';
     const billing = formatBillingModel(p.pricing.model);
     const confidence = p.pricing.normalized.confidence;
+
+    // Cost display: add ~ prefix for active-CPU estimated costs
+    const costDisplay = p.isActiveCpu ? `~${formatCost(cost)}` : formatCost(cost);
 
     // Rank styling
     let rankClass = 'rank';
@@ -324,16 +335,11 @@ ${sponsorImage ? `
     if (confidence === 'exact') confidenceClass = 'confidence-exact';
     else if (confidence === 'estimated') confidenceClass = 'confidence-estimated';
 
-    // Estimated cost display
-    const estCostDisplay = estCost !== null ? formatCost(estCost) : '--';
-    const estCostClass = estCost !== null ? costColorClass(estCost) : 'status';
-
     svg += `
   <!-- Row ${rank}: ${p.id} -->
   <text class="${rankClass}" x="${cols.rank}" y="${y}">${rank}</text>
   <text class="row provider" x="${cols.provider}" y="${y}">${formatProviderName(p.id)}</text>
-  <text class="row cost ${costColorClass(cost)}" x="${cols.cost}" y="${y}">${formatCost(cost)}</text>
-  <text class="row cost ${estCostClass}" x="${cols.estCost}" y="${y}">${estCostDisplay}</text>
+  <text class="row cost ${costColorClass(cost)}" x="${cols.cost}" y="${y}">${costDisplay}</text>
   <text class="row" x="${cols.benchmark}" y="${y}">${benchScore} (${p.benchmark.success_rate})</text>
   <text class="row" x="${cols.billing}" y="${y}">${billing}</text>
   <text class="row value ${valueColorClass(p.valueScore)}" x="${cols.value}" y="${y}">${valueScore}</text>
@@ -358,8 +364,8 @@ ${sponsorImage ? `
   <text class="timestamp" x="${width - padding}" y="${height - 38}" text-anchor="end">Last updated: ${date}</text>
 
   <!-- Footnotes -->
-  <text class="timestamp" x="${padding}" y="${height - 38}">Cost = 1 vCPU + 2 GB RAM per hour (normalized). Value Score = sqrt(benchmark score x cost efficiency).</text>
-  <text class="timestamp" x="${padding}" y="${height - 24}">Est. 25% CPU = estimated cost at 25% CPU utilization. Applies to active-CPU billing only (Vercel, Cloudflare). Memory is always wall-clock.</text>
+  <text class="timestamp" x="${padding}" y="${height - 38}">Eff. Cost = effective cost for 1 vCPU + 2 GB RAM / hr. Active-CPU providers (~) estimated at 25% utilization. Value Score = sqrt(benchmark x cost efficiency).</text>
+  <text class="timestamp" x="${padding}" y="${height - 24}">Active-CPU billing (Vercel, Cloudflare): CPU charged only during execution, memory always wall-clock. Wall-clock providers: full rate shown.</text>
   <text class="timestamp" x="${padding}" y="${height - 10}">Confidence: exact = official pricing page, estimated = back-calculated from bundled tier.</text>
 
 </svg>`;


### PR DESCRIPTION
## Summary

Replaces the raw cost column with an **Eff. Cost / hr** column that reflects realistic costs for I/O-bound workloads like AI agent sandboxes.

## The problem

Vercel and Cloudflare bill on **active CPU time** — they only charge when the CPU is executing, not during I/O wait (LLM calls, network, DB queries). The previous table showed their 100% utilization cost alongside wall-clock providers, making them look more expensive than they actually are for typical usage.

## The fix

Single "Eff. Cost / hr" column:
- **Wall-clock providers**: actual cost shown as-is
- **Active-CPU providers** (Vercel, Cloudflare): estimated at **25% CPU utilization**, prefixed with `~` to signal it's an estimate

The **value score** now uses this effective cost for ranking, so the table tells a consistent story.

## Impact on rankings

| Provider | Old Cost (100%) | Eff. Cost (25%) | Old Value | New Value |
|----------|----------------|-----------------|-----------|-----------|
| Cloudflare | $0.0900 | ~$0.0360 | 63.8 | 79.5 |
| Vercel | $0.1492 | ~$0.0532 | 44.8 | 76.4 |
| E2B | $0.0828 | $0.0828 | 72.7 | 74.8 |
| Daytona | $0.0828 | $0.0828 | 72.6 | 75.4 |

Cloudflare and Vercel move from mid-table to the top two spots by value when their billing model is accounted for.

## Why 25%?

AI agent sandboxes are I/O-bound — most wall-clock time is spent waiting on LLM API responses, not executing CPU instructions. 25% is a conservative estimate; actual utilization for many agent workloads is likely lower (10-15%), which would make active-CPU providers even cheaper.