### PR TITLE
Add sandbox benchmark provider dispatch filter

### DIFF
--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -20,6 +20,10 @@ on:
         description: 'Concurrent sandboxes for burst/staggered tests'
         required: false
         default: '100'
+      provider:
+        description: 'Provider to run (leave empty for all)'
+        required: false
+        default: ''
       mode:
         description: 'Test mode (leave empty to run all)'
         required: false
@@ -42,6 +46,7 @@ permissions:
 jobs:
   bench:
     name: Bench ${{ matrix.provider }}
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.provider == '' || github.event.inputs.provider == matrix.provider
     runs-on: namespace-profile-default
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
This pull request updates the `sandbox-benchmarks.yml` GitHub Actions workflow to add more flexibility when running benchmarks, particularly by allowing selection of a specific provider and improving job filtering. The most important changes are:

**Workflow Input Improvements:**

* Added a new `provider` input to the workflow, allowing users to specify which provider to run benchmarks for, or leave it empty to run for all providers.

**Job Execution Logic:**

* Updated the `bench` job to conditionally run based on the event type and the selected provider, ensuring that only relevant jobs are executed when a specific provider is chosen.