### PR TITLE
feat(pricing): model Modal as active-CPU and drop Namespace

### DIFF
--- a/pricing.json
+++ b/pricing.json
@@ -155,7 +155,7 @@
         "cold_start_ms": 2000
       },
       "pricing": {
-        "model": "per_second",
+        "model": "active_cpu",
         "cpu": {
           "rate": 3.942e-05,
           "unit": "core-sec",
@@ -186,8 +186,9 @@
           "cpu_per_vcpu_hr": 0.07096,
           "memory_per_gib_hr": 0.02419,
           "total_1vcpu_2gb_hr": 0.11914,
+          "effective_cost_1vcpu_2gb_hr": 0.0661,
           "confidence": "exact",
-          "notes": "$0.00003942/core-sec / 2 vCPU x 3600s for CPU. Sandbox non-preemptible rate."
+          "notes": "$0.00003942/core-sec / 2 vCPU x 3600s for CPU. Sandbox non-preemptible rate. Modal bills per-second but is compared as active-CPU at 10% utilization; effective cost respects Modal's 0.125 physical-core (0.25 vCPU) minimum: 0.07096*0.25 + 0.02419*2 = 0.0661."
         }
       },
       "plans": [
@@ -222,84 +223,6 @@
       "free_credits": 30,
       "isolation": "gvisor",
       "notes": "GPU support available. Regional multipliers (1.25x-2.5x) and non-preemptible multiplier (3x) compound. Startup credits up to $25K for eligible startups."
-    },
-    {
-      "id": "namespace",
-      "benchmark": {
-        "score": 43.7,
-        "success_rate": "100/100",
-        "status": "ok",
-        "cold_start_ms": null
-      },
-      "pricing": {
-        "model": "per_minute",
-        "cpu": {
-          "prepaid_rate": 0.001,
-          "overage_rate": 0.0015,
-          "unit": "unit-min",
-          "notes": "1 unit = 1 vCPU x 1 min (Linux). Windows 2x multiplier, macOS 10x multiplier.",
-          "confidence": "exact"
-        },
-        "memory": {
-          "rate": null,
-          "unit": null,
-          "bundled_with_cpu": true,
-          "confidence": "exact",
-          "notes": "Standard shape: 1 vCPU + 2 GB RAM per unit-min. Memory not separately billed."
-        },
-        "storage": {
-          "cache_volume_rate": 0.0048,
-          "cache_volume_unit": "GB-day",
-          "cache_snapshot_rate": 0.002,
-          "cache_snapshot_unit": "GB-hr",
-          "container_registry_rate": 0.2,
-          "container_registry_unit": "GB-month",
-          "confidence": "exact"
-        },
-        "egress": {
-          "rate": null,
-          "free_gb_per_month": null,
-          "confidence": "unknown",
-          "notes": "Not published. Likely included."
-        },
-        "normalized": {
-          "cpu_per_vcpu_hr": 0.06,
-          "memory_per_gib_hr": 0.02,
-          "total_1vcpu_2gb_hr": 0.06,
-          "confidence": "exact",
-          "notes": "Prepaid rate: $0.001/unit-min x 60 min. CPU+memory bundled so total = CPU rate."
-        }
-      },
-      "plans": [
-        {
-          "name": "developer",
-          "base_fee_per_month": 0,
-          "unit_minutes_included": null,
-          "docker_builds_included": null,
-          "billing": "pay_as_you_go"
-        },
-        {
-          "name": "team",
-          "base_fee_per_month": 100,
-          "unit_minutes_included": 100000,
-          "docker_builds_included": 1000
-        },
-        {
-          "name": "business",
-          "base_fee_per_month": 250,
-          "unit_minutes_included": 250000,
-          "docker_builds_included": 2500
-        },
-        {
-          "name": "enterprise",
-          "base_fee_per_month": null,
-          "unit_minutes_included": null,
-          "docker_builds_included": null
-        }
-      ],
-      "free_credits": null,
-      "isolation": "vm",
-      "notes": "Primarily a CI/CD runner platform, not a pure AI sandbox. macOS on Apple M4 Pro available. SOC2 Type II."
     },
     {
       "id": "vercel",

--- a/pricing.svg
+++ b/pricing.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="726" viewBox="0 0 1200 726">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="682" viewBox="0 0 1200 682">
   <defs>
     <linearGradient id="headerGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#f6f8fa;stop-opacity:1" />
@@ -30,7 +30,7 @@
   </style>
 
   <!-- Background -->
-  <rect class="bg" width="1200" height="726"/>
+  <rect class="bg" width="1200" height="682"/>
 
   <!-- Logo (black square with white C) -->
   <g transform="translate(24, 24)">
@@ -79,12 +79,12 @@
   <text class="row confidence-exact" x="920" y="252">exact</text>
   <line class="divider" x1="24" y1="266" x2="1176" y2="266"/>
 
-  <!-- namespace -->
-  <text class="row provider" x="40" y="296">Namespace</text>
-  <text class="row cost fast" x="200" y="296">$0.0600</text>
-  <text class="row" x="380" y="296">43.7 (100/100)</text>
-  <text class="row" x="580" y="296">Per-minute</text>
-  <text class="row value medium" x="740" y="296">55.3</text>
+  <!-- modal -->
+  <text class="row provider" x="40" y="296">Modal</text>
+  <text class="row cost fast" x="200" y="296">~$0.0661</text>
+  <text class="row" x="380" y="296">94.4 (100/100)</text>
+  <text class="row" x="580" y="296">Active CPU</text>
+  <text class="row value fast" x="740" y="296">79.5</text>
   <text class="row confidence-exact" x="920" y="296">exact</text>
   <line class="divider" x1="24" y1="310" x2="1176" y2="310"/>
 
@@ -133,29 +133,20 @@
   <text class="row confidence-exact" x="920" y="516">exact</text>
   <line class="divider" x1="24" y1="530" x2="1176" y2="530"/>
 
-  <!-- modal -->
-  <text class="row provider" x="40" y="560">Modal</text>
-  <text class="row cost medium" x="200" y="560">$0.1191</text>
-  <text class="row" x="380" y="560">94.4 (100/100)</text>
-  <text class="row" x="580" y="560">Per-second</text>
-  <text class="row value fast" x="740" y="560">61.8</text>
-  <text class="row confidence-exact" x="920" y="560">exact</text>
-  <line class="divider" x1="24" y1="574" x2="1176" y2="574"/>
-
   <!-- runloop -->
-  <text class="row provider" x="40" y="604">Runloop</text>
-  <text class="row cost slow" x="200" y="604">$0.1584</text>
-  <text class="row" x="380" y="604">82.3 (100/100)</text>
-  <text class="row" x="580" y="604">Per-second</text>
-  <text class="row value medium" x="740" y="604">41.4</text>
-  <text class="row confidence-exact" x="920" y="604">exact</text>
+  <text class="row provider" x="40" y="560">Runloop</text>
+  <text class="row cost slow" x="200" y="560">$0.1584</text>
+  <text class="row" x="380" y="560">82.3 (100/100)</text>
+  <text class="row" x="580" y="560">Per-second</text>
+  <text class="row value medium" x="740" y="560">41.4</text>
+  <text class="row confidence-exact" x="920" y="560">exact</text>
 
   <!-- Timestamp -->
-  <text class="timestamp" x="1176" y="688" text-anchor="end">Last updated: Mar 16, 2026</text>
+  <text class="timestamp" x="1176" y="644" text-anchor="end">Last updated: Mar 16, 2026</text>
 
   <!-- Footnotes -->
-  <text class="timestamp" x="24" y="688">Eff. Cost = effective cost for 1 vCPU + 2 GB RAM / hr. Active-CPU providers (~) estimated at 10% utilization. Value Score = sqrt(benchmark x cost efficiency).</text>
-  <text class="timestamp" x="24" y="702">Active-CPU billing (Vercel, Cloudflare): CPU charged only during execution, memory always wall-clock. Wall-clock providers: full rate shown.</text>
-  <text class="timestamp" x="24" y="716">Confidence: exact = official pricing page, estimated = back-calculated from bundled tier.</text>
+  <text class="timestamp" x="24" y="644">Eff. Cost = effective cost for 1 vCPU + 2 GB RAM / hr. Active-CPU providers (~) estimated at 10% utilization. Value Score = sqrt(benchmark x cost efficiency).</text>
+  <text class="timestamp" x="24" y="658">Active-CPU billing (Vercel, Cloudflare): CPU charged only during execution, memory always wall-clock. Wall-clock providers: full rate shown.</text>
+  <text class="timestamp" x="24" y="672">Confidence: exact = official pricing page, estimated = back-calculated from bundled tier.</text>
 
 </svg>

--- a/src/sandbox/generate-pricing-svg.ts
+++ b/src/sandbox/generate-pricing-svg.ts
@@ -34,6 +34,12 @@ interface PricingProvider {
       cpu_per_vcpu_hr: number;
       memory_per_gib_hr: number;
       total_1vcpu_2gb_hr: number;
+      /**
+       * Optional precomputed effective cost ($/hr for 1 vCPU + 2 GB). When set,
+       * it is used directly instead of recomputing from the rates above — e.g.
+       * Modal's active-CPU estimate respecting its 0.125 physical-core minimum.
+       */
+      effective_cost_1vcpu_2gb_hr?: number;
       confidence: string;
       notes?: string;
     };
@@ -59,11 +65,15 @@ function computeEstimatedCost(provider: PricingProvider): number | null {
 
 /**
  * Get the effective cost for a provider.
- * For active-CPU providers, uses estimated 25% CPU utilization.
- * For wall-clock providers, uses the full normalized cost.
+ * Uses a precomputed effective cost when provided, otherwise the estimated
+ * active-CPU cost (10% utilization), otherwise the full wall-clock cost.
  */
 function getEffectiveCost(provider: PricingProvider): number {
-  return computeEstimatedCost(provider) ?? provider.pricing.normalized.total_1vcpu_2gb_hr;
+  return (
+    provider.pricing.normalized.effective_cost_1vcpu_2gb_hr ??
+    computeEstimatedCost(provider) ??
+    provider.pricing.normalized.total_1vcpu_2gb_hr
+  );
 }
 
 interface PricingData {


### PR DESCRIPTION
## Summary
- Compare **Modal** as active-CPU at 10% utilization, respecting its **0.125 physical-core (0.25 vCPU) minimum** → effective cost **~\$0.0661/hr**, value **79.5** (was \$0.1191 / 61.8 under full per-second wall-clock).
- Remove the **Namespace** provider from the pricing table.
- Regenerated `pricing.svg` (rows sorted by effective cost; Modal now sits 3rd).

## How it stays current
- The generator now honors an optional `normalized.effective_cost_1vcpu_2gb_hr` and uses it directly (one field, ~4 lines) — so the conservative Modal figure survives regeneration.
- Benchmark/value numbers still refresh live from `results/sequential_tti/latest.json` on each nightly cron run; these `pricing.json` changes persist across those runs.

## Files
- `pricing.json` — drop Namespace; Modal `model: active_cpu` + `effective_cost_1vcpu_2gb_hr: 0.0661`.
- `src/sandbox/generate-pricing-svg.ts` — `getEffectiveCost` prefers the stored effective cost.
- `pricing.svg` — regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)