### PR TITLE
Bump Tensorlake SDK for benchmarks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,9 @@
         "@types/node": "^25.5.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2"
+      },
+      "overrides": {
+        "tensorlake": "0.5.33"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -11996,12 +11999,12 @@
       }
     },
     "node_modules/tensorlake": {
-      "version": "0.5.31",
-      "resolved": "https://registry.npmjs.org/tensorlake/-/tensorlake-0.5.31.tgz",
-      "integrity": "sha512-uZrbQmT77VDig6mLnkfxIoETKug4AN5a1VKIULN5b/PeaVhU0NkNJvjgh88JkJPGLjMFabS7u+bC7xNyXfjnEw==",
+      "version": "0.5.33",
+      "resolved": "https://registry.npmjs.org/tensorlake/-/tensorlake-0.5.33.tgz",
+      "integrity": "sha512-9TX/hKkEL7w6tbZy/yKAJ522Fps9kMkGcoCKibb4XT7OANmwdS3A5GLLsq4ufkVeSxQjaswnmVUoghzFzF1XtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "undici": "^8.1.0",
+        "undici": "8.3.0",
         "ws": "^8.20.0"
       },
       "bin": {
@@ -12016,9 +12019,9 @@
       }
     },
     "node_modules/tensorlake/node_modules/undici": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.4.0.tgz",
-      "integrity": "sha512-tDR4LgFBeV7YBWOFMlmbhtrnFVWuZ6HKbkG+88/csQdhK2tPlW78PnLI2VRjIQtTlslvgSZ4R43WBE+4g6rhng==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -85,5 +85,8 @@
     "@types/node": "^25.5.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2"
+  },
+  "overrides": {
+    "tensorlake": "0.5.33"
   }
 }


### PR DESCRIPTION
## Summary
- force the benchmark install to use tensorlake 0.5.33 via npm overrides
- refresh the lockfile so the Tensorlake provider resolves undici 8.3.0 instead of 8.4.0

## Why
Tensorlake 0.5.33 pins undici to 8.3.0, avoiding the undici 8.4.0 HTTP/2 pooling behavior that serialized concurrent Tensorlake runCommand requests in burst benchmarks.

## Verification
- npm ls tensorlake undici --package-lock-only