### PR TITLE
fix: update gh workflows to trigger dotcom redeploy

### DIFF
--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -222,5 +222,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add results.svg *_tti.svg pricing.svg results/
           git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update benchmark results [skip ci]"
+          git commit -m "chore: update benchmark results"
           git push

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -198,5 +198,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add storage_*.svg results/storage/
           git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update storage benchmark results [skip ci]"
+          git commit -m "chore: update storage benchmark results"
           git push


### PR DESCRIPTION
dotcom redeploy is triggered in CI. removed "[skip ci]" which prevented triggering of redeploy workflow.