### PR TITLE
WIP - fix: supply endpoint to aws-s3 storage provider

### DIFF
--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -74,6 +74,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}

--- a/src/storage/providers.ts
+++ b/src/storage/providers.ts
@@ -16,7 +16,9 @@ export const storageProviders: StorageProviderConfig[] = [
     createStorage: () => s3({
       accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-      region: process.env.AWS_REGION || 'us-east-1',
+      // @computesdk/s3 requires an explicit endpoint (it ignores `region`).
+      // Derive the AWS regional endpoint, or allow an S3-compatible override.
+      endpoint: process.env.S3_ENDPOINT || `https://s3.${process.env.AWS_REGION || 'us-east-1'}.amazonaws.com`,
     }),
     fileSizes: [1 * 1024 * 1024, 4 * 1024 * 1024, 10 * 1024 * 1024, 16 * 1024 * 1024], // 1MB, 4MB, 10MB, 16MB
   },


### PR DESCRIPTION
@computesdk/s3 requires an explicit `endpoint` and ignores `region`, so the aws-s3 benchmark threw "Missing endpoint" at provider construction before any iteration ran. Derive the AWS regional endpoint from AWS_REGION (with an optional S3_ENDPOINT override) and wire S3_ENDPOINT into the storage benchmark workflow.