### PR TITLE
Measure sandbox TTI before identity check

### DIFF
--- a/src/sandbox/benchmark.ts
+++ b/src/sandbox/benchmark.ts
@@ -117,6 +117,18 @@ export async function runIteration(
 
     sandbox = await withTimeout(compute.sandbox.create(sandboxOptions), timeout, 'Sandbox creation timed out');
 
+    const result = await withTimeout(
+      sandbox.runCommand('node -v'),
+      30_000,
+      'First command execution timed out'
+    ) as { exitCode: number; stderr?: string };
+
+    if (result.exitCode !== 0) {
+      throw new Error(`Command failed with exit code ${result.exitCode}: ${result.stderr || 'Unknown error'}`);
+    }
+
+    const ttiMs = performance.now() - start;
+
     const markerA = '/tmp/.bench_ephemeral_check';
     const markerB = '/var/tmp/.bench_ephemeral_check';
     const probeToken = reuseDetector
@@ -177,18 +189,6 @@ export async function runIteration(
 
       rememberSignals(identity, reuseDetector);
     }
-
-    const result = await withTimeout(
-      sandbox.runCommand('node -v'),
-      30_000,
-      'First command execution timed out'
-    ) as { exitCode: number; stderr?: string };
-
-    if (result.exitCode !== 0) {
-      throw new Error(`Command failed with exit code ${result.exitCode}: ${result.stderr || 'Unknown error'}`);
-    }
-
-    const ttiMs = performance.now() - start;
 
     return { ttiMs };
   } finally {


### PR DESCRIPTION
This pull request refactors the `runIteration` function in `src/sandbox/benchmark.ts` by moving the execution and validation of the `node -v` command earlier in the function. This change ensures that the sandbox environment is validated immediately after creation, which can help catch errors sooner in the process.

**Sandbox validation improvements:**

* Moved the `sandbox.runCommand('node -v')` execution and its exit code validation to immediately after sandbox creation, ensuring the sandbox is correctly set up before proceeding. [[1]](diffhunk://#diff-3db34ca0aa94955ed948c38195170990617333a3c4653ed813c374be5dd8f426R120-R131) [[2]](diffhunk://#diff-3db34ca0aa94955ed948c38195170990617333a3c4653ed813c374be5dd8f426L181-L192)