### PR TITLE
Add one-time workflow to migrate repo secrets to org level

### DIFF
--- a/.github/workflows/migrate-secrets-to-org.yml
+++ b/.github/workflows/migrate-secrets-to-org.yml
@@ -16,6 +16,10 @@ on:
         default: true
         type: boolean
 
+# All API calls use ORG_ADMIN_PAT (see GH_TOKEN below); the automatic
+# GITHUB_TOKEN is never used, so grant it nothing.
+permissions: {}
+
 jobs:
   migrate:
     runs-on: ubuntu-latest

--- a/.github/workflows/migrate-secrets-to-org.yml
+++ b/.github/workflows/migrate-secrets-to-org.yml
@@ -1,0 +1,46 @@
+name: Migrate secrets to org
+
+# One-time helper. Reads every repo secret (only readable here, via the
+# secrets context) and re-creates each as a computesdk org secret scoped
+# to selected repos. Delete this file after a successful run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repos:
+        description: Comma-separated repos to grant access (visibility=selected)
+        default: benchmarks,benchmarks-daily
+        type: string
+      dry_run:
+        description: List names only, do not write
+        default: true
+        type: boolean
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Copy repo secrets to org
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+          GH_TOKEN: ${{ secrets.ORG_ADMIN_PAT }}
+          ORG: computesdk
+          REPOS: ${{ inputs.repos }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          # Never copy the automatic token or the admin PAT used to write.
+          SKIP=" github_token GITHUB_TOKEN ORG_ADMIN_PAT "
+          echo "$ALL_SECRETS" | jq -r 'to_entries[] | .key + "\t" + (.value | @base64)' \
+          | while IFS=$'\t' read -r name b64; do
+              case "$SKIP" in *" $name "*) echo "skip   $name"; continue;; esac
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "would set org secret: $name"
+                continue
+              fi
+              printf '%s' "$b64" | base64 -d \
+                | gh secret set "$name" --org "$ORG" \
+                    --visibility selected --repos "$REPOS" --body-file -
+              echo "set    org secret: $name"
+            done
+          echo "done"

--- a/.github/workflows/migrate-secrets-to-org.yml
+++ b/.github/workflows/migrate-secrets-to-org.yml
@@ -1,8 +1,8 @@
 name: Migrate secrets to org
 
-# One-time helper. Reads every repo secret (only readable here, via the
-# secrets context) and re-creates each as a computesdk org secret scoped
-# to selected repos. Delete this file after a successful run.
+# One-time helper. Explicitly maps each repo secret into its own (individually
+# masked) env var and re-creates it as a computesdk org secret scoped to
+# selected repos. Delete this file after a successful run.
 
 on:
   workflow_dispatch:
@@ -22,25 +22,217 @@ jobs:
     steps:
       - name: Copy repo secrets to org
         env:
-          ALL_SECRETS: ${{ toJSON(secrets) }}
           GH_TOKEN: ${{ secrets.ORG_ADMIN_PAT }}
           ORG: computesdk
           REPOS: ${{ inputs.repos }}
           DRY_RUN: ${{ inputs.dry_run }}
