### PR TITLE
activate lelantos in benchmarks

### DIFF
--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -70,7 +70,7 @@ jobs:
           - e2b
           - hopx
           - isorun
-          # - lelantos
+          - lelantos
           - lightning
           - modal
           # - namespace
@@ -123,7 +123,7 @@ jobs:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           HOPX_API_KEY: ${{ secrets.HOPX_API_KEY }}
           ISORUN_API_KEY: ${{ secrets.ISORUN_API_KEY }}
-          # LELANTOS_API_KEY: ${{ secrets.LELANTOS_API_KEY }}
+          LELANTOS_API_KEY: ${{ secrets.LELANTOS_API_KEY }}
           LIGHTNING_API_KEY: ${{ secrets.LIGHTNING_API_KEY }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}

--- a/src/sandbox/providers.ts
+++ b/src/sandbox/providers.ts
@@ -11,7 +11,7 @@ import { declaw } from '@computesdk/declaw';
 import { e2b } from '@computesdk/e2b';
 import { hopx } from '@computesdk/hopx';
 import { isorun } from '@computesdk/isorun';
-// import { lelantos } from '@computesdk/lelantos';
+import { lelantos } from '@computesdk/lelantos';
 import { lightning } from '@computesdk/lightning';
 import { modal } from '@computesdk/modal';
 // import { namespace } from '@computesdk/namespace';
@@ -106,11 +106,11 @@ export const providers: ProviderConfig[] = [
     createCompute: () => isorun({ apiKey: process.env.ISORUN_API_KEY! }),
     sandboxOptions: { image: 'node:22' },
   },
-  // {
-  //   name: 'lelantos',
-  //   requiredEnvVars: ['LELANTOS_API_KEY'],
-  //   createCompute: () => lelantos({ apiKey: process.env.LELANTOS_API_KEY! }),
-  // },
+  {
+    name: 'lelantos',
+    requiredEnvVars: ['LELANTOS_API_KEY'],
+    createCompute: () => lelantos({ apiKey: process.env.LELANTOS_API_KEY! }),
+  },
   {
     name: 'lightning',
     requiredEnvVars: ['LIGHTNING_API_KEY'],


### PR DESCRIPTION
This pull request enables the `lelantos` provider in both the GitHub Actions workflow and the application code, allowing it to be used in the sandbox benchmarks and provider configuration. The main changes include uncommenting and implmenting configuration and code related to `lelantos`.

**Workflow configuration updates:**

* Enabled the `lelantos` provider in the `jobs` matrix in `.github/workflows/sandbox-benchmarks.yml`, so benchmarks will now run for this provider.
* Activated the `LELANTOS_API_KEY` environment variable in the workflow, allowing the job to access the necessary credentials.

**Provider code updates:**

* Imported the `lelantos` provider in `src/sandbox/providers.ts` to make it available for use.
* Added the `lelantos` provider to the `providers` array, enabling it as an available compute provider in the application.