### PR TITLE
fix(browser-throughput): use ACTIONS_PER_SESSION instead of hardcoded 50 in SVG

### DIFF
--- a/browser-throughput.svg
+++ b/browser-throughput.svg
@@ -40,7 +40,7 @@
 
   <!-- Title -->
   <text class="title" x="100" y="55">Browser Step Throughput Benchmarks</text>
-  <text class="subtitle" x="100" y="78">50-action Wikipedia loop per session — agent-style sequential actions</text>
+  <text class="subtitle" x="100" y="78">10-action Wikipedia loop per session — agent-style sequential actions</text>
 
   <!-- Sponsors -->
   <text font-size="11" font-family="Inter, SF Pro Display, sans-serif" fill="#8c959f" x="982" y="36" text-anchor="middle" letter-spacing="1">SPONSORED BY</text>
@@ -68,83 +68,83 @@
   <text class="rank rank-1" x="40" y="208">1</text>
   <text class="row provider" x="80" y="208">Browseruse</text>
   <text class="row total" x="240" y="208">68.7</text>
-  <text class="row total slow" x="360" y="208">--</text>
-  <text class="row" x="500" y="208">--</text>
-  <text class="row" x="640" y="208">--</text>
-  <text class="row" x="780" y="208">--</text>
-  <text class="row" x="920" y="208">--</text>
-  <text class="row" x="1040" y="208">--</text>
-  <text class="row status" x="1180" y="208">0/100</text>
+  <text class="row total medium" x="360" y="208">3.45/s</text>
+  <text class="row" x="500" y="208">2.89s</text>
+  <text class="row" x="640" y="208">3.77s</text>
+  <text class="row" x="780" y="208">296ms</text>
+  <text class="row" x="920" y="208">0.57s</text>
+  <text class="row" x="1040" y="208">3.70s</text>
+  <text class="row status" x="1180" y="208">100/100</text>
   <line class="divider" x1="24" y1="222" x2="1256" y2="222"/>
 
   <!-- Row 2 -->
   <text class="rank rank-2" x="40" y="252">2</text>
   <text class="row provider" x="80" y="252">Kernel</text>
   <text class="row total" x="240" y="252">65.0</text>
-  <text class="row total slow" x="360" y="252">--</text>
-  <text class="row" x="500" y="252">--</text>
-  <text class="row" x="640" y="252">--</text>
-  <text class="row" x="780" y="252">--</text>
-  <text class="row" x="920" y="252">--</text>
-  <text class="row" x="1040" y="252">--</text>
-  <text class="row status" x="1180" y="252">0/100</text>
+  <text class="row total medium" x="360" y="252">2.87/s</text>
+  <text class="row" x="500" y="252">3.48s</text>
+  <text class="row" x="640" y="252">5.03s</text>
+  <text class="row" x="780" y="252">365ms</text>
+  <text class="row" x="920" y="252">0.26s</text>
+  <text class="row" x="1040" y="252">4.11s</text>
+  <text class="row status" x="1180" y="252">100/100</text>
   <line class="divider" x1="24" y1="266" x2="1256" y2="266"/>
 
   <!-- Row 3 -->
   <text class="rank rank-3" x="40" y="296">3</text>
   <text class="row provider" x="80" y="296">Browserbase</text>
   <text class="row total" x="240" y="296">64.5</text>
-  <text class="row total slow" x="360" y="296">--</text>
-  <text class="row" x="500" y="296">--</text>
-  <text class="row" x="640" y="296">--</text>
-  <text class="row" x="780" y="296">--</text>
-  <text class="row" x="920" y="296">--</text>
-  <text class="row" x="1040" y="296">--</text>
-  <text class="row status" x="1180" y="296">0/100</text>
+  <text class="row total medium" x="360" y="296">2.73/s</text>
+  <text class="row" x="500" y="296">3.67s</text>
+  <text class="row" x="640" y="296">4.82s</text>
+  <text class="row" x="780" y="296">248ms</text>
+  <text class="row" x="920" y="296">0.23s</text>
+  <text class="row" x="1040" y="296">4.23s</text>
+  <text class="row status" x="1180" y="296">100/100</text>
   <line class="divider" x1="24" y1="310" x2="1256" y2="310"/>
 
   <!-- Row 4 -->
   <text class="rank" x="40" y="340">4</text>
   <text class="row provider" x="80" y="340">Hyperbrowser</text>
   <text class="row total" x="240" y="340">63.8</text>
-  <text class="row total slow" x="360" y="340">--</text>
-  <text class="row" x="500" y="340">--</text>
-  <text class="row" x="640" y="340">--</text>
-  <text class="row" x="780" y="340">--</text>
-  <text class="row" x="920" y="340">--</text>
-  <text class="row" x="1040" y="340">--</text>
-  <text class="row status" x="1180" y="340">0/100</text>
+  <text class="row total medium" x="360" y="340">2.71/s</text>
+  <text class="row" x="500" y="340">3.69s</text>
+  <text class="row" x="640" y="340">5.56s</text>
+  <text class="row" x="780" y="340">452ms</text>
+  <text class="row" x="920" y="340">0.32s</text>
+  <text class="row" x="1040" y="340">4.30s</text>
+  <text class="row status" x="1180" y="340">100/100</text>
   <line class="divider" x1="24" y1="354" x2="1256" y2="354"/>
 
   <!-- Row 5 -->
   <text class="rank" x="40" y="384">5</text>
   <text class="row provider" x="80" y="384">Steel</text>
   <text class="row total" x="240" y="384">57.9</text>