+          AGENTUITY_API_KEY: ${{ secrets.AGENTUITY_API_KEY }}
+          AI_GATEWAY_MODEL: ${{ secrets.AI_GATEWAY_MODEL }}
+          ANCHORBROWSER_API_KEY: ${{ secrets.ANCHORBROWSER_API_KEY }}
+          ARCHIL_API_KEY: ${{ secrets.ARCHIL_API_KEY }}
+          ARCHIL_DISK_ID: ${{ secrets.ARCHIL_DISK_ID }}
+          ARCHIL_REGION: ${{ secrets.ARCHIL_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
+          AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
+          AZURE_CONTAINER: ${{ secrets.AZURE_CONTAINER }}
+          AZURE_SNAPSHOT_ACCOUNT_KEY: ${{ secrets.AZURE_SNAPSHOT_ACCOUNT_KEY }}
+          AZURE_SNAPSHOT_ACCOUNT_NAME: ${{ secrets.AZURE_SNAPSHOT_ACCOUNT_NAME }}
+          AZURE_SNAPSHOT_CONTAINER: ${{ secrets.AZURE_SNAPSHOT_CONTAINER }}
+          BEAM_TOKEN: ${{ secrets.BEAM_TOKEN }}
+          BEAM_WORKSPACE_ID: ${{ secrets.BEAM_WORKSPACE_ID }}
+          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+          BL_API_KEY: ${{ secrets.BL_API_KEY }}
+          BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
+          BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+          BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+          BROWSER_USE_API_KEY: ${{ secrets.BROWSER_USE_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_AI_GATEWAY_API_KEY: ${{ secrets.CLOUDFLARE_AI_GATEWAY_API_KEY }}
+          CLOUDFLARE_AI_GATEWAY_BASE_URL: ${{ secrets.CLOUDFLARE_AI_GATEWAY_BASE_URL }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_SANDBOX_SECRET: ${{ secrets.CLOUDFLARE_SANDBOX_SECRET }}
+          CLOUDFLARE_SANDBOX_URL: ${{ secrets.CLOUDFLARE_SANDBOX_URL }}
+          CLOUD_RUN_SANDBOX_SECRET: ${{ secrets.CLOUD_RUN_SANDBOX_SECRET }}
+          CLOUD_RUN_SANDBOX_URL: ${{ secrets.CLOUD_RUN_SANDBOX_URL }}
+          COLLIMATE_API_KEY: ${{ secrets.COLLIMATE_API_KEY }}
+          COMPUTESDK_API_KEY: ${{ secrets.COMPUTESDK_API_KEY }}
+          CREATEOS_SANDBOX_API_KEY: ${{ secrets.CREATEOS_SANDBOX_API_KEY }}
+          CSB_API_KEY: ${{ secrets.CSB_API_KEY }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DECLAW_API_KEY: ${{ secrets.DECLAW_API_KEY }}
+          DOTCOM_RAILWAY_ENVIRONMENT_ID: ${{ secrets.DOTCOM_RAILWAY_ENVIRONMENT_ID }}
+          DOTCOM_RAILWAY_PROJECT_ID: ${{ secrets.DOTCOM_RAILWAY_PROJECT_ID }}
+          DOTCOM_RAILWAY_SERVICE_ID: ${{ secrets.DOTCOM_RAILWAY_SERVICE_ID }}
+          DOTCOM_RAILWAY_TOKEN: ${{ secrets.DOTCOM_RAILWAY_TOKEN }}
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          FREESTYLE_API_KEY: ${{ secrets.FREESTYLE_API_KEY }}
+          HOPX_API_KEY: ${{ secrets.HOPX_API_KEY }}
+          HYPERBROWSER_API_KEY: ${{ secrets.HYPERBROWSER_API_KEY }}
+          INGEST_SECRET: ${{ secrets.INGEST_SECRET }}
+          INGEST_URL: ${{ secrets.INGEST_URL }}
+          ISORUN_API_KEY: ${{ secrets.ISORUN_API_KEY }}
+          KERNEL_API_KEY: ${{ secrets.KERNEL_API_KEY }}
+          LELANTOS_API_KEY: ${{ secrets.LELANTOS_API_KEY }}
+          LIGHTNING_API_KEY: ${{ secrets.LIGHTNING_API_KEY }}
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          NORTHFLANK_PROJECT_ID: ${{ secrets.NORTHFLANK_PROJECT_ID }}
+          NORTHFLANK_TOKEN: ${{ secrets.NORTHFLANK_TOKEN }}
+          NOTTE_API_KEY: ${{ secrets.NOTTE_API_KEY }}
+          NSC_TOKEN: ${{ secrets.NSC_TOKEN }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
+          QUILT_API_KEY: ${{ secrets.QUILT_API_KEY }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_SNAPSHOT_ACCESS_KEY_ID: ${{ secrets.R2_SNAPSHOT_ACCESS_KEY_ID }}
+          R2_SNAPSHOT_BUCKET: ${{ secrets.R2_SNAPSHOT_BUCKET }}
+          R2_SNAPSHOT_SECRET_ACCESS_KEY: ${{ secrets.R2_SNAPSHOT_SECRET_ACCESS_KEY }}
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+          RAILWAY_ENVIRONMENT_ID: ${{ secrets.RAILWAY_ENVIRONMENT_ID }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_OWNER_ID: ${{ secrets.RENDER_OWNER_ID }}
+          RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          S3_SNAPSHOT_ACCESS_KEY_ID: ${{ secrets.S3_SNAPSHOT_ACCESS_KEY_ID }}
+          S3_SNAPSHOT_BUCKET: ${{ secrets.S3_SNAPSHOT_BUCKET }}
+          S3_SNAPSHOT_SECRET_ACCESS_KEY: ${{ secrets.S3_SNAPSHOT_SECRET_ACCESS_KEY }}
+          SPRITES_TOKEN: ${{ secrets.SPRITES_TOKEN }}
+          STEEL_API_KEY: ${{ secrets.STEEL_API_KEY }}
+          SUPERSERVE_API_KEY: ${{ secrets.SUPERSERVE_API_KEY }}
+          TENKI_API_KEY: ${{ secrets.TENKI_API_KEY }}
+          TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}
+          TIGRIS_SNAPSHOT_ACCESS_KEY: ${{ secrets.TIGRIS_SNAPSHOT_ACCESS_KEY }}
+          TIGRIS_SNAPSHOT_SECRET_KEY: ${{ secrets.TIGRIS_SNAPSHOT_SECRET_KEY }}
+          TIGRIS_SNAPSHOT_STORAGE_BUCKET: ${{ secrets.TIGRIS_SNAPSHOT_STORAGE_BUCKET }}
+          TIGRIS_STORAGE_ACCESS_KEY_ID: ${{ secrets.TIGRIS_STORAGE_ACCESS_KEY_ID }}
+          TIGRIS_STORAGE_BUCKET: ${{ secrets.TIGRIS_STORAGE_BUCKET }}
+          TIGRIS_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.TIGRIS_STORAGE_SECRET_ACCESS_KEY }}
+          UPSTASH_BOX_API_KEY: ${{ secrets.UPSTASH_BOX_API_KEY }}
+          VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
+          VERCEL_AI_GATEWAY_BASE_URL: ${{ secrets.VERCEL_AI_GATEWAY_BASE_URL }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_SNAPSHOT_BLOB_READ_WRITE_TOKEN: ${{ secrets.VERCEL_SNAPSHOT_BLOB_READ_WRITE_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           set -euo pipefail
-          # Never copy the automatic token or the admin PAT used to write.
-          SKIP=" github_token GITHUB_TOKEN ORG_ADMIN_PAT "
-          echo "$ALL_SECRETS" | jq -r 'to_entries[] | .key + "\t" + (.value | @base64)' \
-          | while IFS=$'\t' read -r name b64; do
-              case "$SKIP" in *" $name "*) echo "skip   $name"; continue;; esac
-              if [ "$DRY_RUN" = "true" ]; then
-                echo "would set org secret: $name"
-                continue
-              fi
-              printf '%s' "$b64" | base64 -d \
-                | gh secret set "$name" --org "$ORG" \
-                    --visibility selected --repos "$REPOS" --body-file -
-              echo "set    org secret: $name"
-            done
+          for name in \
+            AGENTUITY_API_KEY \
+            AI_GATEWAY_MODEL \
+            ANCHORBROWSER_API_KEY \
+            ARCHIL_API_KEY \
+            ARCHIL_DISK_ID \
+            ARCHIL_REGION \
+            AWS_ACCESS_KEY_ID \
+            AWS_REGION \
+            AWS_SECRET_ACCESS_KEY \
+            AZURE_ACCOUNT_KEY \
+            AZURE_ACCOUNT_NAME \
+            AZURE_CONTAINER \
+            AZURE_SNAPSHOT_ACCOUNT_KEY \
+            AZURE_SNAPSHOT_ACCOUNT_NAME \
+            AZURE_SNAPSHOT_CONTAINER \
+            BEAM_TOKEN \
+            BEAM_WORKSPACE_ID \
+            BLOB_READ_WRITE_TOKEN \
+            BL_API_KEY \
+            BL_WORKSPACE \
+            BROWSERBASE_API_KEY \
+            BROWSERBASE_PROJECT_ID \
+            BROWSER_USE_API_KEY \
+            CLOUDFLARE_ACCOUNT_ID \
+            CLOUDFLARE_AI_GATEWAY_API_KEY \
+            CLOUDFLARE_AI_GATEWAY_BASE_URL \
+            CLOUDFLARE_API_TOKEN \
+            CLOUDFLARE_SANDBOX_SECRET \
+            CLOUDFLARE_SANDBOX_URL \
+            CLOUD_RUN_SANDBOX_SECRET \
+            CLOUD_RUN_SANDBOX_URL \
+            COLLIMATE_API_KEY \
+            COMPUTESDK_API_KEY \
+            CREATEOS_SANDBOX_API_KEY \
+            CSB_API_KEY \
+            DAYTONA_API_KEY \
+            DECLAW_API_KEY \
+            DOTCOM_RAILWAY_ENVIRONMENT_ID \
+            DOTCOM_RAILWAY_PROJECT_ID \
+            DOTCOM_RAILWAY_SERVICE_ID \
+            DOTCOM_RAILWAY_TOKEN \
+            E2B_API_KEY \
+            FREESTYLE_API_KEY \
+            HOPX_API_KEY \
+            HYPERBROWSER_API_KEY \
+            INGEST_SECRET \
+            INGEST_URL \
+            ISORUN_API_KEY \
+            KERNEL_API_KEY \
+            LELANTOS_API_KEY \
+            LIGHTNING_API_KEY \
+            MODAL_TOKEN_ID \
+            MODAL_TOKEN_SECRET \
+            NORTHFLANK_PROJECT_ID \
+            NORTHFLANK_TOKEN \
+            NOTTE_API_KEY \
+            NSC_TOKEN \
+            OPENROUTER_API_KEY \
+            OPENROUTER_BASE_URL \
+            QUILT_API_KEY \
+            R2_ACCESS_KEY_ID \
+            R2_ACCOUNT_ID \
+            R2_BUCKET \
+            R2_SECRET_ACCESS_KEY \
+            R2_SNAPSHOT_ACCESS_KEY_ID \
+            R2_SNAPSHOT_BUCKET \
+            R2_SNAPSHOT_SECRET_ACCESS_KEY \
+            RAILWAY_API_TOKEN \
+            RAILWAY_ENVIRONMENT_ID \
+            RENDER_API_KEY \
+            RENDER_OWNER_ID \
+            RUNLOOP_API_KEY \
+            S3_BUCKET \
+            S3_SNAPSHOT_ACCESS_KEY_ID \
+            S3_SNAPSHOT_BUCKET \
+            S3_SNAPSHOT_SECRET_ACCESS_KEY \
+            SPRITES_TOKEN \
+            STEEL_API_KEY \
+            SUPERSERVE_API_KEY \
+            TENKI_API_KEY \
+            TENSORLAKE_API_KEY \
+            TIGRIS_SNAPSHOT_ACCESS_KEY \
+            TIGRIS_SNAPSHOT_SECRET_KEY \
+            TIGRIS_SNAPSHOT_STORAGE_BUCKET \
+            TIGRIS_STORAGE_ACCESS_KEY_ID \
+            TIGRIS_STORAGE_BUCKET \
+            TIGRIS_STORAGE_SECRET_ACCESS_KEY \
+            UPSTASH_BOX_API_KEY \
+            VERCEL_AI_GATEWAY_API_KEY \
+            VERCEL_AI_GATEWAY_BASE_URL \
+            VERCEL_PROJECT_ID \
+            VERCEL_SNAPSHOT_BLOB_READ_WRITE_TOKEN \
+            VERCEL_TEAM_ID \
+            VERCEL_TOKEN \
+            ; do
+            # indirect expansion: read this secret's value from its env var
+            value="${!name-}"
+            if [ -z "$value" ]; then
+              echo "skip (unset) $name"
+              continue
+            fi
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "would set org secret: $name"
+              continue
+            fi
+            # value goes straight to stdin -- never in argv, never base64'd,
+            # so GitHub's log masking stays effective
+            printf '%s' "$value" \
+              | gh secret set "$name" --org "$ORG" \
+                  --visibility selected --repos "$REPOS" --body-file -
+            echo "set    org secret: $name"
+          done
           echo "done"


### PR DESCRIPTION
One-time helper to move this repo's ~95 Actions secrets up to **computesdk org-level** secrets so they can be managed in one place and shared with `benchmarks-daily` (and any other selected repo).

## Why a workflow
Secret *values* are write-only — they can't be read via the API/CLI. The only place they're readable is inside a workflow run in this repo, via the `${{ toJSON(secrets) }}` context. So the migration has to run here.

## What it does
`.github/workflows/migrate-secrets-to-org.yml` (manual `workflow_dispatch`):
- Reads every repo secret, re-creates each as a `computesdk` **org secret** with `--visibility selected` scoped to `benchmarks,benchmarks-daily` (configurable input).
- Values are piped via `--body-file -` (never in argv/logs); only names are printed.
- Skips `github_token` and `ORG_ADMIN_PAT`.
- Defaults to **`dry_run: true`** — first run just lists names, writes nothing.

## Requires
A repo secret `ORG_ADMIN_PAT` — a fine-grained PAT for `computesdk` with **Organization → Secrets: Read and write**.

## After running
- Verify with `gh secret list --org computesdk`.
- Repo-level secrets are left in place (they shadow org ones), so nothing changes for `benchmarks` until they're deleted later.
- **Delete this workflow file** once the migration is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)