### PR TITLE
Revert "chore: run browseruse sessions proxyless"

### DIFF
--- a/src/browser/providers.ts
+++ b/src/browser/providers.ts
@@ -27,7 +27,6 @@ export const browserProviders: BrowserProviderConfig[] = [
     createBrowserProvider: () => browseruse({
       apiKey: process.env.BROWSER_USE_API_KEY!
     }),
-    sessionCreateOptions: { proxies: false },
   },
   {
     name: 'hyperbrowser',

--- a/src/browser/throughput-providers.ts
+++ b/src/browser/throughput-providers.ts
@@ -40,7 +40,6 @@ export const throughputProviders: ThroughputProviderConfig[] = [
       stealth: true,
       headless: true,
       viewport: VIEWPORT,
-      proxies: false,
     },
   },
   {


### PR DESCRIPTION
Reverts #165.

#165 opted a single provider out of proxies while browserbase, hyperbrowser, and kernel all run the throughput benchmark with `stealth: true` (proxied page loads). That makes the configs non-comparable: in the published results, every proxied provider navigates at ~1050–1180ms median while browseruse fetches direct at ~690ms — a per-navigation gap large enough to dominate the composite ranking.

This restores an identical session config for all providers in both the latency and throughput benchmarks. If proxyless is the preferred baseline instead, it should be applied to every provider rather than one — happy to rework this PR in that direction.

Made with [Cursor](https://cursor.com)