### PR TITLE
add northflank to benchmarks

### DIFF
--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
           - hopx
           - modal
           - namespace
-          # - northflank
+          - northflank
           - runloop
           - tensorlake
           - upstash
@@ -99,8 +99,8 @@ jobs:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           NSC_TOKEN: ${{ secrets.NSC_TOKEN }}
-          # NORTHFLANK_TOKEN: ${{ secrets.NORTHFLANK_TOKEN }}
-          # NORTHFLANK_PROJECT_ID: ${{ secrets.NORTHFLANK_PROJECT_ID }}
+          NORTHFLANK_TOKEN: ${{ secrets.NORTHFLANK_TOKEN }}
+          NORTHFLANK_PROJECT_ID: ${{ secrets.NORTHFLANK_PROJECT_ID }}
           RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
           TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}
           UPSTASH_BOX_API_KEY: ${{ secrets.UPSTASH_BOX_API_KEY }}

--- a/src/sandbox/providers.ts
+++ b/src/sandbox/providers.ts
@@ -8,7 +8,7 @@ import { e2b } from '@computesdk/e2b';
 import { hopx } from '@computesdk/hopx';
 import { modal } from '@computesdk/modal';
 import { namespace } from '@computesdk/namespace';
-// import { northflank } from '@computesdk/northflank';
+import { northflank } from '@computesdk/northflank';
 import { runloop } from '@computesdk/runloop';
 import { sprites } from '@computesdk/sprites';
 import { tensorlake } from '@computesdk/tensorlake'
@@ -79,15 +79,15 @@ export const providers: ProviderConfig[] = [
     createCompute: () => namespace({ token: process.env.NSC_TOKEN! }),
     sandboxOptions: { image: 'node:22' },
   },
-  // {
-  //   name: 'northflank',
-  //   requiredEnvVars: ['NORTHFLANK_TOKEN', 'NORTHFLANK_PROJECT_ID'],
-  //   createCompute: () => northflank({
-  //     token: process.env.NORTHFLANK_TOKEN!,
-  //     projectId: process.env.NORTHFLANK_PROJECT_ID!,
-  //     runtime: 'node',
-  //   }),
-  // },
+  {
+    name: 'northflank',
+    requiredEnvVars: ['NORTHFLANK_TOKEN', 'NORTHFLANK_PROJECT_ID'],
+    createCompute: () => northflank({
+      token: process.env.NORTHFLANK_TOKEN!,
+      projectId: process.env.NORTHFLANK_PROJECT_ID!,
+      runtime: 'node',
+    }),
+  },
   {
     name: 'runloop',
     requiredEnvVars: ['RUNLOOP_API_KEY'],


### PR DESCRIPTION
This pull request enables support for the `northflank` provider in both the sandbox benchmark workflow and the application code. The changes ensure that `northflank` is now included as an active provider, with its required environment variables properly set up.