### PR TITLE
Bump ComputeSDK dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@computesdk/tigris": "^1.1.1",
         "@computesdk/upstash": "^0.3.0",
         "@computesdk/vercel": "^1.7.22",
-        "computesdk": "^2.5.4",
+        "computesdk": "^4.1.3",
         "dotenv": "^17.4.0",
         "playwright-core": "^1.59.1"
       },
@@ -808,16 +808,6 @@
         "playwright-core": "^1.40.0"
       }
     },
-    "node_modules/@computesdk/anchorbrowser/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/anchorbrowser/node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -848,6 +838,15 @@
       "dependencies": {
         "@computesdk/cmd": "0.4.1",
         "computesdk": "2.6.0"
+      }
+    },
+    "node_modules/@computesdk/archil/node_modules/computesdk": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-2.6.0.tgz",
+      "integrity": "sha512-XM4O9YdoAOm/mmTG+H4gKbivdlfzuFeR7Iax6B2vhQ5I9T29wnvnN4U09TzKaiJ+WkdTYfKVv+yo7jcv1Mcsuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@computesdk/cmd": "0.4.1"
       }
     },
     "node_modules/@computesdk/beam": {
@@ -899,16 +898,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@computesdk/beam/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/beam/node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -949,16 +938,6 @@
         "computesdk": "4.1.3"
       }
     },
-    "node_modules/@computesdk/blaxel/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/browserbase": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@computesdk/browserbase/-/browserbase-0.3.8.tgz",
@@ -970,16 +949,6 @@
         "computesdk": "4.1.3",
         "dotenv": "^16.0.0",
         "playwright-core": "^1.40.0"
-      }
-    },
-    "node_modules/@computesdk/browserbase/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@computesdk/browserbase/node_modules/dotenv": {
@@ -1005,16 +974,6 @@
         "computesdk": "4.1.3",
         "dotenv": "^16.0.0",
         "playwright-core": "^1.40.0"
-      }
-    },
-    "node_modules/@computesdk/browseruse/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@computesdk/browseruse/node_modules/dotenv": {
@@ -1043,16 +1002,6 @@
         "computesdk-cloudflare": "dist/setup.mjs"
       }
     },
-    "node_modules/@computesdk/cloudflare/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/cmd": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@computesdk/cmd/-/cmd-0.4.1.tgz",
@@ -1070,16 +1019,6 @@
         "computesdk": "4.1.3"
       }
     },
-    "node_modules/@computesdk/codesandbox/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/collimate": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@computesdk/collimate/-/collimate-0.1.0.tgz",
@@ -1088,16 +1027,6 @@
       "dependencies": {
         "@computesdk/provider": "2.1.3",
         "computesdk": "4.1.3"
-      }
-    },
-    "node_modules/@computesdk/collimate/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@computesdk/daytona": {
@@ -1109,16 +1038,6 @@
         "@computesdk/provider": "2.1.3",
         "@daytonaio/sdk": "^0.143.0",
         "computesdk": "4.1.3"
-      }
-    },
-    "node_modules/@computesdk/daytona/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@computesdk/declaw": {
@@ -1162,16 +1081,6 @@
         "e2b": "^2.26.0"
       }
     },
-    "node_modules/@computesdk/e2b/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/hopx": {
       "version": "0.2.26",
       "resolved": "https://registry.npmjs.org/@computesdk/hopx/-/hopx-0.2.26.tgz",
@@ -1181,16 +1090,6 @@
         "@computesdk/provider": "2.1.3",
         "@hopx-ai/sdk": "^0.5.1",
         "computesdk": "4.1.3"
-      }
-    },
-    "node_modules/@computesdk/hopx/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@computesdk/hyperbrowser": {
@@ -1204,16 +1103,6 @@
         "computesdk": "4.1.3",
         "dotenv": "^16.0.0",
         "playwright-core": "^1.40.0"
-      }
-    },
-    "node_modules/@computesdk/hyperbrowser/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@computesdk/hyperbrowser/node_modules/dotenv": {
@@ -1242,16 +1131,6 @@
         "just-bash": ">=2.0.0"
       }
     },
