### PR TITLE
ci: run benchmark workflows weekly on Friday instead of daily

### DIFF
--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 0 * * *' # Daily at midnight UTC
+    - cron: '0 0 * * 5' # Weekly on Friday at midnight UTC
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 3 * * *' # Daily at 03:00 UTC (offset from main browser benchmark)
+    - cron: '0 3 * * 5' # Weekly on Friday at 03:00 UTC (offset from main browser benchmark)
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 0 * * *' # Daily at midnight UTC
+    - cron: '0 0 * * 5' # Weekly on Friday at midnight UTC
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/snapshot-fork-benchmarks.yml
+++ b/.github/workflows/snapshot-fork-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 7 * * *' # Daily at 7am UTC (offset from the storage benchmark at 6am to avoid racing pushes to master)
+    - cron: '0 7 * * 5' # Weekly on Friday at 7am UTC (offset from the storage benchmark at 6am to avoid racing pushes to master)
   workflow_dispatch:
     inputs:
       iterations:
@@ -40,7 +40,7 @@ jobs:
     # One real snapshot+fork cycle per provider per iteration: each iteration
     # creates and tears down real buckets/objects, so iteration counts are kept
     # low (and on the smallest dataset) to bound cost and leak risk. PRs run a
-    # single iteration; the daily schedule runs 100 for trend data and commits
+    # single iteration; the weekly schedule runs 100 for trend data and commits
     # the combined results. Fork PRs without secrets skip gracefully
     # (missing-creds path) rather than failing.
     runs-on: namespace-profile-default

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 6 * * *' # Daily at 6am UTC
+    - cron: '0 6 * * 5' # Weekly on Friday at 6am UTC
   workflow_dispatch:
     inputs:
       iterations:
@@ -167,7 +167,7 @@ jobs:
 
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             // Only render sizes that actually ran in this workflow. The checkout
-            // carries committed latest.json files for every size (from the daily
+            // carries committed latest.json files for every size (from the weekly
             // run), so we derive the size list from this run's downloaded
             // artifacts (storage-results-<provider>-<size>) instead of hardcoding.
             const sizeOrder = ['1mb', '4mb', '10mb', '16mb'];


### PR DESCRIPTION
Change all five scheduled benchmark workflows from daily to weekly (Friday UTC), preserving existing hour offsets to avoid racing pushes to master.