### PR TITLE
fix(browser): stabilize throughput benchmark sampling

### DIFF
--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -15,7 +15,7 @@ on:
       iterations:
         description: 'Iterations per provider (sessions)'
         required: false
-        default: '10'
+        default: '100'
 
 concurrency:
   group: browser-throughput-benchmarks
@@ -64,7 +64,7 @@ jobs:
           npm run bench -- \
             --mode browser-throughput \
             --provider ${{ matrix.provider }} \
-            --iterations ${{ github.event_name == 'pull_request' && '3' || github.event.inputs.iterations || '10' }}
+            --iterations ${{ github.event_name == 'pull_request' && '3' || github.event.inputs.iterations || '100' }}
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4

--- a/THROUGHPUT.md
+++ b/THROUGHPUT.md
@@ -22,7 +22,7 @@ This benchmark closes that gap.
 
 ## What gets measured
 
-For each provider, the benchmark runs **N sessions** (default 10, configurable). Each session executes a fixed sequence of **50 sequential actions** end-to-end inside one running browser. We record, in order:
+For each provider, the benchmark runs **N sessions** (default 100, configurable). Each session executes a fixed sequence of **50 sequential actions** end-to-end inside one running browser. We record, in order:
 
 - Session creation time (`createMs`)
 - CDP connection time (`connectMs`)
@@ -111,6 +111,7 @@ A few deliberate choices in `runThroughputIteration`:
 - **The action index is recorded.** With 50 ordered actions per session, downstream analysis can detect if late-session actions are systematically slower than early-session ones — a useful signal for memory leaks or resource exhaustion in long-running sessions.
 - **Action timeout is 30 seconds**, applied per-action via `withTimeout`. A single slow action can't hang an entire run, and the timeout lands well above any reasonable real action duration.
 - **`page.goBack` uses `waitUntil: 'commit'`** rather than the Playwright default of `'load'`, because browsers restoring a page from the back-forward cache fire `pageshow` instead of `load` — `'load'` would hang for the full timeout on every bfcache restore. The next `waitForSelector` confirms arrival on the previous page.
+- **All-provider local runs are interleaved.** When running every throughput provider from the CLI, the runner executes one session per provider per round. This reduces time-of-run network bias compared with completing all sessions for one provider before starting the next. CI already runs providers in separate matrix jobs.
 
 ## Scoring
 
@@ -151,7 +152,7 @@ The full per-action distribution is preserved in the JSON output, so anyone who 
 # Single provider, single session — useful for development
 npm run bench:browser-throughput:browserbase -- --iterations 1
 
-# All four providers, default 10 sessions each
+# All four providers, default 100 sessions each
 npm run bench:browser-throughput
 
 # Specific provider with custom iteration count
@@ -179,7 +180,7 @@ npm run generate-browser-throughput-svg
 
 ## Scheduling
 
-The GitHub Actions workflow `browser-throughput-benchmarks.yml` runs daily at 03:00 UTC (offset from the lifecycle browser benchmark at 00:00) with 10 iterations per provider. Pull requests touching browser code run a faster 3-iteration version and post a comparison table as a PR comment.
+The GitHub Actions workflow `browser-throughput-benchmarks.yml` runs daily at 03:00 UTC (offset from the lifecycle browser benchmark at 00:00) with 100 iterations per provider. Pull requests touching browser code run a faster 3-iteration version and post a comparison table as a PR comment.
 
 ## Limitations
 

--- a/src/browser/throughput-benchmark.ts
+++ b/src/browser/throughput-benchmark.ts
@@ -140,7 +140,7 @@ async function runActionLoop(page: Page, results: ActionResult[]): Promise<void>
   }
 }
 
