### PR TITLE
update: benchmark browser providers against the same Wikipedia pages

### DIFF
--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -26,9 +26,37 @@ permissions:
   pull-requests: write
 
 jobs:
+  setup:
+    name: Resolve target pages
+    runs-on: namespace-profile-default
+    outputs:
+      urls: ${{ steps.pick.outputs.urls }}
+    steps:
+      - name: Resolve one shared random article per iteration
+        id: pick
+        run: |
+          # Resolve one concrete article per iteration up front so every
+          # provider benchmarks against the same page in a given round — but a
+          # different page each round, so we don't measure a warmed cache.
+          count=${{ github.event_name == 'pull_request' && '3' || github.event.inputs.iterations || '100' }}
+          urls=()
+          for i in $(seq 1 "$count"); do
+            # Follow Special:Random's redirect once to a concrete article URL.
+            url=$(curl -sL -A 'ComputeSDK-Benchmark' -o /dev/null -w '%{url_effective}' \
+              'https://en.wikipedia.org/wiki/Special:Random')
+            if [ -z "$url" ] || [[ "$url" == *"Special:Random"* ]]; then
+              url='https://en.wikipedia.org/wiki/Special:Random'
+            fi
+            urls+=("$url")
+          done
+          json=$(printf '%s\n' "${urls[@]}" | jq -R . | jq -cs .)
+          echo "urls=$json" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${#urls[@]} shared article URLs for all providers"
+
   bench:
     name: Bench ${{ matrix.provider }}
     runs-on: namespace-profile-default
+    needs: setup
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -57,6 +85,7 @@ jobs:
         run: rm -rf results/browser-throughput/
       - name: Run browser throughput benchmark
         env:
+          THROUGHPUT_URLS: ${{ needs.setup.outputs.urls }}
           BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
           BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
           BROWSER_USE_API_KEY: ${{ secrets.BROWSER_USE_API_KEY }}

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -49,8 +49,13 @@ jobs:
             fi
             urls+=("$url")
           done
-          json=$(printf '%s\n' "${urls[@]}" | jq -R . | jq -cs .)
-          echo "urls=$json" >> "$GITHUB_OUTPUT"
+          # Emit as a newline-delimited multiline output. Pure bash — avoids a
+          # jq/python dependency that may be absent on the runner image.
+          {
+            echo "urls<<URLS_EOF"
+            printf '%s\n' "${urls[@]}"
+            echo "URLS_EOF"
+          } >> "$GITHUB_OUTPUT"
           echo "Resolved ${#urls[@]} shared article URLs for all providers"
 
   bench:

--- a/src/browser/throughput-benchmark.ts
+++ b/src/browser/throughput-benchmark.ts
@@ -27,15 +27,20 @@ const FIRST_HEADING = '#firstHeading';
 const NAV_URLS: string[] = parseNavUrls();
 
 function parseNavUrls(): string[] {
-  const raw = process.env.THROUGHPUT_URLS;
+  const raw = process.env.THROUGHPUT_URLS?.trim();
   if (!raw) return [];
-  try {
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) return parsed.filter((u): u is string => typeof u === 'string' && u.length > 0);
-  } catch {
-    // Malformed input falls back to per-navigation random URLs below.
+  // Accept either a JSON array or a plain newline/whitespace-delimited list, so
+  // the workflow can emit the URLs with pure bash and not depend on jq/python
+  // being present on the runner image.
+  if (raw.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed.filter((u): u is string => typeof u === 'string' && u.length > 0);
+    } catch {
+      // Malformed JSON falls through to whitespace splitting below.
+    }
   }
-  return [];
+  return raw.split(/\s+/).filter(u => u.length > 0);
 }
 
 /** The article URL iteration `i` should navigate to (same across providers). */

--- a/src/browser/throughput-benchmark.ts
+++ b/src/browser/throughput-benchmark.ts
@@ -16,6 +16,33 @@ import {
 
 const RANDOM_URL = 'https://en.wikipedia.org/wiki/Special:Random';
 const FIRST_HEADING = '#firstHeading';
+
+// Providers must be benchmarked against the same pages to be comparable, but in
+// CI each provider runs as a separate job/process — so `Special:Random` makes
+// each one draw different articles. The workflow resolves one concrete article
+// URL per iteration up front and injects the list via THROUGHPUT_URLS (a JSON
+// array). Iteration i then navigates to urls[i] for *every* provider: the same
+// page across providers, but a different page each iteration so we don't measure
+// a warmed cache. Absent the env var (local runs), navigation stays random.
+const NAV_URLS: string[] = parseNavUrls();
+
+function parseNavUrls(): string[] {
+  const raw = process.env.THROUGHPUT_URLS;
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed.filter((u): u is string => typeof u === 'string' && u.length > 0);
+  } catch {
+    // Malformed input falls back to per-navigation random URLs below.
+  }
+  return [];
+}
+
+/** The article URL iteration `i` should navigate to (same across providers). */
+export function navUrlForIteration(i: number): string {
+  if (NAV_URLS.length > 0) return NAV_URLS[i % NAV_URLS.length];
+  return RANDOM_URL;
+}
 // Match article-body links across both classic MediaWiki HTML (relative "/wiki/Foo")
 // and Parsoid read-HTML (protocol-relative absolute "//en.wikipedia.org/wiki/Foo").
 // :not([href*=":"]) still excludes namespace pages (Help:, File:) and external http(s) links.
