### PR TITLE
Fix Archil disk id create option

### DIFF
--- a/src/sandbox/providers.ts
+++ b/src/sandbox/providers.ts
@@ -32,7 +32,7 @@ export const providers: ProviderConfig[] = [
     name: 'archil',
     requiredEnvVars: ['ARCHIL_API_KEY', 'ARCHIL_REGION', 'ARCHIL_DISK_ID'],
     createCompute: () => archil({ apiKey: process.env.ARCHIL_API_KEY!, region: process.env.ARCHIL_REGION! }),
-    sandboxOptions: { metadata: { diskId: process.env.ARCHIL_DISK_ID! } }
+    sandboxOptions: { diskId: process.env.ARCHIL_DISK_ID! }
   },
   {
     name: 'blaxel',


### PR DESCRIPTION
## Summary
- pass Archil diskId as a top-level sandbox create option
- matches the new @computesdk/archil create() requirement after the version bump

## Verification
- ARCHIL_API_KEY=test ARCHIL_REGION=aws-us-east-1 ARCHIL_DISK_ID=disk_test node --input-type=module -e "import { providers } from './src/sandbox/providers.ts'; const archil = providers.find((provider) => provider.name === 'archil'); if (archil?.sandboxOptions?.diskId !== 'disk_test') throw new Error('Archil diskId is not top-level'); console.log(JSON.stringify(archil.sandboxOptions));"

Note: npx tsc --noEmit currently fails on master due to existing top-level await errors in src/scale/scripts/*.ts with the current tsconfig module target.