### PR TITLE
fix(browser-throughput): match Parsoid article links

### DIFF
--- a/src/browser/throughput-benchmark.ts
+++ b/src/browser/throughput-benchmark.ts
@@ -13,7 +13,10 @@ import {
 
 const RANDOM_URL = 'https://en.wikipedia.org/wiki/Special:Random';
 const FIRST_HEADING = '#firstHeading';
-const ARTICLE_LINK = '#mw-content-text a[href^="/wiki/"]:not([href*=":"])';
+// Match article-body links across both classic MediaWiki HTML (relative "/wiki/Foo")
+// and Parsoid read-HTML (protocol-relative absolute "//en.wikipedia.org/wiki/Foo").
+// :not([href*=":"]) still excludes namespace pages (Help:, File:) and external http(s) links.
+const ARTICLE_LINK = '#mw-content-text a[href*="/wiki/"]:not([href*=":"])';
 const LOOPS_PER_SESSION = 5;
 const ACTIONS_PER_LOOP = 10;
 const ACTIONS_PER_SESSION = LOOPS_PER_SESSION * ACTIONS_PER_LOOP; // 50


### PR DESCRIPTION
## Problem

The browser-throughput benchmark's "click first article link" step uses:

```ts
const ARTICLE_LINK = '#mw-content-text a[href^="/wiki/"]:not([href*=":"])';
```

This matches **zero** links on current Wikipedia. Wikipedia now serves **Parsoid** read-HTML, whose in-article links are **protocol-relative absolute** URLs (`//en.wikipedia.org/wiki/Foo`, `rel="mw:WikiLink"`) rather than relative `/wiki/Foo`. So the `href^="/wiki/"` (starts-with) selector never matches an article-body link.

Consequences per session: the click's `waitForSelector` times out (10s), the follow-on `#firstHeading` waits then time out (30s), only ~40–46/50 actions complete, and APS collapses to noise.

## Fix

One line: `href^=` (starts-with) → `href*=` (contains). It matches **both** classic (`/wiki/Foo`) and Parsoid (`//…/wiki/Foo`) links, and `:not([href*=":"])` still excludes namespace pages (`Help:`, `File:`) and external `http(s):` links (protocol-relative `//` links contain no colon).

## Evidence (measured against Browserbase prod, 3 iterations each)

| selector | APS (median) | spread | actions | task time |
|---|---|---|---|---|
| `href^=` (current) | **0.64** | erratic 0.2–0.7 | 40–46 / 50 | 70s–207s |
| `href*=` (this PR) | **3.49** | stable 2.7–3.8 | **50 / 50** | ~14s |

## Verification of the DOM

On current article pages, `#mw-content-text a[rel~="mw:WikiLink"]` finds ~1400 links with `href="//en.wikipedia.org/wiki/..."`; `#mw-content-text a[href^="/wiki/"]` finds 0. The `href*="/wiki/"` selector matches the real article links in both HTML variants.