-  <text class="row total slow" x="360" y="384">--</text>
-  <text class="row" x="500" y="384">--</text>
-  <text class="row" x="640" y="384">--</text>
-  <text class="row" x="780" y="384">--</text>
-  <text class="row" x="920" y="384">--</text>
-  <text class="row" x="1040" y="384">--</text>
-  <text class="row status" x="1180" y="384">0/100</text>
+  <text class="row total slow" x="360" y="384">1.86/s</text>
+  <text class="row" x="500" y="384">5.39s</text>
+  <text class="row" x="640" y="384">7.12s</text>
+  <text class="row" x="780" y="384">641ms</text>
+  <text class="row" x="920" y="384">0.38s</text>
+  <text class="row" x="1040" y="384">6.68s</text>
+  <text class="row status" x="1180" y="384">100/100</text>
   <line class="divider" x1="24" y1="398" x2="1256" y2="398"/>
 
   <!-- Row 6 -->
   <text class="rank" x="40" y="428">6</text>
   <text class="row provider" x="80" y="428">Notte</text>
   <text class="row total" x="240" y="428">52.2</text>
-  <text class="row total slow" x="360" y="428">--</text>
-  <text class="row" x="500" y="428">--</text>
-  <text class="row" x="640" y="428">--</text>
-  <text class="row" x="780" y="428">--</text>
-  <text class="row" x="920" y="428">--</text>
-  <text class="row" x="1040" y="428">--</text>
-  <text class="row status" x="1180" y="428">0/100</text>
+  <text class="row total slow" x="360" y="428">1.31/s</text>
+  <text class="row" x="500" y="428">7.62s</text>
+  <text class="row" x="640" y="428">9.12s</text>
+  <text class="row" x="780" y="428">1242ms</text>
+  <text class="row" x="920" y="428">0.18s</text>
+  <text class="row" x="1040" y="428">8.65s</text>
+  <text class="row status" x="1180" y="428">100/100</text>
 
   <!-- Timestamp -->
   <text class="timestamp" x="1256" y="488" text-anchor="end">Last updated: Jul 7, 2026, 04:39 AM UTC</text>
 
   <!-- Footnote -->
-  <text class="timestamp" x="24" y="502">Each session runs 50 sequential actions (navigate, wait, screenshot, textContent, click, goBack) on Wikipedia. Higher APS is better.</text>
+  <text class="timestamp" x="24" y="502">Each session runs 10 sequential actions (navigate, wait, screenshot, textContent, click, goBack) on Wikipedia. Higher APS is better.</text>
 
 </svg>

--- a/src/browser/generate-throughput-svg.ts
+++ b/src/browser/generate-throughput-svg.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import type { ThroughputBenchmarkResult } from './throughput-types.js';
+import { ACTIONS_PER_SESSION, type ThroughputBenchmarkResult } from './throughput-types.js';
 import {
   computeThroughputCompositeScores,
   sortThroughputByCompositeScore,
@@ -99,7 +99,7 @@ function generateSVG(results: ThroughputBenchmarkResult[], timestamp: string): s
   };
 
   const title = 'Browser Step Throughput Benchmarks';
-  const subtitle = '50-action Wikipedia loop per session — agent-style sequential actions';
+  const subtitle = `${ACTIONS_PER_SESSION}-action Wikipedia loop per session — agent-style sequential actions`;
 
   let svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
   <defs>
@@ -182,8 +182,7 @@ ${sponsorImages.length > 0 ? (() => {
     const screenshotMed = r.summary.perActionType.screenshot?.median ?? 0;
     const createMed = r.summary.createMs.median;
 
-    const expectedActions = 50;
-    const fullSuccess = r.iterations.filter(it => !it.error && it.actionsCompleted === expectedActions).length;
+    const fullSuccess = r.iterations.filter(it => !it.error && it.actionsCompleted === ACTIONS_PER_SESSION).length;
     const total = r.iterations.length;
     const allFailed = fullSuccess === 0;
     const score = r.compositeScore !== undefined ? r.compositeScore.toFixed(1) : '--';
@@ -239,7 +238,7 @@ ${sponsorImages.length > 0 ? (() => {
   <text class="timestamp" x="${width - padding}" y="${height - 28}" text-anchor="end">Last updated: ${date}</text>
 
   <!-- Footnote -->
-  <text class="timestamp" x="${padding}" y="${height - 14}">Each session runs 50 sequential actions (navigate, wait, screenshot, textContent, click, goBack) on Wikipedia. Higher APS is better.</text>
+  <text class="timestamp" x="${padding}" y="${height - 14}">Each session runs ${ACTIONS_PER_SESSION} sequential actions (navigate, wait, screenshot, textContent, click, goBack) on Wikipedia. Higher APS is better.</text>
 
 </svg>`;
 


### PR DESCRIPTION
The SVG generator counted a session as a full success only when actionsCompleted === 50, but sessions now run ACTIONS_PER_SESSION (10) actions. Every provider tripped allFailed, blanking all metric cells to "--" with 0/100 status while the Score column still showed. Use the shared constant for the success count and the subtitle/footnote copy, then regenerate the SVG.