### PR TITLE
Disable Browserbase recordings and native select polyfill

### DIFF
--- a/src/browser/providers.ts
+++ b/src/browser/providers.ts
@@ -23,6 +23,7 @@ export const browserProviders: BrowserProviderConfig[] = [
       region: 'us-east-1',
       stealth: false,
       recordSession: false,
+      enableNativeSelectPolyfill: false,
     },
   },
   {

--- a/src/browser/providers.ts
+++ b/src/browser/providers.ts
@@ -22,6 +22,7 @@ export const browserProviders: BrowserProviderConfig[] = [
     sessionCreateOptions: {
       region: 'us-east-1',
       stealth: false,
+      recordSession: false,
     },
   },
   {

--- a/src/browser/throughput-providers.ts
+++ b/src/browser/throughput-providers.ts
@@ -29,6 +29,7 @@ export const throughputProviders: ThroughputProviderConfig[] = [
       headless: true,
       viewport: VIEWPORT,
       recordSession: false,
+      enableNativeSelectPolyfill: false,
     },
   },
   {

--- a/src/browser/throughput-providers.ts
+++ b/src/browser/throughput-providers.ts
@@ -28,6 +28,7 @@ export const throughputProviders: ThroughputProviderConfig[] = [
       proxies: false,
       headless: true,
       viewport: VIEWPORT,
+      recordSession: false,
     },
   },
   {


### PR DESCRIPTION
Disables session recordings and the native select polyfill for Browserbase browser benchmarks.

This normalizes results alongside other providers that don't record by default.

Validated with `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022`.
