### PR TITLE
activate lightning in sandbox benchmarks

### DIFF
--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -71,7 +71,7 @@ jobs:
           - hopx
           - isorun
           # - lelantos
-          # - lightning
+          - lightning
           - modal
           # - namespace
           - northflank
@@ -124,7 +124,7 @@ jobs:
           HOPX_API_KEY: ${{ secrets.HOPX_API_KEY }}
           ISORUN_API_KEY: ${{ secrets.ISORUN_API_KEY }}
           # LELANTOS_API_KEY: ${{ secrets.LELANTOS_API_KEY }}
-          # LIGHTNING_API_KEY: ${{ secrets.LIGHTNING_API_KEY }}
+          LIGHTNING_API_KEY: ${{ secrets.LIGHTNING_API_KEY }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           # NSC_TOKEN: ${{ secrets.NSC_TOKEN }}

--- a/src/sandbox/providers.ts
+++ b/src/sandbox/providers.ts
@@ -12,7 +12,7 @@ import { e2b } from '@computesdk/e2b';
 import { hopx } from '@computesdk/hopx';
 import { isorun } from '@computesdk/isorun';
 // import { lelantos } from '@computesdk/lelantos';
-// import { lightning } from '@computesdk/lightning';
+import { lightning } from '@computesdk/lightning';
 import { modal } from '@computesdk/modal';
 // import { namespace } from '@computesdk/namespace';
 import { northflank } from '@computesdk/northflank';
@@ -111,11 +111,11 @@ export const providers: ProviderConfig[] = [
   //   requiredEnvVars: ['LELANTOS_API_KEY'],
   //   createCompute: () => lelantos({ apiKey: process.env.LELANTOS_API_KEY! }),
   // },
-  // {
-  //   name: 'lightning',
-  //   requiredEnvVars: ['LIGHTNING_API_KEY'],
-  //   createCompute: () => lightning({ apiKey: process.env.LIGHTNING_API_KEY! }),
-  // },
+  {
+    name: 'lightning',
+    requiredEnvVars: ['LIGHTNING_API_KEY'],
+    createCompute: () => lightning({ apiKey: process.env.LIGHTNING_API_KEY! }),
+  },
   {
     name: 'modal',
     requiredEnvVars: ['MODAL_TOKEN_ID', 'MODAL_TOKEN_SECRET'],


### PR DESCRIPTION
This pull request enables support for the `lightning` provider in both the workflow configuration and the codebase, allowing benchmarks and sandbox environments to utilize Lightning. The main changes involve uncommenting and implementing the relevant code and configuration for Lightning.

**Workflow configuration updates:**

- **Enable Lightning in benchmarks:**
  - [`.github/workflows/sandbox-benchmarks.yml`](diffhunk://#diff-a22b9fd719d3cb633e9932dc33fd2defd2a4108b16ffbc71d45d1cc88a428949L74-R74): Implement `lightning` in the list of providers to be benchmarked.
  - [`.github/workflows/sandbox-benchmarks.yml`](diffhunk://#diff-a22b9fd719d3cb633e9932dc33fd2defd2a4108b16ffbc71d45d1cc88a428949L127-R127): Un-commented and enabled the `LIGHTNING_API_KEY` environment variable for the workflow.

**Codebase updates:**

- **Activate Lightning provider support:**
  - [`src/sandbox/providers.ts`](diffhunk://#diff-9d3f6be0ee75b51a544aefe7c6b6c8801c60cce50ed78ae5a3367107ab7e65b7L15-R15): Un-commented the import of `lightning` from `@computesdk/lightning`.
  - [`src/sandbox/providers.ts`](diffhunk://#diff-9d3f6be0ee75b51a544aefe7c6b6c8801c60cce50ed78ae5a3367107ab7e65b7L114-R118): Implement the `lightning` provider configuration to the `providers` array, including the required environment variable and the `createCompute` function.