-async function runThroughputIteration(
+export async function runThroughputIteration(
   provider: any,
   timeout: number,
   sessionCreateOptions: Record<string, unknown>,
@@ -222,7 +222,7 @@ async function runThroughputIteration(
   };
 }
 
-function summarizeIterations(iterations: ThroughputTimingResult[]): ThroughputStats {
+export function summarizeIterations(iterations: ThroughputTimingResult[]): ThroughputStats {
   const createValues = iterations.map(i => i.createMs).filter(v => v > 0);
   const taskValues = iterations.map(i => i.taskMs).filter(v => v > 0);
   const totalValues = iterations.map(i => i.totalMs).filter(v => v > 0);
@@ -248,7 +248,7 @@ function summarizeIterations(iterations: ThroughputTimingResult[]): ThroughputSt
   };
 }
 
-function emptySummary(): ThroughputStats {
+export function emptySummary(): ThroughputStats {
   const empty: ThroughputStatsTriple = { median: 0, p95: 0, p99: 0 };
   const perActionType = {} as Record<ActionType, ThroughputStatsTriple>;
   for (const t of ACTION_TYPES) perActionType[t] = { ...empty };
@@ -266,7 +266,7 @@ export async function runThroughputBenchmark(
 ): Promise<ThroughputBenchmarkResult> {
   const {
     name,
-    iterations = 10,
+    iterations = 100,
     timeout = 120_000,
     requiredEnvVars,
     sessionCreateOptions = {},

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,7 +9,13 @@ import { runConcurrentBenchmark } from './sandbox/concurrent.js';
 import { runStaggeredBenchmark } from './sandbox/staggered.js';
 import { runStorageBenchmark, writeStorageResultsJson } from './storage/benchmark.js';
 import { runBrowserBenchmark, writeBrowserResultsJson } from './browser/benchmark.js';
-import { runThroughputBenchmark, writeThroughputResultsJson } from './browser/throughput-benchmark.js';
+import {
+  emptySummary,
+  runThroughputBenchmark,
+  runThroughputIteration,
+  summarizeIterations,
+  writeThroughputResultsJson,
+} from './browser/throughput-benchmark.js';
 import { printResultsTable, writeResultsJson } from './sandbox/table.js';
 import { providers } from './sandbox/providers.js';
 import { storageProviders } from './storage/providers.js';
@@ -22,7 +28,7 @@ import { computeThroughputCompositeScores } from './browser/throughput-scoring.j
 import type { BenchmarkResult, BenchmarkMode } from './sandbox/types.js';
 import type { StorageBenchmarkResult } from './storage/types.js';
 import type { BrowserBenchmarkResult } from './browser/types.js';
-import type { ThroughputBenchmarkResult } from './browser/throughput-types.js';
+import type { ThroughputBenchmarkResult, ThroughputTimingResult } from './browser/throughput-types.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -227,26 +233,92 @@ async function runBrowser(toRun: typeof browserProviders): Promise<void> {
 }
 
 async function runBrowserThroughput(toRun: typeof throughputProviders): Promise<void> {
-  // Throughput sessions are ~12s each, so we use a much lower default than
-  // the global iterations CLI value. Only override when --iterations was
-  // explicitly passed; otherwise let runThroughputBenchmark apply its own
-  // default (10 sessions per provider).
+  // Only override when --iterations was explicitly passed; otherwise let
+  // runThroughputBenchmark apply its own default (100 sessions per provider).
   const throughputIterations = iterationsArg ? iterations : undefined;
+  const iterationsToRun = throughputIterations ?? 100;
 
   console.log('\n' + '='.repeat(70));
   console.log('  MODE: BROWSER THROUGHPUT');
-  console.log(`  Iterations per provider: ${throughputIterations ?? 10}`);
+  console.log(`  Iterations per provider: ${iterationsToRun}`);
   console.log('='.repeat(70));
 
   const results: ThroughputBenchmarkResult[] = [];
 
-  for (const providerConfig of toRun) {
-    const result = await runThroughputBenchmark(
-      throughputIterations !== undefined
-        ? { ...providerConfig, iterations: throughputIterations }
-        : providerConfig,
-    );
-    results.push(result);
+  if (providerFilter || toRun.length === 1) {
+    for (const providerConfig of toRun) {
+      const result = await runThroughputBenchmark(
+        throughputIterations !== undefined
+          ? { ...providerConfig, iterations: throughputIterations }
+          : providerConfig,
+      );
+      results.push(result);
+    }
+  } else {
+    const resultByProvider = new Map<string, ThroughputBenchmarkResult>();
+    const active: Array<{
+      name: string;
+      provider: any;
+      timeout: number;
+      sessionCreateOptions: Record<string, unknown>;
+      iterations: ThroughputTimingResult[];
+    }> = [];
+
+    for (const providerConfig of toRun) {
+      const missingVars = providerConfig.requiredEnvVars.filter(v => !process.env[v]);
+      if (missingVars.length > 0) {
+        resultByProvider.set(providerConfig.name, {
+          provider: providerConfig.name,
+          mode: 'browser-throughput',
+          iterations: [],
+          summary: emptySummary(),
+          skipped: true,
+          skipReason: `Missing: ${missingVars.join(', ')}`,
+        });
+        continue;
+      }
+
+      active.push({
+        name: providerConfig.name,
+        provider: providerConfig.createBrowserProvider(),
+        timeout: providerConfig.timeout ?? 120_000,
+        sessionCreateOptions: providerConfig.sessionCreateOptions ?? {},
+        iterations: [],
+      });
+    }
+
+    console.log(`\n--- Interleaved Throughput Benchmark (${iterationsToRun} rounds × ${active.length} providers) ---`);
+    console.log('Provider      Sess  Create   Connect  Task     Release  Total    APS    Actions');
+    console.log('────────────  ────  ───────  ───────  ───────  ───────  ───────  ─────  ───────');
+
+    for (let i = 0; i < iterationsToRun; i++) {
+      for (const state of active) {
+        const result = await runThroughputIteration(state.provider, state.timeout, state.sessionCreateOptions);
+        state.iterations.push(result);
+
+        const pad = (n: number) => `${Math.round(n)}ms`.padStart(7);
+        const aps = result.actionsPerSecond.toFixed(1).padStart(5);
+        const status = `${result.actionsCompleted}/50`;
+        const errSuffix = result.error ? `  ✗ ${result.error.slice(0, 50)}` : '';
+        console.log(
+          `${state.name.padEnd(12)}  ${String(i + 1).padStart(4)}  ${pad(result.createMs)}  ${pad(result.connectMs)}  ${pad(result.taskMs)}  ${pad(result.releaseMs)}  ${pad(result.totalMs)}  ${aps}  ${status}${errSuffix}`,
+        );
+      }
+    }
+
+    for (const state of active) {
+      resultByProvider.set(state.name, {
+        provider: state.name,
+        mode: 'browser-throughput',
+        iterations: state.iterations,
+        summary: summarizeIterations(state.iterations),
+      });
+    }
+
+    for (const providerConfig of toRun) {
+      const result = resultByProvider.get(providerConfig.name);
+      if (result) results.push(result);
+    }
   }
 
   // Compute composite scores


### PR DESCRIPTION
## Summary
- increase browser throughput benchmark defaults from 10 to 100 iterations per provider
- keep PR throughput runs at 3 iterations for faster CI feedback
- interleave local all-provider throughput runs round-by-round to reduce time-of-run network bias
- update throughput benchmark docs to match the new behavior

## Testing
- Not run: local `npm run bench:browser-throughput -- --iterations 0` is blocked by `tsx: Permission denied` in this worktree
- Not run: `npx tsc --noEmit` because TypeScript is not installed in this repo