### PR TITLE
Disable stealth for browser throughput + latency benchmarks

### DIFF
--- a/src/browser/providers.ts
+++ b/src/browser/providers.ts
@@ -19,7 +19,10 @@ export const browserProviders: BrowserProviderConfig[] = [
       apiKey: process.env.BROWSERBASE_API_KEY!,
       projectId: process.env.BROWSERBASE_PROJECT_ID!,
     }),
-    sessionCreateOptions: { region: 'us-east-1' },
+    sessionCreateOptions: {
+      region: 'us-east-1',
+      stealth: false,
+    },
   },
   {
     name: 'browseruse',
@@ -27,7 +30,10 @@ export const browserProviders: BrowserProviderConfig[] = [
     createBrowserProvider: () => browseruse({
       apiKey: process.env.BROWSER_USE_API_KEY!
     }),
-    sessionCreateOptions: { proxies: false },
+    sessionCreateOptions: {
+      proxies: false,
+      stealth: false,
+    },
   },
   {
     name: 'hyperbrowser',
@@ -35,7 +41,10 @@ export const browserProviders: BrowserProviderConfig[] = [
     createBrowserProvider: () => hyperbrowser({
       apiKey: process.env.HYPERBROWSER_API_KEY!
     }),
-    sessionCreateOptions: { region: 'us-east' },
+    sessionCreateOptions: {
+      region: 'us-east',
+      stealth: false,
+    },
   },
   {
     name: 'kernel',
@@ -43,6 +52,7 @@ export const browserProviders: BrowserProviderConfig[] = [
     createBrowserProvider: () => kernel({
       apiKey: process.env.KERNEL_API_KEY!
     }),
+    sessionCreateOptions: { stealth: false },
   },
   {
     name: 'notte',
@@ -50,6 +60,7 @@ export const browserProviders: BrowserProviderConfig[] = [
     createBrowserProvider: () => notte({
       apiKey: process.env.NOTTE_API_KEY!
     }),
+    sessionCreateOptions: { stealth: false },
   },
   {
     name: 'steel',
@@ -57,6 +68,7 @@ export const browserProviders: BrowserProviderConfig[] = [
     createBrowserProvider: () => steel({
       apiKey: process.env.STEEL_API_KEY!
     }),
+    sessionCreateOptions: { stealth: false },
   },
   // add browser providers above
 ];

--- a/src/browser/throughput-providers.ts
+++ b/src/browser/throughput-providers.ts
@@ -37,10 +37,10 @@ export const throughputProviders: ThroughputProviderConfig[] = [
       apiKey: process.env.BROWSER_USE_API_KEY!,
     }),
     sessionCreateOptions: {
-      stealth: true,
+      stealth: false,
+      proxies: false,
       headless: true,
       viewport: VIEWPORT,
-      proxies: false,
     },
   },
   {
@@ -77,7 +77,8 @@ export const throughputProviders: ThroughputProviderConfig[] = [
       apiKey: process.env.NOTTE_API_KEY!,
     }),
     sessionCreateOptions: {
-      stealth: true,
+      stealth: false,
+      proxies: false,
       headless: true,
       viewport: VIEWPORT,
     },

--- a/src/browser/throughput-providers.ts
+++ b/src/browser/throughput-providers.ts
@@ -10,8 +10,7 @@ import type { ThroughputProviderConfig } from './throughput-types.js';
  * Throughput benchmark provider configurations.
  *
  * Mirrors src/browser/providers.ts but overrides sessionCreateOptions to
- * include stealth + a 1920x1080 viewport for every provider — these are the
- * settings agent workloads typically use.
+ * use a consistent 1920x1080 viewport for every provider.
  */
 const VIEWPORT = { width: 1920, height: 1080 };
 
@@ -25,7 +24,8 @@ export const throughputProviders: ThroughputProviderConfig[] = [
     }),
     sessionCreateOptions: {
       region: 'us-east-1',
-      stealth: true,
+      stealth: false,
+      proxies: false,
       headless: true,
       viewport: VIEWPORT,
     },
@@ -51,7 +51,8 @@ export const throughputProviders: ThroughputProviderConfig[] = [
     }),
     sessionCreateOptions: {
       region: 'us-east',
-      stealth: true,
+      stealth: false,
+      proxies: false,
       headless: true,
       viewport: VIEWPORT,
     },
@@ -63,7 +64,8 @@ export const throughputProviders: ThroughputProviderConfig[] = [
       apiKey: process.env.KERNEL_API_KEY!,
     }),
     sessionCreateOptions: {
-      stealth: true,
+      stealth: false,
+      proxies: false,
       headless: true,
       viewport: VIEWPORT,
     },
@@ -87,7 +89,8 @@ export const throughputProviders: ThroughputProviderConfig[] = [
       apiKey: process.env.STEEL_API_KEY!,
     }),
     sessionCreateOptions: {
-      stealth: true,
+      stealth: false,
+      proxies: false,
       headless: true,
       viewport: VIEWPORT,
     },


### PR DESCRIPTION
## Summary
- disable stealth for all browser throughput benchmark providers
- explicitly disable proxies for throughput session creation
- keep the shared 1920x1080 viewport and headless settings

## Testing
- ./node_modules/typescript/bin/tsc --noEmit *(fails: existing unrelated TypeScript errors in src/scale scripts and tigris sink)*