### PR TITLE
Use scalableSandboxes for Modal on TTI benchmarks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@computesdk/hyperbrowser": "^0.2.0",
         "@computesdk/just-bash": "^0.4.6",
         "@computesdk/kernel": "^0.2.1",
-        "@computesdk/modal": "^1.8.42",
+        "@computesdk/modal": "^1.9.3",
         "@computesdk/namespace": "^1.6.4",
         "@computesdk/northflank": "^1.1.0",
         "@computesdk/notte": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@computesdk/hyperbrowser": "^0.2.0",
     "@computesdk/just-bash": "^0.4.6",
     "@computesdk/kernel": "^0.2.1",
-    "@computesdk/modal": "^1.8.42",
+    "@computesdk/modal": "^1.9.3",
     "@computesdk/namespace": "^1.6.4",
     "@computesdk/northflank": "^1.1.0",
     "@computesdk/notte": "^0.3.0",

--- a/src/sandbox/providers.ts
+++ b/src/sandbox/providers.ts
@@ -71,7 +71,7 @@ export const providers: ProviderConfig[] = [
   {
     name: 'modal',
     requiredEnvVars: ['MODAL_TOKEN_ID', 'MODAL_TOKEN_SECRET'],
-    createCompute: () => modal({ tokenId: process.env.MODAL_TOKEN_ID!, tokenSecret: process.env.MODAL_TOKEN_SECRET! }),
+    createCompute: () => modal({ tokenId: process.env.MODAL_TOKEN_ID!, tokenSecret: process.env.MODAL_TOKEN_SECRET!, scalableSandboxes: true }),
   },
   {
     name: 'namespace',


### PR DESCRIPTION
Modal's scalable sandboxes scheduler is now openly available to use, and is much stronger for performance-sensitive applications / apps that care about TTI. Thus this PR moves the TTI benchmark to use this scheduler.