### PR TITLE
feat: activate cloud-run provider in sandbox benchmarks

### DIFF
--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -51,7 +51,7 @@ jobs:
           - archil
           - beam
           - blaxel
-          # - cloud-run
+          - cloud-run
           - cloudflare
           - codesandbox
           # - collimate
@@ -96,8 +96,8 @@ jobs:
           ARCHIL_DISK_ID: ${{ secrets.ARCHIL_DISK_ID }}
           BEAM_TOKEN: ${{ secrets.BEAM_TOKEN }}
           BEAM_WORKSPACE_ID: ${{ secrets.BEAM_WORKSPACE_ID }}
-          # CLOUD_RUN_SANDBOX_URL: ${{ secrets.CLOUD_RUN_SANDBOX_URL }}
-          # CLOUD_RUN_SANDBOX_SECRET: ${{ secrets.CLOUD_RUN_SANDBOX_SECRET }}
+          CLOUD_RUN_SANDBOX_URL: ${{ secrets.CLOUD_RUN_SANDBOX_URL }}
+          CLOUD_RUN_SANDBOX_SECRET: ${{ secrets.CLOUD_RUN_SANDBOX_SECRET }}
           BL_API_KEY: ${{ secrets.BL_API_KEY }}
           BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
           CLOUDFLARE_SANDBOX_URL: ${{ secrets.CLOUDFLARE_SANDBOX_URL }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@computesdk/blaxel": "^1.6.16",
         "@computesdk/browserbase": "^0.3.8",
         "@computesdk/browseruse": "^0.2.6",
-        "@computesdk/cloud-run": "^0.1.1",
+        "@computesdk/cloud-run": "^0.1.4",
         "@computesdk/cloudflare": "^1.6.13",
         "@computesdk/codesandbox": "^1.5.50",
         "@computesdk/collimate": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@computesdk/blaxel": "^1.6.16",
     "@computesdk/browserbase": "^0.3.8",
     "@computesdk/browseruse": "^0.2.6",
-    "@computesdk/cloud-run": "^0.1.1",
+    "@computesdk/cloud-run": "^0.1.4",
     "@computesdk/cloudflare": "^1.6.13",
     "@computesdk/codesandbox": "^1.5.50",
     "@computesdk/collimate": "^0.1.0",

--- a/src/sandbox/providers.ts
+++ b/src/sandbox/providers.ts
@@ -2,7 +2,7 @@ import { archil } from '@computesdk/archil';
 import { beam } from '@computesdk/beam';
 import { blaxel } from '@computesdk/blaxel';
 import { codesandbox } from '@computesdk/codesandbox';
-// import { cloudRun } from '@computesdk/cloud-run';
+import { cloudRun } from '@computesdk/cloud-run';
 // import { collimate } from '@computesdk/collimate';
 import { cloudflare } from '@computesdk/cloudflare';
 import { createosSandbox } from '@computesdk/createos-sandbox';
@@ -52,11 +52,11 @@ export const providers: ProviderConfig[] = [
     requiredEnvVars: ['BL_API_KEY', 'BL_WORKSPACE'],
     createCompute: () => blaxel({ apiKey: process.env.BL_API_KEY!, workspace: process.env.BL_WORKSPACE!, region: 'us-was-1' }),
   },
-  // {
-  //   name: 'cloud-run',
-  //   requiredEnvVars: ['CLOUD_RUN_SANDBOX_URL', 'CLOUD_RUN_SANDBOX_SECRET'],
-  //   createCompute: () => cloudRun({ sandboxUrl: process.env.CLOUD_RUN_SANDBOX_URL!, sandboxSecret: process.env.CLOUD_RUN_SANDBOX_SECRET! }),
-  // },
+  {
+    name: 'cloud-run',
+    requiredEnvVars: ['CLOUD_RUN_SANDBOX_URL', 'CLOUD_RUN_SANDBOX_SECRET'],
+    createCompute: () => cloudRun({ sandboxUrl: process.env.CLOUD_RUN_SANDBOX_URL!, sandboxSecret: process.env.CLOUD_RUN_SANDBOX_SECRET! }),
+  },
   {
     name: 'cloudflare',
     requiredEnvVars: ['CLOUDFLARE_SANDBOX_URL', 'CLOUDFLARE_SANDBOX_SECRET'],


### PR DESCRIPTION
Activates the Cloud Run provider for sandbox benchmarks now that the gateway is deployed and secrets are configured.

Changes:
- Uncommented `cloudRun` import and provider entry in `src/sandbox/providers.ts`
- Added `cloud-run` to the benchmark matrix in `.github/workflows/sandbox-benchmarks.yml`
- Uncommented `CLOUD_RUN_SANDBOX_URL` and `CLOUD_RUN_SANDBOX_SECRET` env vars in the workflow

Gateway deployed to `main-498812` in `us-east4` (Virginia). Secrets added to GitHub repo.