### PR TITLE
Add sandbox benchmark dry run option

### DIFF
--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -24,6 +24,11 @@ on:
         description: 'Provider to run (leave empty for all)'
         required: false
         default: ''
+      dry_run:
+        description: 'Run without ingesting or committing results'
+        required: false
+        default: false
+        type: boolean
       mode:
         description: 'Test mode (leave empty to run all)'
         required: false
@@ -183,7 +188,7 @@ jobs:
       - name: Merge results
         run: npx tsx src/merge-results.ts --input artifacts
       - name: Ingest results to platform
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event.inputs.dry_run != 'true'
         continue-on-error: true
         env:
           INGEST_URL: ${{ secrets.INGEST_URL }}
@@ -281,7 +286,7 @@ jobs:
               });
             }
       - name: Commit and push
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event.inputs.dry_run != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
This pull request adds a new `dry_run` input option to the `sandbox-benchmarks.yml` GitHub Actions workflow. The main purpose is to allow running the workflow without ingesting or committing results, which is useful for testing the workflow without making persistent changes.

Key changes:

**Workflow Input Enhancements**
* Added a `dry_run` boolean input to the workflow, allowing users to specify if the workflow should run in "dry run" mode without ingesting or committing results.

**Conditional Execution Based on `dry_run`**
* Updated the "Ingest results to platform" step to skip execution if `dry_run` is set to `true`.
* Updated the "Commit and push" step to also skip execution if `dry_run` is set to `true`.