### PR TITLE
Bump isorun to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1254,12 +1254,11 @@
       }
     },
     "node_modules/@computesdk/isorun/node_modules/isorun": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isorun/-/isorun-1.0.0.tgz",
-      "integrity": "sha512-+6NQ8dOxgvDzltSeAtPJKYx4bH9NPywArCGi/GaTHpf/va8HAORHsSVis8okxTIOgw4GGBCFJL2NBKysMcaggA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/isorun/-/isorun-1.0.1.tgz",
+      "integrity": "sha512-9vQfaldpHn9Ta2Ld5hvN4r8br6OvCh1Zo8ooYbN5JDJqY8lyUQPdGByrP1UfwlJ1AzM/lgO03mGieMBYL15XnA==",
       "license": "MIT",
       "dependencies": {
-        "@currentspace/http3": "^0.8.5",
         "undici": "8.3.0"
       },
       "bin": {
@@ -1269,6 +1268,7 @@
         "node": ">=22.19.0"
       },
       "optionalDependencies": {
+        "@isorun/http-transport-darwin-arm64": "^0.8.8",
         "@isorun/http-transport-linux-arm64-gnu": "^0.8.8",
         "@isorun/http-transport-linux-arm64-musl": "^0.8.8",
         "@isorun/http-transport-linux-x64-gnu": "^0.8.8",
@@ -1682,74 +1682,6 @@
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
         "@connectrpc/connect": "2.0.0-rc.3"
-      }
-    },
-    "node_modules/@currentspace/http3": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@currentspace/http3/-/http3-0.8.5.tgz",
-      "integrity": "sha512-Quxr3ul3raPslOi0xS3NGMx/TkjDiChafqJ1Td3qeyQXT5tqLpFSQDqA54Ewg0YemEMB5JInFWc9dsVCKW16dw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=24.0.0"
-      },
-      "optionalDependencies": {
-        "@currentspace/http3-darwin-arm64": "0.8.5",
-        "@currentspace/http3-linux-arm64-gnu": "0.8.5",
-        "@currentspace/http3-linux-x64-gnu": "0.8.5"
-      }
-    },
-    "node_modules/@currentspace/http3-darwin-arm64": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@currentspace/http3-darwin-arm64/-/http3-darwin-arm64-0.8.5.tgz",
-      "integrity": "sha512-8ocdwlTfqZp0awQUlv5kB9C3Q7C1iZagtNpv+TzQpQph1ZWu1K5iS209IjR2EIAGs6V1WIczjc8slZCUB97RuQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=24.0.0"
-      }
-    },
-    "node_modules/@currentspace/http3-linux-arm64-gnu": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@currentspace/http3-linux-arm64-gnu/-/http3-linux-arm64-gnu-0.8.5.tgz",
-      "integrity": "sha512-cNbSWE2EwY/yfpnj7qtgXpIC9AkFh28ACc7xygnKE0ayIvRweoLsP+GMtgwGVUWAxDB1vf6X8PMXxZYKmWqI0A==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=24.0.0"
-      }
-    },
-    "node_modules/@currentspace/http3-linux-x64-gnu": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@currentspace/http3-linux-x64-gnu/-/http3-linux-x64-gnu-0.8.5.tgz",
-      "integrity": "sha512-pENtrt3EVG3O5ktGci2hoNJmIIOokuUVDYzhs/6teMcNFSUqWTHIm7VGfJajj67iUgRzWeRYjVv3/Y0lcinNqA==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=24.0.0"
       }
     },
     "node_modules/@daytonaio/api-client": {
@@ -2566,6 +2498,19 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@isorun/http-transport-darwin-arm64": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@isorun/http-transport-darwin-arm64/-/http-transport-darwin-arm64-0.8.8.tgz",
+      "integrity": "sha512-IJ55O6u1KGlYlRDpl/p+kPzIlu/aP1Jp24Q4Yl/pl6XfiFwNoNS3HN7WcpkTLlgtBjATHN5Iw74wxuKAP5bVQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@isorun/http-transport-linux-arm64-gnu": {
       "version": "0.8.8",


### PR DESCRIPTION
Refreshes the lockfile for isorun SDK to bump it to `1.0.1`.