-    "node_modules/@computesdk/just-bash/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/kernel": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/@computesdk/kernel/-/kernel-0.2.8.tgz",
@@ -1261,16 +1140,6 @@
         "@computesdk/provider": "2.1.3",
         "@onkernel/sdk": "^0.49.0",
         "computesdk": "4.1.3"
-      }
-    },
-    "node_modules/@computesdk/kernel/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@computesdk/modal": {
@@ -1284,16 +1153,6 @@
         "modal": "0.7.6"
       }
     },
-    "node_modules/@computesdk/modal/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/namespace": {
       "version": "1.6.12",
       "resolved": "https://registry.npmjs.org/@computesdk/namespace/-/namespace-1.6.12.tgz",
@@ -1302,16 +1161,6 @@
       "dependencies": {
         "@computesdk/provider": "2.1.3",
         "computesdk": "4.1.3"
-      }
-    },
-    "node_modules/@computesdk/namespace/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@computesdk/northflank": {
@@ -1325,16 +1174,6 @@
         "computesdk": "4.1.3"
       }
     },
-    "node_modules/@computesdk/northflank/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/notte": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@computesdk/notte/-/notte-0.3.4.tgz",
@@ -1346,16 +1185,6 @@
         "dotenv": "^16.0.0",
         "notte-sdk": "^0.0.3",
         "playwright-core": "^1.40.0"
-      }
-    },
-    "node_modules/@computesdk/notte/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@computesdk/notte/node_modules/dotenv": {
@@ -1378,16 +1207,6 @@
       "dependencies": {
         "@computesdk/cmd": "0.4.1",
         "computesdk": "4.1.3",
-        "daemond": "0.1.4"
-      }
-    },
-    "node_modules/@computesdk/provider/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
         "daemond": "0.1.4"
       }
     },
@@ -1415,16 +1234,6 @@
         "node": ">=22"
       }
     },
-    "node_modules/@computesdk/railway/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/runloop": {
       "version": "1.3.52",
       "resolved": "https://registry.npmjs.org/@computesdk/runloop/-/runloop-1.3.52.tgz",
@@ -1434,16 +1243,6 @@
         "@computesdk/provider": "2.1.3",
         "@runloop/api-client": "^1.23.0",
         "computesdk": "4.1.3"
-      }
-    },
-    "node_modules/@computesdk/runloop/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@computesdk/s3": {
@@ -1466,16 +1265,6 @@
         "computesdk": "4.1.3"
       }
     },
-    "node_modules/@computesdk/sprites/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/steel": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@computesdk/steel/-/steel-0.2.4.tgz",
@@ -1487,16 +1276,6 @@
         "dotenv": "^16.0.0",
         "playwright-core": "^1.40.0",
         "steel-sdk": "^0.18.0"
-      }
-    },
-    "node_modules/@computesdk/steel/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@computesdk/steel/node_modules/dotenv": {
@@ -1522,16 +1301,6 @@
         "tensorlake": "0.5.33"
       }
     },
-    "node_modules/@computesdk/tensorlake/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/tigris": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/@computesdk/tigris/-/tigris-1.1.10.tgz",
@@ -1553,16 +1322,6 @@
         "computesdk": "4.1.3"
       }
     },
-    "node_modules/@computesdk/upstash/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
-      }
-    },
     "node_modules/@computesdk/vercel": {
       "version": "1.7.30",
       "resolved": "https://registry.npmjs.org/@computesdk/vercel/-/vercel-1.7.30.tgz",
@@ -1573,16 +1332,6 @@
         "@vercel/sandbox": "^1.9.3",
         "computesdk": "4.1.3",
         "ms": "^2.1.3"
-      }
-    },
-    "node_modules/@computesdk/vercel/node_modules/computesdk": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
-      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@computesdk/cmd": "0.4.1",
-        "daemond": "0.1.4"
       }
     },
     "node_modules/@connectrpc/connect": {
@@ -2537,22 +2286,6 @@
         "zod": {
           "optional": false
         }
-      }
-    },
-    "node_modules/@mongodb-js/zstd": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/zstd/-/zstd-7.0.0.tgz",
-      "integrity": "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-addon-api": "^8.5.0",
-        "prebuild-install": "^7.1.3"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
       }
     },
     "node_modules/@nodable/entities": {
@@ -5601,9 +5334,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@runloop/api-client": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@runloop/api-client/-/api-client-1.23.1.tgz",
-      "integrity": "sha512-jiWJI1BMamHVr7asReQnwzQ0/jL4VmcKPJ8eiFAyd6kFyidOIBDukUUdEzB3pd0lrbMlOeE6ePSDp8A5gbCadA==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@runloop/api-client/-/api-client-1.24.0.tgz",
+      "integrity": "sha512-A/G9l2MlBz/u0Wr2RvCEJvh0+4Pn/8p15BTq9wQt3vEgEGLEk844+9bIKsfWbDvU/4JdRvIUND79Vu5qvKQzUQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -6636,35 +6369,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/blessed": {
       "version": "0.1.81",
       "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
@@ -7357,12 +7061,13 @@
       }
     },
     "node_modules/computesdk": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-2.6.0.tgz",
