### PR TITLE
feat: add github workflow to update dotcom on results change

### DIFF
--- a/.github/workflows/trigger-dotcom-rebuild.yml
+++ b/.github/workflows/trigger-dotcom-rebuild.yml
@@ -1,0 +1,23 @@
+name: Trigger Dotcom Rebuild
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'results/**'
+
+jobs:
+  redeploy-dotcom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Railway CLI
+        run: npm i -g @railway/cli
+
+      - name: Trigger redeploy
+        run: railway redeploy --yes
+        env:
+          RAILWAY_TOKEN: ${{ secrets.DOTCOM_RAILWAY_TOKEN }}
+          RAILWAY_SERVICE_ID: ${{ secrets.DOTCOM_RAILWAY_SERVICE_ID }}
+          RAILWAY_PROJECT_ID: ${{ secrets.DOTCOM_RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID: ${{ secrets.DOTCOM_RAILWAY_ENVIRONMENT_ID }}


### PR DESCRIPTION
Add workflow to trigger dotcom redeploy on benchmark result changes

When benchmark results are updated in results/**, the Railway-hosted
dotcom site needs to rebuild to pick up the new data. This workflow
installs the Railway CLI and runs a redeploy using DOTCOM_RAILWAY_*
secrets, keeping them namespaced to avoid collision with the sandbox
Railway credentials.
