### PR TITLE
Make benchmark result pushes race-safe

### DIFF
--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -201,4 +201,19 @@ jobs:
           git add package.json package-lock.json browser.svg results/browser/
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "chore: update browser benchmark results [skip ci]"
-          git push
+
+          # Remote master can advance during the run (concurrent benchmark
+          # workflows push to master too), so a plain push fails non-fast-forward.
+          # Rebase onto the latest remote and retry a few times before giving up.
+          branch="${GITHUB_REF#refs/heads/}"
+          for attempt in 1 2 3 4 5; do
+            if git push origin "HEAD:${branch}"; then
+              echo "Pushed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); rebasing onto origin/${branch}"
+            git fetch origin "${branch}"
+            git rebase "origin/${branch}" || { git rebase --abort; exit 1; }
+          done
+          echo "Failed to push after multiple attempts" >&2
+          exit 1

--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -88,6 +88,11 @@ jobs:
     if: always()
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the rebase-on-push retry below has a merge base.
+          # A shallow (depth-1) clone can make `git rebase origin/<branch>`
+          # fail when the remote has advanced past the shallow boundary.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -207,13 +212,16 @@ jobs:
           # Rebase onto the latest remote and retry a few times before giving up.
           branch="${GITHUB_REF#refs/heads/}"
           for attempt in 1 2 3 4 5; do
+            # Rebase before each attempt (including the last) so every rebase
+            # is followed by a push — otherwise the final iteration's rebase
+            # would be wasted and a resolvable non-fast-forward could still fail.
+            git fetch origin "${branch}"
+            git rebase "origin/${branch}" || { git rebase --abort; exit 1; }
             if git push origin "HEAD:${branch}"; then
               echo "Pushed on attempt ${attempt}"
               exit 0
             fi
-            echo "Push rejected (attempt ${attempt}); rebasing onto origin/${branch}"
-            git fetch origin "${branch}"
-            git rebase "origin/${branch}" || { git rebase --abort; exit 1; }
+            echo "Push rejected (attempt ${attempt}); will rebase and retry"
           done
           echo "Failed to push after multiple attempts" >&2
           exit 1

--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -257,4 +257,19 @@ jobs:
           git add package.json package-lock.json results.svg *_tti.svg pricing.svg results/
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "chore: update benchmark results [skip ci]"
-          git push
+
+          # Remote master can advance during the run (concurrent runs / other
+          # commits), so a plain push fails non-fast-forward. Rebase onto the
+          # latest remote and retry a few times before giving up.
+          branch="${GITHUB_REF#refs/heads/}"
+          for attempt in 1 2 3 4 5; do
+            if git push origin "HEAD:${branch}"; then
+              echo "Pushed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); rebasing onto origin/${branch}"
+            git fetch origin "${branch}"
+            git rebase "origin/${branch}" || { git rebase --abort; exit 1; }
+          done
+          echo "Failed to push after multiple attempts" >&2
+          exit 1

--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -133,6 +133,11 @@ jobs:
     if: always()
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the rebase-on-push retry below has a merge base.
+          # A shallow (depth-1) clone can make `git rebase origin/<branch>`
+          # fail when the remote has advanced past the shallow boundary.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -263,13 +268,16 @@ jobs:
           # latest remote and retry a few times before giving up.
           branch="${GITHUB_REF#refs/heads/}"
           for attempt in 1 2 3 4 5; do
+            # Rebase before each attempt (including the last) so every rebase
+            # is followed by a push — otherwise the final iteration's rebase
+            # would be wasted and a resolvable non-fast-forward could still fail.
+            git fetch origin "${branch}"
+            git rebase "origin/${branch}" || { git rebase --abort; exit 1; }
             if git push origin "HEAD:${branch}"; then
               echo "Pushed on attempt ${attempt}"
               exit 0
             fi
-            echo "Push rejected (attempt ${attempt}); rebasing onto origin/${branch}"
-            git fetch origin "${branch}"
-            git rebase "origin/${branch}" || { git rebase --abort; exit 1; }
+            echo "Push rejected (attempt ${attempt}); will rebase and retry"
           done
           echo "Failed to push after multiple attempts" >&2
           exit 1

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -222,4 +222,19 @@ jobs:
           git add package.json package-lock.json storage_*.svg results/storage/
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "chore: update storage benchmark results [skip ci]"
-          git push
+
+          # Remote master can advance during the run (concurrent benchmark
+          # workflows push to master too), so a plain push fails non-fast-forward.
+          # Rebase onto the latest remote and retry a few times before giving up.
+          branch="${GITHUB_REF#refs/heads/}"
+          for attempt in 1 2 3 4 5; do
+            if git push origin "HEAD:${branch}"; then
+              echo "Pushed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); rebasing onto origin/${branch}"
+            git fetch origin "${branch}"
+            git rebase "origin/${branch}" || { git rebase --abort; exit 1; }
+          done
+          echo "Failed to push after multiple attempts" >&2
+          exit 1

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -105,6 +105,11 @@ jobs:
     if: always()
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the rebase-on-push retry below has a merge base.
+          # A shallow (depth-1) clone can make `git rebase origin/<branch>`
+          # fail when the remote has advanced past the shallow boundary.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -228,13 +233,16 @@ jobs:
           # Rebase onto the latest remote and retry a few times before giving up.
           branch="${GITHUB_REF#refs/heads/}"
           for attempt in 1 2 3 4 5; do
+            # Rebase before each attempt (including the last) so every rebase
+            # is followed by a push — otherwise the final iteration's rebase
+            # would be wasted and a resolvable non-fast-forward could still fail.
+            git fetch origin "${branch}"
+            git rebase "origin/${branch}" || { git rebase --abort; exit 1; }
             if git push origin "HEAD:${branch}"; then
               echo "Pushed on attempt ${attempt}"
               exit 0
             fi
-            echo "Push rejected (attempt ${attempt}); rebasing onto origin/${branch}"
-            git fetch origin "${branch}"
-            git rebase "origin/${branch}" || { git rebase --abort; exit 1; }
+            echo "Push rejected (attempt ${attempt}); will rebase and retry"
           done
           echo "Failed to push after multiple attempts" >&2
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .env
 node_modules/
 .DS_Store
+
+scale.cjs
+fetch-raw-json.ts


### PR DESCRIPTION
## Make benchmark result pushes race-safe

### Problem
The daily-midnight `sandbox` and `browser` benchmark workflows both run at `0 0 * * *` and push results to `master` independently. When their "Commit and push" steps overlap, the second push fails non-fast-forward (`! [rejected] master -> master (fetch first)`), failing the job. A prior fix (1e581b0) only moved `storage` off the midnight slot — it never addressed the underlying unguarded push, so sandbox↔browser kept colliding. Recent provider/scale growth (northflank, tensorlake, burst VMs) widened the push windows enough that the collision now lands most nights.

### Fix
Replace the bare `git push` in the sandbox, browser, and storage benchmark workflows with a fetch → rebase → retry loop, so concurrent runs can safely push regardless of timing.

### Notes
- The ingest `404 "Application not found"` seen in the failing run is a separate upstream config issue (missing app registration behind `INGEST_URL`/`INGEST_SECRET`). That step already has `continue-on-error: true` and does not fail the job — not addressed here.
- `pricing-svg.yml` already rebases before pushing and was left as-is.
