### PR TITLE
fix(browser-throughput): match Parsoid article links

### DIFF
--- a/src/browser/throughput-benchmark.ts
+++ b/src/browser/throughput-benchmark.ts
@@ -13,7 +13,10 @@ import {
 
 const RANDOM_URL = 'https://en.wikipedia.org/wiki/Special:Random';
 const FIRST_HEADING = '#firstHeading';
-const ARTICLE_LINK = '#mw-content-text a[href^="/wiki/"]:not([href*=":"])';
+// Match article-body links across both classic MediaWiki HTML (relative "/wiki/Foo")
+// and Parsoid read-HTML (protocol-relative absolute "//en.wikipedia.org/wiki/Foo").
+// :not([href*=":"]) still excludes namespace pages (Help:, File:) and external http(s) links.
+const ARTICLE_LINK = '#mw-content-text a[href*="/wiki/"]:not([href*=":"])';
 const LOOPS_PER_SESSION = 5;
 const ACTIONS_PER_LOOP = 10;
 const ACTIONS_PER_SESSION = LOOPS_PER_SESSION * ACTIONS_PER_LOOP; // 50


### PR DESCRIPTION
## Problem

The browser-throughput benchmark's click-first-article-link step currently uses a selector that only matches relative Wikipedia links:

```ts
const ARTICLE_LINK = '#mw-content-text a[href^="/wiki/"]:not([href*=":"])';
```

Current Wikipedia article pages can serve Parsoid read-HTML where article links are protocol-relative absolute URLs such as `//en.wikipedia.org/wiki/Foo`. That makes the existing `href^="/wiki/"` selector miss article-body links and causes repeated action timeouts.

## Fix

Use `href*="/wiki/"` so the benchmark matches both relative `/wiki/Foo` links and protocol-relative `//en.wikipedia.org/wiki/Foo` links. The existing `:not([href*=":"])` filter still excludes namespace pages and external `http(s)` links.

Replaces #166.