-      "integrity": "sha512-XM4O9YdoAOm/mmTG+H4gKbivdlfzuFeR7Iax6B2vhQ5I9T29wnvnN4U09TzKaiJ+WkdTYfKVv+yo7jcv1Mcsuw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/computesdk/-/computesdk-4.1.3.tgz",
+      "integrity": "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ==",
       "license": "MIT",
       "dependencies": {
-        "@computesdk/cmd": "0.4.1"
+        "@computesdk/cmd": "0.4.1",
+        "daemond": "0.1.4"
       }
     },
     "node_modules/confbox": {
@@ -7522,34 +7227,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deepmerge": {
@@ -8126,17 +7803,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -8511,14 +8177,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -8631,14 +8289,6 @@
       "bin": {
         "giget": "dist/cli.mjs"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/gl-matrix": {
       "version": "2.8.1",
@@ -9790,20 +9440,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -9817,17 +9453,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -9850,14 +9475,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/modal": {
       "version": "0.7.6",
@@ -9913,14 +9530,6 @@
         "node": "^18 || >=20"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -9948,31 +9557,6 @@
       "license": "MIT",
       "dependencies": {
         "ts-error": "^1.0.6"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
-      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-domexception": {
@@ -10070,29 +9654,6 @@
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
-      }
-    },
-    "node_modules/node-liblzma": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-liblzma/-/node-liblzma-2.2.0.tgz",
-      "integrity": "sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g==",
-      "hasInstallScript": true,
-      "license": "LGPL-3.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-addon-api": "^8.5.0",
-        "node-gyp-build": "^4.8.4"
-      },
-      "bin": {
-        "nxz": "lib/cli/nxz.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/oorabona"
       }
     },
     "node_modules/nopt": {
@@ -10720,35 +10281,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -10930,31 +10462,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
     },
     "node_modules/rc9": {
       "version": "3.0.1",
@@ -11535,55 +11042,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/slice-ansi": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
@@ -11881,17 +11339,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strnum": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
@@ -11989,62 +11436,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-fs/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/tar-fs/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/tar-fs/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tar-stream": {
@@ -12214,20 +11605,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/turndown": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@computesdk/tigris": "^1.1.1",
     "@computesdk/upstash": "^0.3.0",
     "@computesdk/vercel": "^1.7.22",
-    "computesdk": "^2.5.4",
+    "computesdk": "^4.1.3",
     "dotenv": "^17.4.0",
     "playwright-core": "^1.59.1"
   },


### PR DESCRIPTION
## Summary

- Bump the benchmark repo's explicit `computesdk` dependency from the 2.x range to `^4.1.3`.
- Refresh `package-lock.json`, which dedupes most provider-local `computesdk@4.1.3` installs to the root dependency.
- Refresh the Runloop transitive client lock from `@runloop/api-client@1.23.1` to `1.24.0`.

## Relation to computesdk/computesdk#592

Merging computesdk/computesdk#592 should publish a new `@computesdk/runloop` patch release, not a new core `computesdk` package. The benchmark repo already allows future Runloop patch releases with `@computesdk/runloop` `^1.3.52`; once that release is published, `npm update` can pick it up. This PR covers the already-published pieces available now.

## Validation

- `npm ci`
- `npm run bench -- --provider runloop --iterations 0 --concurrency 0`

## Notes

`npx tsc --noEmit` currently fails on an unrelated storage provider type error in `src/storage/providers.ts` (`region` is not part of `S3Config`).