@@ -68,14 +95,14 @@ async function timeAction<T>(
   }
 }
 
-async function runActionLoop(page: Page, results: ActionResult[]): Promise<void> {
+async function runActionLoop(page: Page, results: ActionResult[], navigateUrl: string): Promise<void> {
   for (let loop = 0; loop < LOOPS_PER_SESSION; loop++) {
     const baseIdx = loop * ACTIONS_PER_LOOP;
 
-    // 1. Navigate to a random article
+    // 1. Navigate to the article for this iteration (shared across providers)
     {
       const r = await timeAction(() =>
-        page.goto(RANDOM_URL, { waitUntil: 'load' }) as Promise<unknown>,
+        page.goto(navigateUrl, { waitUntil: 'load' }) as Promise<unknown>,
       );
       results.push({ index: baseIdx + 1, type: 'navigate', durationMs: r.durationMs, success: r.success, error: r.error });
     }
@@ -147,6 +174,7 @@ export async function runThroughputIteration(
   provider: any,
   timeout: number,
   sessionCreateOptions: Record<string, unknown>,
+  navigateUrl: string,
 ): Promise<ThroughputTimingResult> {
   const totalStart = performance.now();
   const actions: ActionResult[] = [];
@@ -184,7 +212,7 @@ export async function runThroughputIteration(
 
     // 3. Run the 50-action loop. Individual action failures are recorded but
     // do not abort the session.
-    await runActionLoop(page, actions);
+    await runActionLoop(page, actions, navigateUrl);
   } catch (err) {
     iterationError = err instanceof Error ? err.message : String(err);
   } finally {
@@ -295,7 +323,7 @@ export async function runThroughputBenchmark(
   console.log('────  ───────  ───────  ───────  ───────  ───────  ─────  ───────');
 
   for (let i = 0; i < iterations; i++) {
-    const result = await runThroughputIteration(provider, timeout, sessionCreateOptions);
+    const result = await runThroughputIteration(provider, timeout, sessionCreateOptions, navUrlForIteration(i));
     results.push(result);
 
     const pad = (n: number) => `${Math.round(n)}ms`.padStart(7);

--- a/src/run.ts
+++ b/src/run.ts
@@ -16,6 +16,7 @@ import {
 import { runBrowserBenchmark, writeBrowserResultsJson } from './browser/benchmark.js';
 import {
   emptySummary,
+  navUrlForIteration,
   runThroughputBenchmark,
   runThroughputIteration,
   summarizeIterations,
@@ -364,8 +365,10 @@ async function runBrowserThroughput(toRun: typeof throughputProviders): Promise<
     console.log('────────────  ────  ───────  ───────  ───────  ───────  ───────  ─────  ───────');
 
     for (let i = 0; i < iterationsToRun; i++) {
+      // Same URL for every provider in this round; different URL each round.
+      const navigateUrl = navUrlForIteration(i);
       for (const state of active) {
-        const result = await runThroughputIteration(state.provider, state.timeout, state.sessionCreateOptions);
+        const result = await runThroughputIteration(state.provider, state.timeout, state.sessionCreateOptions, navigateUrl);
         state.iterations.push(result);
 
         const pad = (n: number) => `${Math.round(n)}ms`.padStart(7);


### PR DESCRIPTION
This pull request updates the browser throughput benchmark workflow to ensure that all providers are benchmarked against the same set of article pages in each iteration. This change improves the comparability of results by eliminating differences caused by each provider navigating to different random articles. The workflow now resolves a list of concrete article URLs up front and shares them across all provider jobs via an environment variable.

**Workflow and Benchmarking Consistency Improvements:**

* Added a `setup` job to `.github/workflows/browser-throughput-benchmarks.yml` that resolves a list of concrete article URLs (one per iteration) and exposes them as the `THROUGHPUT_URLS` output, ensuring all providers benchmark the same pages in each round.
* Updated the `bench` job to depend on `setup` and inject the resolved URLs into the environment for use during benchmarking.

**Benchmark Code Updates:**

* Introduced `navUrlForIteration(i)` in `src/browser/throughput-benchmark.ts`, which returns the shared article URL for a given iteration, defaulting to random if not set (for local runs). All navigation steps now use this function to ensure consistency across providers.
* Modified `runThroughputIteration` and related functions to accept and use the shared navigation URL for each iteration, propagating this change through the benchmark code and the main runner in `src/run.ts`. [[1]](diffhunk://#diff-368ced7742a6159950272243e47ed86bbe7e49a78eaedb77f642c567fc2cd48bR177) [[2]](diffhunk://#diff-368ced7742a6159950272243e47ed86bbe7e49a78eaedb77f642c567fc2cd48bL187-R215) [[3]](diffhunk://#diff-368ced7742a6159950272243e47ed86bbe7e49a78eaedb77f642c567fc2cd48bL298-R326) [[4]](diffhunk://#diff-69c9100f2a3041c22e8fddf77d13fd7eb1aa42a8a200aa35a81ea589c135e66aR19) [[5]](diffhunk://#diff-69c9100f2a3041c22e8fddf77d13fd7eb1aa42a8a200aa35a81ea589c135e66aR368-R371)In the throughput workflow resolve one shared article per iteration up front and inject the list via THROUGHPUT_URLS, so iteration "i" hits the same page for every provider but a different page each iteration (fair comparison, no warmed-cache bias).