### PR TITLE
feat: add tensorlake sandbox provider to benchmarks

### DIFF
--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -60,6 +60,7 @@ jobs:
           - modal
           - namespace
           - runloop
+          - tensorlake
           - upstash
           - vercel
     steps:
@@ -98,6 +99,7 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           NSC_TOKEN: ${{ secrets.NSC_TOKEN }}
           RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
+          TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}
           UPSTASH_BOX_API_KEY: ${{ secrets.UPSTASH_BOX_API_KEY }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}

--- a/src/sandbox/providers.ts
+++ b/src/sandbox/providers.ts
@@ -1,17 +1,18 @@
 import { archil } from '@computesdk/archil';
-import { e2b } from '@computesdk/e2b';
+import { blaxel } from '@computesdk/blaxel';
+import { codesandbox } from '@computesdk/codesandbox';
+import { cloudflare } from '@computesdk/cloudflare';
 import { daytona } from '@computesdk/daytona';
 import { declaw } from '@computesdk/declaw';
-import { blaxel } from '@computesdk/blaxel';
-import { modal } from '@computesdk/modal';
-import { vercel } from '@computesdk/vercel';
+import { e2b } from '@computesdk/e2b';
 import { hopx } from '@computesdk/hopx';
-import { codesandbox } from '@computesdk/codesandbox';
-import { runloop } from '@computesdk/runloop';
+import { modal } from '@computesdk/modal';
 import { namespace } from '@computesdk/namespace';
-import { cloudflare } from '@computesdk/cloudflare';
+import { runloop } from '@computesdk/runloop';
 import { sprites } from '@computesdk/sprites';
+import { tensorlake } from '@computesdk/tensorlake'
 import { upstash } from '@computesdk/upstash';
+import { vercel } from '@computesdk/vercel';
 import { compute } from 'computesdk';
 import type { ProviderConfig } from './types.js';
 
@@ -86,6 +87,11 @@ export const providers: ProviderConfig[] = [
     name: 'sprites',
     requiredEnvVars: ['SPRITES_TOKEN'],
     createCompute: () => sprites({ apiKey: process.env.SPRITES_TOKEN! }),
+  },
+  {
+    name: 'tensorlake',
+    requiredEnvVars: ['TENSORLAKE_API_KEY'],
+    createCompute: () => tensorlake({ apiKey: process.env.TENSORLAKE_API_KEY! }),
   },
   {
     name: 'upstash',


### PR DESCRIPTION
This pull request adds support for the Tensorlake provider to the sandbox benchmarking workflow and the provider configuration. The main changes include updating the workflow to handle Tensorlake credentials and registering Tensorlake as a provider in the codebase.

**Provider integration:**

* Added `tensorlake` to the list of providers in the `providers` array in `src/sandbox/providers.ts`, including its required environment variable and initialization logic.
* Imported the `tensorlake` provider from `@computesdk/tensorlake` in `src/sandbox/providers.ts`.

**Workflow updates:**

* Included `tensorlake` in the list of providers to benchmark in the `.github/workflows/sandbox-benchmarks.yml` workflow.
* Added `TENSORLAKE_API_KEY` as an environment variable in the workflow to support the new provider.