### PR TITLE
fix: pricing-svg workflow triggers on master, not main

### DIFF
--- a/.github/workflows/pricing-svg.yml
+++ b/.github/workflows/pricing-svg.yml
@@ -2,7 +2,7 @@ name: Pricing SVG
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     paths:
       - 'pricing.json'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Three changes to the pricing table:

1. **Fix workflow trigger** — `pricing-svg.yml` was targeting `main` but the repo's default branch is `master`
2. **10% CPU utilization** — lowered from 25% for active-CPU provider estimates (Vercel, Cloudflare). More realistic for I/O-bound AI agent workloads where most wall-clock time is spent waiting on LLM API responses
3. **Remove ranking, sort by price** — dropped the `#` column and medal colors. Table now sorts by effective cost (cheapest first) without declaring winners

## Effective costs at 10% utilization

| Provider | Eff. Cost / hr | Billing |
|----------|---------------|---------|
| Cloudflare | ~$0.0252 | Active CPU |
| Vercel | ~$0.0340 | Active CPU |
| Namespace | $0.0600 | Per-minute |
| E2B | $0.0828 | Per-second |
| Blaxel | $0.0828 | Per-second |
| Hopx | $0.0828 | Per-second |
| Daytona | $0.0828 | Per-second |
| Modal | $0.1191 | Per-second |
| CodeSandbox | $0.1486 | Per-hour |
| Runloop | $0.1584 | Per-second |

Value score is still shown as a reference column but no longer drives the sort order.