### PR TITLE
Add MIOSA storage benchmark provider

### DIFF
--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -52,6 +52,7 @@ jobs:
           - aws-s3
           - cloudflare-r2
           - tigris
+          - miosa
         file_size: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.file_size != '' && fromJson(format('["{0}"]', github.event.inputs.file_size))) || fromJson('["1MB","4MB","10MB","16MB"]') }}
     steps:
       - uses: actions/checkout@v4
@@ -81,6 +82,9 @@ jobs:
           TIGRIS_STORAGE_ACCESS_KEY_ID: ${{ secrets.TIGRIS_STORAGE_ACCESS_KEY_ID }}
           TIGRIS_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.TIGRIS_STORAGE_SECRET_ACCESS_KEY }}
           TIGRIS_STORAGE_BUCKET: ${{ secrets.TIGRIS_STORAGE_BUCKET }}
+          MIOSA_API_KEY: ${{ secrets.MIOSA_API_KEY }}
+          MIOSA_BASE_URL: ${{ secrets.MIOSA_BASE_URL }}
+          MIOSA_STORAGE_BUCKET_ID: ${{ secrets.MIOSA_STORAGE_BUCKET_ID }}
         run: |
           FILE_SIZE="${{ matrix.file_size }}"
           npm run bench -- \
@@ -175,7 +179,7 @@ jobs:
               body += '|---|----------|-------|----------|------------|--------|--------|\n';
 
               results.forEach((r, i) => {
-                const name = r.provider === 'aws-s3' ? 'AWS S3' : r.provider === 'cloudflare-r2' ? 'Cloudflare R2' : r.provider.charAt(0).toUpperCase() + r.provider.slice(1);
+                const name = r.provider === 'aws-s3' ? 'AWS S3' : r.provider === 'cloudflare-r2' ? 'Cloudflare R2' : r.provider === 'miosa' ? 'MIOSA' : r.provider.charAt(0).toUpperCase() + r.provider.slice(1);
                 const score = r.compositeScore !== undefined ? r.compositeScore.toFixed(1) : '--';
                 const dl = (r.summary.downloadMs.median / 1000).toFixed(2) + 's';
                 const tp = r.summary.throughputMbps.median.toFixed(1) + ' Mbps';

--- a/env.example
+++ b/env.example
@@ -58,6 +58,10 @@ TIGRIS_SECRET_ACCESS_KEY=your_tigris_secret_access_key
 TIGRIS_REGION=your_tigris_region
 TIGRIS_BUCKET=your_tigris_bucket
 
+MIOSA_API_KEY=your_miosa_api_key
+MIOSA_BASE_URL=https://api.miosa.ai/api/v1
+MIOSA_STORAGE_BUCKET_ID=your_miosa_storage_bucket_id
+
 ######### BEAM ########
 BEAM_TOKEN=your_beam_token
 BEAM_WORKSPACE_ID=your_beam_workspace_id

--- a/src/storage/generate-svg.ts
+++ b/src/storage/generate-svg.ts
@@ -64,6 +64,7 @@ function getArgValue(args: string[], flag: string): string | undefined {
 function formatProviderName(s: string): string {
   if (s === 'aws-s3') return 'AWS S3';
   if (s === 'cloudflare-r2') return 'Cloudflare R2';
+  if (s === 'miosa') return 'MIOSA';
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 

--- a/src/storage/miosa.ts
+++ b/src/storage/miosa.ts
@@ -1,0 +1,178 @@
+import type {
+  DownloadResult,
+  ListOptions,
+  ListResult,
+  StorageObject,
+  StorageProvider,
+  UploadOptions,
+} from '@computesdk/provider';
+
+interface MiosaConfig {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+interface MiosaObject {
+  key?: string;
+  size?: number;
+  size_bytes?: number;
+  content_type?: string;
+  etag?: string;
+  last_modified?: string;
+}
+
+interface MiosaListResponse {
+  data?: MiosaObject[];
+  objects?: MiosaObject[];
+  items?: MiosaObject[];
+  cursor?: string;
+  next_cursor?: string;
+  nextContinuationToken?: string;
+  truncated?: boolean;
+}
+
+function cleanBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '');
+}
+
+function objectPath(bucket: string, key: string): string {
+  const encodedKey = key
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+
+  return `/storage/buckets/${encodeURIComponent(bucket)}/objects/${encodedKey}`;
+}
+
+function toBody(data: Uint8Array | string): BodyInit {
+  if (typeof data === 'string') return data;
+  return new Blob([data.slice()]);
+}
+
+function byteLength(data: Uint8Array | string): number {
+  return typeof data === 'string' ? Buffer.byteLength(data, 'utf8') : data.byteLength;
+}
+
+function toStorageObject(bucket: string, object: MiosaObject): StorageObject {
+  return {
+    bucket,
+    key: object.key || '',
+    size: object.size_bytes ?? object.size ?? 0,
+    etag: object.etag,
+    lastModified: object.last_modified ? new Date(object.last_modified) : undefined,
+  };
+}
+
+async function parseError(response: Response): Promise<string> {
+  const text = await response.text().catch(() => '');
+  if (!text) return `${response.status} ${response.statusText}`;
+
+  try {
+    const body = JSON.parse(text) as {
+      error?: { message?: string; code?: string };
+      message?: string;
+    };
+    return body.error?.message || body.error?.code || body.message || text;
+  } catch {
+    return text;
+  }
+}
+
+export function miosa(config: MiosaConfig = {}): StorageProvider {
+  const apiKey = config.apiKey || process.env.MIOSA_API_KEY;
+  const baseUrl = cleanBaseUrl(
+    config.baseUrl || process.env.MIOSA_BASE_URL || 'https://api.miosa.ai/api/v1',
+  );
+
+  if (!apiKey) {
+    throw new Error("Missing MIOSA API key. Provide 'apiKey' in config or set MIOSA_API_KEY.");
+  }
+
+  async function request(path: string, init: RequestInit = {}): Promise<Response> {
+    const headers = new Headers(init.headers);
+    headers.set('Authorization', `Bearer ${apiKey}`);
+    headers.set('Accept', 'application/json');
+
+    const response = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(await parseError(response));
+    }
+
+    return response;
+  }
+
+  return {
+    async upload(
+      bucket: string,
+      key: string,
+      data: Uint8Array | string,
+      options?: UploadOptions,
+    ): Promise<StorageObject> {
+      const response = await request(objectPath(bucket, key), {
+        method: 'PUT',
+        headers: {
+          'Content-Type': options?.contentType || 'application/octet-stream',
+        },
+        body: toBody(data),
+      });
+
+      return {
+        bucket,
+        key,
+        size: byteLength(data),
+        etag: response.headers.get('etag') || undefined,
+        lastModified: new Date(),
+        metadata: options?.metadata,
+      };
+    },
+
+    async download(bucket: string, key: string): Promise<DownloadResult> {
+      const response = await request(objectPath(bucket, key));
+      const arrayBuffer = await response.arrayBuffer();
+      const data = new Uint8Array(arrayBuffer);
+
+      return {
+        data,
+        size: data.byteLength,
+        contentType: response.headers.get('content-type') || undefined,
+        etag: response.headers.get('etag') || undefined,
+        lastModified: response.headers.get('last-modified')
+          ? new Date(response.headers.get('last-modified')!)
+          : undefined,
+      };
+    },
+
+    async delete(bucket: string, key: string): Promise<void> {
+      await request(objectPath(bucket, key), { method: 'DELETE' });
+    },
+
+    async list(bucket: string, options?: ListOptions): Promise<ListResult> {
+      const params = new URLSearchParams();
+      if (options?.prefix) params.set('prefix', options.prefix);
+      if (options?.maxKeys) params.set('max_keys', String(options.maxKeys));
+      if (options?.continuationToken) params.set('marker', options.continuationToken);
+
+      const query = params.toString();
+      const response = await request(
+        `/storage/buckets/${encodeURIComponent(bucket)}/objects${query ? `?${query}` : ''}`,
+      );
+      const payload = (await response.json()) as MiosaListResponse | MiosaObject[];
+      const objects = Array.isArray(payload)
+        ? payload
+        : payload.data || payload.objects || payload.items || [];
+      const continuationToken = Array.isArray(payload)
+        ? undefined
+        : payload.next_cursor || payload.cursor || payload.nextContinuationToken;
+
+      return {
+        objects: objects.map((object) => toStorageObject(bucket, object)),
+        truncated: Array.isArray(payload) ? false : Boolean(payload.truncated || continuationToken),
+        continuationToken,
+      };
+    },
+  };
+}

--- a/src/storage/providers.ts
+++ b/src/storage/providers.ts
@@ -2,6 +2,7 @@ import { s3 } from '@computesdk/s3';
 import { r2 } from '@computesdk/r2';
 import { tigris } from '@computesdk/tigris';
 import type { StorageProviderConfig } from './types.js';
+import { miosa } from './miosa.js';
 
 /**
  * Storage provider benchmark configurations.
@@ -38,6 +39,16 @@ export const storageProviders: StorageProviderConfig[] = [
     createStorage: () => tigris({
       accessKeyId: process.env.TIGRIS_STORAGE_ACCESS_KEY_ID!,
       secretAccessKey: process.env.TIGRIS_STORAGE_SECRET_ACCESS_KEY!,
+    }),
+    fileSizes: [1 * 1024 * 1024, 4 * 1024 * 1024, 10 * 1024 * 1024, 16 * 1024 * 1024],
+  },
+  {
+    name: 'miosa',
+    requiredEnvVars: ['MIOSA_API_KEY', 'MIOSA_STORAGE_BUCKET_ID'],
+    bucket: process.env.MIOSA_STORAGE_BUCKET_ID!,
+    createStorage: () => miosa({
+      apiKey: process.env.MIOSA_API_KEY!,
+      baseUrl: process.env.MIOSA_BASE_URL,
     }),
     fileSizes: [1 * 1024 * 1024, 4 * 1024 * 1024, 10 * 1024 * 1024, 16 * 1024 * 1024],
   },


### PR DESCRIPTION
## Summary
- add a MIOSA storage adapter implementing the ComputeSDK StorageProvider interface
- register MIOSA in the storage benchmark matrix for 1MB, 4MB, 10MB, and 16MB runs
- document and wire required benchmark secrets: MIOSA_API_KEY, MIOSA_STORAGE_BUCKET_ID, optional MIOSA_BASE_URL

## Verification
- npm run bench -- --mode storage --provider miosa --file-size 1MB --iterations 1 skips cleanly when MIOSA secrets are absent
- targeted mock-server check verifies upload body/auth/content-type, download, list, and delete

Note: npx tsc --noEmit currently fails on an existing aws-s3 config type mismatch: region is not in S3Config.