### PR TITLE
chore: implement 1 loop per session on daily + remove hardcoded counts

### DIFF
--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -135,6 +135,7 @@ jobs:
               body += '> No browser-throughput benchmark results were generated.\n\n';
             } else {
               const data = JSON.parse(fs.readFileSync(latestPath, 'utf-8'));
+              const expectedActions = data.config?.actionsPerSession ?? 0;
               const results = data.results
                 .filter(r => !r.skipped)
                 .sort((a, b) => (b.compositeScore || 0) - (a.compositeScore || 0));
@@ -152,7 +153,6 @@ jobs:
                   const taskMed = (r.summary.taskMs.median / 1000).toFixed(2) + 's';
                   const taskP95 = (r.summary.taskMs.p95 / 1000).toFixed(2) + 's';
                   const screenshotMed = Math.round(r.summary.perActionType.screenshot?.median || 0) + 'ms';
-                  const expectedActions = 50;
                   const ok = r.iterations.filter(it => !it.error && it.actionsCompleted === expectedActions).length;
                   const count = r.iterations.length;
                   body += `| ${i + 1} | ${name} | ${score} | ${aps} | ${taskMed} | ${taskP95} | ${screenshotMed} | ${ok}/${count} |\n`;

--- a/src/browser/throughput-benchmark.ts
+++ b/src/browser/throughput-benchmark.ts
@@ -17,8 +17,8 @@ const FIRST_HEADING = '#firstHeading';
 // and Parsoid read-HTML (protocol-relative absolute "//en.wikipedia.org/wiki/Foo").
 // :not([href*=":"]) still excludes namespace pages (Help:, File:) and external http(s) links.
 const ARTICLE_LINK = '#mw-content-text a[href*="/wiki/"]:not([href*=":"])';
-const LOOPS_PER_SESSION = 5;
-const ACTIONS_PER_LOOP = 10;
+const LOOPS_PER_SESSION = 1;
+const ACTIONS_PER_LOOP = 10; // fixed to match num of actions defined in benchmark
 const ACTIONS_PER_SESSION = LOOPS_PER_SESSION * ACTIONS_PER_LOOP; // 50
 
 const ACTION_TIMEOUT_MS = 30_000;

--- a/src/browser/throughput-benchmark.ts
+++ b/src/browser/throughput-benchmark.ts
@@ -2,6 +2,9 @@ import { chromium, type Browser, type Page } from 'playwright-core';
 import { withTimeout } from '../util/timeout.js';
 import {
   ACTION_TYPES,
+  ACTIONS_PER_LOOP,
+  ACTIONS_PER_SESSION,
+  LOOPS_PER_SESSION,
   type ActionResult,
   type ActionType,
   type ThroughputBenchmarkResult,
@@ -17,9 +20,6 @@ const FIRST_HEADING = '#firstHeading';
 // and Parsoid read-HTML (protocol-relative absolute "//en.wikipedia.org/wiki/Foo").
 // :not([href*=":"]) still excludes namespace pages (Help:, File:) and external http(s) links.
 const ARTICLE_LINK = '#mw-content-text a[href*="/wiki/"]:not([href*=":"])';
-const LOOPS_PER_SESSION = 1;
-const ACTIONS_PER_LOOP = 10; // fixed to match num of actions defined in benchmark
-const ACTIONS_PER_SESSION = LOOPS_PER_SESSION * ACTIONS_PER_LOOP; // 50
 
 const ACTION_TIMEOUT_MS = 30_000;
 

--- a/src/browser/throughput-scoring.ts
+++ b/src/browser/throughput-scoring.ts
@@ -1,4 +1,4 @@
-import type { ThroughputBenchmarkResult } from './throughput-types.js';
+import { ACTIONS_PER_SESSION, type ThroughputBenchmarkResult } from './throughput-types.js';
 
 export interface ThroughputScoringWeights {
   apsMedian: number;
@@ -33,14 +33,13 @@ function scoreLatency(valueMs: number): number {
  * Compute the success rate for a throughput benchmark result (0 to 1).
  *
  * A session counts as successful iff it ran end-to-end without an iteration
- * error AND completed all 50 actions. Partial completions still contribute
- * timing data but are not counted as full successes.
+ * error AND completed all ACTIONS_PER_SESSION actions. Partial completions
+ * still contribute timing data but are not counted as full successes.
  */
 export function computeThroughputSuccessRate(result: ThroughputBenchmarkResult): number {
   if (result.skipped || result.iterations.length === 0) return 0;
-  const expectedActions = 50;
   const fullySuccessful = result.iterations.filter(
-    i => !i.error && i.actionsCompleted === expectedActions,
+    i => !i.error && i.actionsCompleted === ACTIONS_PER_SESSION,
   ).length;
   return fullySuccessful / result.iterations.length;
 }

--- a/src/browser/throughput-types.ts
+++ b/src/browser/throughput-types.ts
@@ -1,3 +1,10 @@
+/** How many times the fixed action loop repeats within a single session. */
+export const LOOPS_PER_SESSION = 1;
+/** Number of discrete actions in one loop (fixed to the actions defined in the benchmark). */
+export const ACTIONS_PER_LOOP = 10;
+/** Total actions a session runs end-to-end. A "full success" completes exactly this many. */
+export const ACTIONS_PER_SESSION = LOOPS_PER_SESSION * ACTIONS_PER_LOOP;
+
 export type ActionType = 'navigate' | 'waitForSelector' | 'screenshot' | 'textContent' | 'click' | 'goBack';
 
 export const ACTION_TYPES: ActionType[] = [


### PR DESCRIPTION
This pull request refactors how the browser throughput benchmark code defines and uses constants for session and action counts. Instead of hardcoding values like 50 actions per session, the code now centralizes these values as exported constants in `throughput-types.ts`, making the configuration more maintainable and consistent across the codebase. The changes also update all relevant files to use these constants.

**Centralization and configuration of action/session constants:**

* Introduced `LOOPS_PER_SESSION`, `ACTIONS_PER_LOOP`, and `ACTIONS_PER_SESSION` as exported constants in `src/browser/throughput-types.ts`, replacing hardcoded values throughout the codebase. (`[src/browser/throughput-types.tsR1-R7](diffhunk://#diff-facc34fb83ecb890fbaf4ba45a69ae5df2c9bf9cf7306b9175edd2b5306d6b00R1-R7)`)
* Updated `src/browser/throughput-benchmark.ts` to import and use the new constants, removing local definitions. (`[[1]](diffhunk://#diff-368ced7742a6159950272243e47ed86bbe7e49a78eaedb77f642c567fc2cd48bR5-R7)`, `[[2]](diffhunk://#diff-368ced7742a6159950272243e47ed86bbe7e49a78eaedb77f642c567fc2cd48bL20-L22)`)
* Updated `src/browser/throughput-scoring.ts` to import and use `ACTIONS_PER_SESSION` instead of hardcoded values, ensuring scoring logic always matches the current configuration. (`[[1]](diffhunk://#diff-a26d879e1d43765994b290d04df3a3e67be99f27138f3536786fce2ad21c7d86L1-R1)`, `[[2]](diffhunk://#diff-a26d879e1d43765994b290d04df3a3e67be99f27138f3536786fce2ad21c7d86L36-R42)`)

**Workflow reporting consistency:**

* Modified `.github/workflows/browser-throughput-benchmarks.yml` to use the dynamically determined `expectedActions` from the benchmark result config, ensuring the workflow output always matches the actual benchmark configuration. (`[[1]](diffhunk://#diff-505445e9d00507b583eadcf3fbfae264406f0d793ae35d5625e915bcc2fce151R138)`, `[[2]](diffhunk://#diff-505445e9d00507b583eadcf3fbfae264406f0d793ae35d5625e915bcc2fce151L155)`)