### PR TITLE
Run Browser Use sessions proxyless

### DIFF
--- a/src/browser/providers.ts
+++ b/src/browser/providers.ts
@@ -27,6 +27,7 @@ export const browserProviders: BrowserProviderConfig[] = [
     createBrowserProvider: () => browseruse({
       apiKey: process.env.BROWSER_USE_API_KEY!
     }),
+    sessionCreateOptions: { proxies: false },
   },
   {
     name: 'hyperbrowser',

--- a/src/browser/throughput-providers.ts
+++ b/src/browser/throughput-providers.ts
@@ -40,6 +40,7 @@ export const throughputProviders: ThroughputProviderConfig[] = [
       stealth: true,
       headless: true,
       viewport: VIEWPORT,
+      proxies: false,
     },
   },
   {


### PR DESCRIPTION
Browser Use sessions were being created with the provider's default proxy configuration, while the other providers in the suite run without a proxy. This sets `proxies: false` on the Browser Use session options (mapped to `proxyCountryCode: null` by `@computesdk/browseruse`) in both the browser and throughput configs, so all providers are benchmarked under the same network conditions.