### PR TITLE
Enable Factory Droid @droid tag responses

### DIFF
--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -1,0 +1,38 @@
+name: Droid Tag
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  droid:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@droid') || contains(github.event.issue.title, '@droid'))) ||
+      (github.event_name == 'pull_request' && (contains(github.event.pull_request.body, '@droid') || contains(github.event.pull_request.title, '@droid')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Droid Exec
+        uses: Factory-AI/droid-action@main
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -5,21 +5,15 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
-  pull_request:
-    types: [opened, edited]
 
 jobs:
   droid:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@droid')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@droid')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@droid') || contains(github.event.issue.title, '@droid'))) ||
-      (github.event_name == 'pull_request' && (contains(github.event.pull_request.body, '@droid') || contains(github.event.pull_request.title, '@droid')))
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -11,22 +11,28 @@ on:
 jobs:
   droid:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@droid')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@droid')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid'))
+      github.actor != 'dependabot[bot]' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@droid') && contains(fromJson('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@droid') && contains(fromJson('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid') && contains(fromJson('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.review.author_association))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
       actions: read
+    env:
+      FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        if: env.FACTORY_API_KEY != ''
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@main
+        if: env.FACTORY_API_KEY != ''
+        uses: Factory-AI/droid-action@7c7bfea2aa3bb7ea87579402cc1d89dbcf6b13b3 # main
         with:
-          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          factory_api_key: ${{ env.FACTORY_API_KEY }}


### PR DESCRIPTION
This PR adds the Factory Droid `@droid` tag response workflow. When someone mentions `@droid` in an issue or PR comment, Droid will respond automatically.

The workflow uses the `Factory-AI/droid-action@main` GitHub Action and authenticates with the `FACTORY_API_KEY` org secret (already configured for the `computesdk` org).

Learn more at https://docs.factory.ai
Generate an API key at https://app.factory.ai/settings/api-keys