### PR TITLE
feat: add sandbox dax benchmark

### DIFF
--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -39,6 +39,7 @@ on:
           - sequential
           - staggered
           - burst
+          - sandbox-dax
 
 concurrency:
   group: benchmarks
@@ -161,10 +162,99 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  workload-bench:
+    name: Bench ${{ matrix.provider }} sandbox-dax
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.mode == '' || github.event.inputs.mode == 'sandbox-dax' }}
+    runs-on: namespace-profile-default
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        provider:
+          - archil
+          - beam
+          - blaxel
+          - cloud-run
+          - cloudflare
+          - codesandbox
+          - createos
+          - daytona
+          - declaw
+          - e2b
+          - hopx
+          - isorun
+          - modal
+          - northflank
+          - runloop
+          - superserve
+          - tensorlake
+          - upstash
+          - vercel
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'npm'
+      - name: Install dependencies
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            npm update
+          else
+            npm ci
+          fi
+      - name: Clear stale results from checkout
+        run: rm -rf results/
+      - name: Run dax benchmark
+        env:
+          COMPUTESDK_API_KEY: ${{ secrets.COMPUTESDK_API_KEY }}
+          ARCHIL_API_KEY: ${{ secrets.ARCHIL_API_KEY }}
+          ARCHIL_REGION: ${{ secrets.ARCHIL_REGION }}
+          ARCHIL_DISK_ID: ${{ secrets.ARCHIL_DISK_ID }}
+          BEAM_TOKEN: ${{ secrets.BEAM_TOKEN }}
+          BEAM_WORKSPACE_ID: ${{ secrets.BEAM_WORKSPACE_ID }}
+          CLOUD_RUN_SANDBOX_URL: ${{ secrets.CLOUD_RUN_SANDBOX_URL }}
+          CLOUD_RUN_SANDBOX_SECRET: ${{ secrets.CLOUD_RUN_SANDBOX_SECRET }}
+          BL_API_KEY: ${{ secrets.BL_API_KEY }}
+          BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
+          CLOUDFLARE_SANDBOX_URL: ${{ secrets.CLOUDFLARE_SANDBOX_URL }}
+          CLOUDFLARE_SANDBOX_SECRET: ${{ secrets.CLOUDFLARE_SANDBOX_SECRET }}
+          CSB_API_KEY: ${{ secrets.CSB_API_KEY }}
+          CREATEOS_SANDBOX_API_KEY: ${{ secrets.CREATEOS_SANDBOX_API_KEY }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DECLAW_API_KEY: ${{ secrets.DECLAW_API_KEY }}
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          HOPX_API_KEY: ${{ secrets.HOPX_API_KEY }}
+          ISORUN_API_KEY: ${{ secrets.ISORUN_API_KEY }}
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          NORTHFLANK_TOKEN: ${{ secrets.NORTHFLANK_TOKEN }}
+          NORTHFLANK_PROJECT_ID: ${{ secrets.NORTHFLANK_PROJECT_ID }}
+          RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
+          SUPERSERVE_API_KEY: ${{ secrets.SUPERSERVE_API_KEY }}
+          TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}
+          UPSTASH_BOX_API_KEY: ${{ secrets.UPSTASH_BOX_API_KEY }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          npm run bench -- \
+            --provider ${{ matrix.provider }} \
+            --mode sandbox-dax \
+            --iterations ${{ github.event_name == 'pull_request' && '1' || '3' }}
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: results-${{ matrix.provider }}-sandbox-dax
+          path: results/
+          if-no-files-found: ignore
+          retention-days: 7
+
   collect:
     name: Collect Results
     runs-on: namespace-profile-default
-    needs: bench
+    needs: [bench, workload-bench]
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -253,6 +343,31 @@ jobs:
                 const ok = r.iterations.filter(it => !it.error).length;
                 const total = r.iterations.length;
                 body += `| ${i + 1} | ${r.provider} | ${score} | ${median} | ${p95} | ${p99} | ${ok}/${total} |\n`;
+              });
+
+              body += '\n';
+            }
+
+            const workloadModes = [
+              { key: 'sandbox-dax', label: 'Sandbox Dax', metric: r => `total ${(r.summary.totalMs.median / 1000).toFixed(2)}s · clone ${(r.summary.cloneMs.median / 1000).toFixed(2)}s · install ${(r.summary.installMs.median / 1000).toFixed(2)}s · typecheck ${(r.summary.typecheckMs.median / 1000).toFixed(2)}s` },
+            ];
+            for (const mode of workloadModes) {
+              const latestPath = path.join('results', mode.key, 'latest.json');
+              if (!fs.existsSync(latestPath)) continue;
+
+              const data = JSON.parse(fs.readFileSync(latestPath, 'utf-8'));
+              const results = data.results.filter(r => !r.skipped);
+              if (results.length === 0) continue;
+              hasResults = true;
+
+              body += `### ${mode.label}\n\n`;
+              body += '| Provider | Metric | Status |\n';
+              body += '|----------|--------|--------|\n';
+
+              results.forEach(r => {
+                const ok = r.iterations.filter(it => !it.error).length;
+                const total = r.iterations.length;
+                body += `| ${r.provider} | ${mode.metric(r)} | ${ok}/${total} |\n`;
               });
 
               body += '\n';

--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -349,7 +349,7 @@ jobs:
             }
 
             const workloadModes = [
-              { key: 'sandbox-dax', label: 'Sandbox Dax', metric: r => `total ${(r.summary.totalMs.median / 1000).toFixed(2)}s · clone ${(r.summary.cloneMs.median / 1000).toFixed(2)}s · install ${(r.summary.installMs.median / 1000).toFixed(2)}s · typecheck ${(r.summary.typecheckMs.median / 1000).toFixed(2)}s` },
+              { key: 'sandbox-dax', label: 'Sandbox Dax', metric: r => { const l = [...r.iterations].reverse().find(i => i.phasesCompleted != null); const s = l ? `${l.phasesCompleted}/${l.phasesTotal}` : '--'; return `${s} phases · total ${(r.summary.totalMs.median / 1000).toFixed(2)}s · prepare ${(r.summary.prepareMs.median / 1000).toFixed(2)}s · clone ${(r.summary.cloneMs.median / 1000).toFixed(2)}s · install ${(r.summary.installMs.median / 1000).toFixed(2)}s · typecheck ${(r.summary.typecheckMs.median / 1000).toFixed(2)}s`; } },
             ];
             for (const mode of workloadModes) {
               const latestPath = path.join('results', mode.key, 'latest.json');

--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -162,8 +162,8 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  workload-bench:
-    name: Bench ${{ matrix.provider }} sandbox-dax
+  dax:
+    name: Dax ${{ matrix.provider }}
     if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.mode == '' || github.event.inputs.mode == 'sandbox-dax' }}
     runs-on: namespace-profile-default
     timeout-minutes: 60
@@ -254,7 +254,7 @@ jobs:
   collect:
     name: Collect Results
     runs-on: namespace-profile-default
-    needs: [bench, workload-bench]
+    needs: [bench, dax]
     if: always()
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -367,7 +367,9 @@ jobs:
               results.forEach(r => {
                 const ok = r.iterations.filter(it => !it.error).length;
                 const total = r.iterations.length;
-                body += `| ${r.provider} | ${mode.metric(r)} | ${ok}/${total} |\n`;
+                const latest = [...r.iterations].reverse().find(i => i.phasesCompleted != null);
+                const status = latest ? `${latest.phasesCompleted}/${latest.phasesTotal} phases` : `${ok}/${total} OK`;
+                body += `| ${r.provider} | ${mode.metric(r)} | ${status} |\n`;
               });
 
               body += '\n';

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bench:sequential": "tsx src/run.ts --mode sequential",
     "bench:staggered": "tsx src/run.ts --mode staggered",
     "bench:burst": "tsx src/run.ts --mode burst",
+    "bench:sandbox:dax": "tsx src/run.ts --mode sandbox-dax",
     "bench:blaxel": "tsx src/run.ts --provider blaxel",
     "bench:codesandbox": "tsx src/run.ts --provider codesandbox",
     "bench:daytona": "tsx src/run.ts --provider daytona",

--- a/src/merge-results.ts
+++ b/src/merge-results.ts
@@ -37,6 +37,9 @@ import type { ThroughputBenchmarkResult } from './browser/throughput-types.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
+const SANDBOX_WORKLOAD_DIRS = new Set([
+  'sandbox-dax',
+]);
 
 const args = process.argv.slice(2);
 function getArgValue(flag: string): string | undefined {
@@ -74,6 +77,7 @@ function modeToDir(mode: string): string {
     case 'staggered': return 'staggered_tti';
     case 'burst':
     case 'concurrent': return 'burst_tti';
+    case 'sandbox-dax': return 'sandbox-dax';
     default: return `${mode}_tti`;
   }
 }
@@ -168,6 +172,55 @@ async function main() {
     await writeResultsJson(deduped, outPath);
 
     // Copy to latest.json
+    const latestPath = path.join(resultsDir, 'latest.json');
+    fs.copyFileSync(outPath, latestPath);
+    console.log(`Copied latest: ${latestPath}`);
+  }
+
+  // Merge sandbox workload benchmark results (e.g. sandbox-dax)
+  const workloadByMode: Record<string, { results: { result: any; fromSingleProvider: boolean }[] }> = {};
+
+  for (const file of jsonFiles) {
+    const raw = JSON.parse(fs.readFileSync(file, 'utf-8')) as { results?: any[] };
+    if (!raw.results || raw.results.length === 0) continue;
+
+    const dirName = path.basename(path.dirname(file));
+    if (!SANDBOX_WORKLOAD_DIRS.has(dirName)) continue;
+
+    const fromSingleProvider = raw.results.length === 1;
+    if (!workloadByMode[dirName]) workloadByMode[dirName] = { results: [] };
+    for (const result of raw.results) {
+      workloadByMode[dirName].results.push({ result, fromSingleProvider });
+    }
+  }
+
+  for (const [mode, { results }] of Object.entries(workloadByMode)) {
+    const seen = new Map<string, { result: any; fromSingleProvider: boolean }>();
+    for (const entry of results) {
+      const existing = seen.get(entry.result.provider);
+      if (!existing || (entry.fromSingleProvider && !existing.fromSingleProvider)) {
+        seen.set(entry.result.provider, entry);
+      }
+    }
+
+    const deduped = Array.from(seen.values()).map(e => e.result);
+    console.log(`\nMerging ${deduped.length} provider results for mode: ${mode}`);
+
+    const timestamp = new Date().toISOString().slice(0, 10);
+    const resultsDir = path.resolve(ROOT, `results/${modeToDir(mode)}`);
+    fs.mkdirSync(resultsDir, { recursive: true });
+
+    const output = {
+      version: '1.0',
+      timestamp: new Date().toISOString(),
+      config: { mode },
+      results: deduped,
+    };
+
+    const outPath = path.join(resultsDir, `${timestamp}.json`);
+    fs.writeFileSync(outPath, JSON.stringify(output, null, 2));
+    console.log(`Results written to ${outPath}`);
+
     const latestPath = path.join(resultsDir, 'latest.json');
     fs.copyFileSync(outPath, latestPath);
     console.log(`Copied latest: ${latestPath}`);

--- a/src/run.ts
+++ b/src/run.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 import { runBenchmark } from './sandbox/benchmark.js';
 import { runConcurrentBenchmark } from './sandbox/concurrent.js';
 import { runStaggeredBenchmark } from './sandbox/staggered.js';
+import { runDaxBenchmark, writeDaxResultsJson } from './sandbox/dax.js';
 import { runStorageBenchmark, writeStorageResultsJson } from './storage/benchmark.js';
 import {
   runSnapshotForkBenchmark,
@@ -58,18 +59,19 @@ function getArgValue(args: string[], flag: string): string | undefined {
 }
 
 /** Resolve which modes to run */
-function getModesToRun(): BenchmarkMode[] | ['storage'] | ['snapshot-fork'] | ['browser'] | ['browser-throughput'] {
+function getModesToRun(): BenchmarkMode[] | ['storage'] | ['snapshot-fork'] | ['browser'] | ['browser-throughput'] | ['sandbox-dax'] {
   if (!rawMode) return ['sequential', 'staggered', 'burst'];
   if (rawMode === 'storage') return ['storage'];
   if (rawMode === 'snapshot-fork') return ['snapshot-fork'];
   if (rawMode === 'browser') return ['browser'];
   if (rawMode === 'browser-throughput') return ['browser-throughput'];
+  if (rawMode === 'sandbox-dax') return ['sandbox-dax'];
   const m = rawMode === 'concurrent' ? 'burst' : rawMode as BenchmarkMode;
   return [m];
 }
 
 /** Map mode to results subdirectory name */
-function modeToDir(m: BenchmarkMode | 'storage' | 'snapshot-fork' | 'browser-throughput'): string {
+function modeToDir(m: BenchmarkMode | 'storage' | 'snapshot-fork' | 'browser-throughput' | 'sandbox-dax'): string {
   switch (m) {
     case 'sequential': return 'sequential_tti';
     case 'staggered': return 'staggered_tti';
@@ -78,6 +80,7 @@ function modeToDir(m: BenchmarkMode | 'storage' | 'snapshot-fork' | 'browser-thr
     case 'storage': return 'storage';
     case 'snapshot-fork': return 'snapshot-fork';
     case 'browser-throughput': return 'browser-throughput';
+    case 'sandbox-dax': return 'sandbox-dax';
     default: return `${m}_tti`;
   }
 }
@@ -432,6 +435,41 @@ async function runBrowserThroughput(toRun: typeof throughputProviders): Promise<
   console.log(`Copied latest: ${latestPath}`);
 }
 
+async function runSandboxDax(toRun: typeof providers): Promise<void> {
+  console.log('\n' + '='.repeat(70));
+  console.log('  MODE: SANDBOX DAX');
+  console.log(`  Iterations per provider: ${iterations}`);
+  console.log('='.repeat(70));
+
+  const results = [];
+
+  for (const providerConfig of toRun) {
+    const result = await runDaxBenchmark({ ...providerConfig, iterations });
+    results.push(result);
+  }
+
+  console.log('\n--- Sandbox Dax Benchmark Results ---');
+  for (const r of results) {
+    if (r.skipped) {
+      console.log(`${r.provider}: SKIPPED (${r.skipReason})`);
+      continue;
+    }
+    const ok = r.iterations.filter(i => !i.error).length;
+    const total = r.iterations.length;
+    console.log(`${r.provider}:`);
+    console.log(`  Total: ${(r.summary.totalMs.median / 1000).toFixed(2)}s median | clone ${(r.summary.cloneMs.median / 1000).toFixed(2)}s | install ${(r.summary.installMs.median / 1000).toFixed(2)}s | typecheck ${(r.summary.typecheckMs.median / 1000).toFixed(2)}s (${ok}/${total} OK)`);
+  }
+
+  const timestamp = new Date().toISOString().slice(0, 10);
+  const resultsDir = path.resolve(__dirname, `../results/${modeToDir('sandbox-dax')}`);
+  fs.mkdirSync(resultsDir, { recursive: true });
+  const outPath = path.join(resultsDir, `${timestamp}.json`);
+  await writeDaxResultsJson(results, outPath);
+  const latestPath = path.join(resultsDir, 'latest.json');
+  fs.copyFileSync(outPath, latestPath);
+  console.log(`Copied latest: ${latestPath}`);
+}
+
 async function main() {
   const modes = getModesToRun();
 
@@ -524,6 +562,22 @@ async function main() {
 
     await runSnapshotFork(toRun, datasetArg);
     console.log('\nAll snapshot/fork tests complete.');
+    return;
+  }
+
+  if (modes[0] === 'sandbox-dax') {
+    const toRun = providerFilter
+      ? providers.filter(p => p.name === providerFilter)
+      : providers;
+
+    if (toRun.length === 0) {
+      console.error(`Unknown provider: ${providerFilter}`);
+      console.error(`Available: ${providers.map(p => p.name).join(', ')}`);
+      process.exit(1);
+    }
+
+    await runSandboxDax(toRun);
+    console.log('\nAll sandbox dax tests complete.');
     return;
   }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -456,8 +456,9 @@ async function runSandboxDax(toRun: typeof providers): Promise<void> {
     }
     const ok = r.iterations.filter(i => !i.error).length;
     const total = r.iterations.length;
-    console.log(`${r.provider}:`);
-    console.log(`  Total: ${(r.summary.totalMs.median / 1000).toFixed(2)}s median | clone ${(r.summary.cloneMs.median / 1000).toFixed(2)}s | install ${(r.summary.installMs.median / 1000).toFixed(2)}s | typecheck ${(r.summary.typecheckMs.median / 1000).toFixed(2)}s (${ok}/${total} OK)`);
+    const latest = [...r.iterations].reverse().find(i => i.phasesCompleted != null);
+    const phaseScore = latest ? `${latest.phasesCompleted}/${latest.phasesTotal}` : '--';
+    console.log(`${r.provider}: ${phaseScore} phases | total ${(r.summary.totalMs.median / 1000).toFixed(2)}s | prepare ${(r.summary.prepareMs.median / 1000).toFixed(2)}s | clone ${(r.summary.cloneMs.median / 1000).toFixed(2)}s | install ${(r.summary.installMs.median / 1000).toFixed(2)}s | typecheck ${(r.summary.typecheckMs.median / 1000).toFixed(2)}s (${ok}/${total} OK)`);
   }
 
   const timestamp = new Date().toISOString().slice(0, 10);

--- a/src/sandbox/dax.ts
+++ b/src/sandbox/dax.ts
@@ -89,7 +89,8 @@ export async function runDaxBenchmark(config: ProviderConfig): Promise<DaxBenchm
         const score = result.phasesCompleted != null ? `${result.phasesCompleted}/${result.phasesTotal}` : '';
         console.log(`    FAILED${score ? ` (${score} phases)` : ''}: ${result.error}${phaseStr}`);
       } else {
-        console.log(`    OK (${result.phasesCompleted}/${result.phasesTotal}): total ${(result.totalMs! / 1000).toFixed(2)}s | prepare ${(result.prepareMs! / 1000).toFixed(2)}s | clone ${(result.cloneMs! / 1000).toFixed(2)}s | install ${(result.installMs! / 1000).toFixed(2)}s | typecheck ${(result.typecheckMs! / 1000).toFixed(2)}s`);
+        const fmt = (ms?: number) => ms ? `${(ms / 1000).toFixed(2)}s` : 'N/A';
+        console.log(`    OK (${result.phasesCompleted}/${result.phasesTotal}): total ${fmt(result.totalMs)} | prepare ${fmt(result.prepareMs)} | clone ${fmt(result.cloneMs)} | install ${fmt(result.installMs)} | typecheck ${fmt(result.typecheckMs)}`);
       }
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
@@ -115,7 +116,7 @@ export async function runDaxBenchmark(config: ProviderConfig): Promise<DaxBenchm
   }
 
   const successful = results.filter(r => !r.error);
-  const withTiming = results.filter(r => r.totalMs > 0);
+  const withTiming = results.filter(r => r.totalMs > 0 && (r.phasesCompleted ?? 0) > 0);
 
   return {
     provider: name,
@@ -194,6 +195,12 @@ if (result.error) {
 // Count completed phases
 const phaseKeys = ['prepare', 'cache_clear', 'bun_download', 'bun_unpack', 'clone', 'install', 'typecheck'];
 const phasesCompleted = phaseKeys.filter(k => phases[k] !== undefined).length;
+
+// If no phases completed, the script didn't actually run (e.g. curl missing)
+if (phasesCompleted === 0 && !benchError) {
+  const tail = stderr.trim().split('\n').slice(-2).join(' | ');
+  benchError = 'No benchmark phases completed' + (tail ? ': ' + tail : ' (curl may not be available)');
+}
 
 console.log(JSON.stringify({
   totalMs,

--- a/src/sandbox/dax.ts
+++ b/src/sandbox/dax.ts
@@ -8,6 +8,8 @@ const BENCH_SCRIPT_URL = 'https://raw.githubusercontent.com/anomalyco/opencode/p
 
 export interface DaxTimingResult {
   totalMs: number;
+  phasesCompleted?: number;
+  phasesTotal?: number;
   prepareMs?: number;
   bunDownloadMs?: number;
   bunUnpackMs?: number;
@@ -35,6 +37,9 @@ export interface DaxBenchmarkResult {
   iterations: DaxTimingResult[];
   summary: {
     totalMs: Stats;
+    prepareMs: Stats;
+    bunDownloadMs: Stats;
+    bunUnpackMs: Stats;
     cloneMs: Stats;
     installMs: Stats;
     typecheckMs: Stats;
@@ -73,14 +78,18 @@ export async function runDaxBenchmark(config: ProviderConfig): Promise<DaxBenchm
       const result = await runDaxIteration(sandbox, name, timeout);
       results.push(result);
       if (result.error) {
-        const phases = [];
-        if (result.cloneMs) phases.push(`clone ${(result.cloneMs / 1000).toFixed(2)}s`);
-        if (result.installMs) phases.push(`install ${(result.installMs / 1000).toFixed(2)}s`);
-        if (result.typecheckMs) phases.push(`typecheck ${(result.typecheckMs / 1000).toFixed(2)}s`);
-        const phaseStr = phases.length > 0 ? ` | ${phases.join(' | ')}` : '';
-        console.log(`    FAILED: ${result.error}${phaseStr}`);
+        const parts = [];
+        if (result.prepareMs) parts.push(`prepare ${(result.prepareMs / 1000).toFixed(2)}s`);
+        if (result.bunDownloadMs) parts.push(`bun dl ${(result.bunDownloadMs / 1000).toFixed(2)}s`);
+        if (result.bunUnpackMs) parts.push(`bun unpack ${(result.bunUnpackMs / 1000).toFixed(2)}s`);
+        if (result.cloneMs) parts.push(`clone ${(result.cloneMs / 1000).toFixed(2)}s`);
+        if (result.installMs) parts.push(`install ${(result.installMs / 1000).toFixed(2)}s`);
+        if (result.typecheckMs) parts.push(`typecheck ${(result.typecheckMs / 1000).toFixed(2)}s`);
+        const phaseStr = parts.length > 0 ? ` | ${parts.join(' | ')}` : '';
+        const score = result.phasesCompleted != null ? `${result.phasesCompleted}/${result.phasesTotal}` : '';
+        console.log(`    FAILED${score ? ` (${score} phases)` : ''}: ${result.error}${phaseStr}`);
       } else {
-        console.log(`    Total: ${(result.totalMs! / 1000).toFixed(2)}s | clone ${(result.cloneMs! / 1000).toFixed(2)}s | install ${(result.installMs! / 1000).toFixed(2)}s | typecheck ${(result.typecheckMs! / 1000).toFixed(2)}s`);
+        console.log(`    OK (${result.phasesCompleted}/${result.phasesTotal}): total ${(result.totalMs! / 1000).toFixed(2)}s | prepare ${(result.prepareMs! / 1000).toFixed(2)}s | clone ${(result.cloneMs! / 1000).toFixed(2)}s | install ${(result.installMs! / 1000).toFixed(2)}s | typecheck ${(result.typecheckMs! / 1000).toFixed(2)}s`);
       }
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
@@ -182,8 +191,14 @@ if (result.error) {
   benchError = result.error.message || String(result.error);
 }
 
+// Count completed phases
+const phaseKeys = ['prepare', 'cache_clear', 'bun_download', 'bun_unpack', 'clone', 'install', 'typecheck'];
+const phasesCompleted = phaseKeys.filter(k => phases[k] !== undefined).length;
+
 console.log(JSON.stringify({
   totalMs,
+  phasesCompleted,
+  phasesTotal: phaseKeys.length,
   prepareMs: phases.prepare,
   cacheClearMs: phases.cache_clear,
   bunDownloadMs: phases.bun_download,
@@ -229,6 +244,9 @@ function summarize(results: DaxTimingResult[]): DaxBenchmarkResult['summary'] {
   };
   return {
     totalMs: pick('totalMs'),
+    prepareMs: pick('prepareMs'),
+    bunDownloadMs: pick('bunDownloadMs'),
+    bunUnpackMs: pick('bunUnpackMs'),
     cloneMs: pick('cloneMs'),
     installMs: pick('installMs'),
     typecheckMs: pick('typecheckMs'),
@@ -237,7 +255,7 @@ function summarize(results: DaxTimingResult[]): DaxBenchmarkResult['summary'] {
 
 function emptySummary(): DaxBenchmarkResult['summary'] {
   const empty = { median: 0, p95: 0, p99: 0 };
-  return { totalMs: empty, cloneMs: empty, installMs: empty, typecheckMs: empty };
+  return { totalMs: empty, prepareMs: empty, bunDownloadMs: empty, bunUnpackMs: empty, cloneMs: empty, installMs: empty, typecheckMs: empty };
 }
 
 function round(n: number): number {
@@ -250,6 +268,8 @@ export async function writeDaxResultsJson(results: DaxBenchmarkResult[], outPath
     mode: r.mode,
     iterations: r.iterations.map(i => ({
       totalMs: round(i.totalMs),
+      ...(i.phasesCompleted !== undefined ? { phasesCompleted: i.phasesCompleted } : {}),
+      ...(i.phasesTotal !== undefined ? { phasesTotal: i.phasesTotal } : {}),
       ...(i.prepareMs !== undefined ? { prepareMs: round(i.prepareMs) } : {}),
       ...(i.cacheClearMs !== undefined ? { cacheClearMs: round(i.cacheClearMs) } : {}),
       ...(i.bunDownloadMs !== undefined ? { bunDownloadMs: round(i.bunDownloadMs) } : {}),

--- a/src/sandbox/dax.ts
+++ b/src/sandbox/dax.ts
@@ -73,7 +73,12 @@ export async function runDaxBenchmark(config: ProviderConfig): Promise<DaxBenchm
       const result = await runDaxIteration(sandbox, name, timeout);
       results.push(result);
       if (result.error) {
-        console.log(`    FAILED: ${result.error}`);
+        const phases = [];
+        if (result.cloneMs) phases.push(`clone ${(result.cloneMs / 1000).toFixed(2)}s`);
+        if (result.installMs) phases.push(`install ${(result.installMs / 1000).toFixed(2)}s`);
+        if (result.typecheckMs) phases.push(`typecheck ${(result.typecheckMs / 1000).toFixed(2)}s`);
+        const phaseStr = phases.length > 0 ? ` | ${phases.join(' | ')}` : '';
+        console.log(`    FAILED: ${result.error}${phaseStr}`);
       } else {
         console.log(`    Total: ${(result.totalMs! / 1000).toFixed(2)}s | clone ${(result.cloneMs! / 1000).toFixed(2)}s | install ${(result.installMs! / 1000).toFixed(2)}s | typecheck ${(result.typecheckMs! / 1000).toFixed(2)}s`);
       }
@@ -101,12 +106,13 @@ export async function runDaxBenchmark(config: ProviderConfig): Promise<DaxBenchm
   }
 
   const successful = results.filter(r => !r.error);
+  const withTiming = results.filter(r => r.totalMs > 0);
 
   return {
     provider: name,
     mode: 'sandbox-dax',
     iterations: results,
-    summary: successful.length > 0 ? summarize(successful) : emptySummary(),
+    summary: withTiming.length > 0 ? summarize(withTiming) : emptySummary(),
     successRate: results.length > 0 ? successful.length / results.length : 0,
   };
 }
@@ -216,11 +222,16 @@ console.log(JSON.stringify({
 }
 
 function summarize(results: DaxTimingResult[]): DaxBenchmarkResult['summary'] {
+  const empty = { median: 0, p95: 0, p99: 0 };
+  const pick = (key: keyof DaxTimingResult) => {
+    const values = results.map(r => r[key]).filter((v): v is number => typeof v === 'number' && v > 0);
+    return values.length > 0 ? computeStats(values) : empty;
+  };
   return {
-    totalMs: computeStats(results.map(r => r.totalMs)),
-    cloneMs: computeStats(results.map(r => r.cloneMs ?? 0)),
-    installMs: computeStats(results.map(r => r.installMs ?? 0)),
-    typecheckMs: computeStats(results.map(r => r.typecheckMs ?? 0)),
+    totalMs: pick('totalMs'),
+    cloneMs: pick('cloneMs'),
+    installMs: pick('installMs'),
+    typecheckMs: pick('typecheckMs'),
   };
 }
 

--- a/src/sandbox/dax.ts
+++ b/src/sandbox/dax.ts
@@ -1,0 +1,281 @@
+import fs from 'fs';
+import os from 'os';
+import type { ProviderConfig, Stats } from './types.js';
+import { computeStats } from '../util/stats.js';
+import { withTimeout } from '../util/timeout.js';
+
+const BENCH_SCRIPT_URL = 'https://raw.githubusercontent.com/anomalyco/opencode/provider-benchmark/script/provider-benchmark.sh';
+
+export interface DaxTimingResult {
+  totalMs: number;
+  prepareMs?: number;
+  bunDownloadMs?: number;
+  bunUnpackMs?: number;
+  cloneMs?: number;
+  installMs?: number;
+  typecheckMs?: number;
+  cacheClearMs?: number;
+  diskAfterClone?: number;
+  diskAfterInstall?: number;
+  diskAfterTypecheck?: number;
+  commit?: string;
+  bunVersion?: string;
+  nodeVersion?: string;
+  architecture?: string;
+  kernel?: string;
+  logicalCpus?: string;
+  cpuModel?: string;
+  memoryKib?: string;
+  error?: string;
+}
+
+export interface DaxBenchmarkResult {
+  provider: string;
+  mode: 'sandbox-dax';
+  iterations: DaxTimingResult[];
+  summary: {
+    totalMs: Stats;
+    cloneMs: Stats;
+    installMs: Stats;
+    typecheckMs: Stats;
+  };
+  successRate?: number;
+  skipped?: boolean;
+  skipReason?: string;
+}
+
+export async function runDaxBenchmark(config: ProviderConfig): Promise<DaxBenchmarkResult> {
+  const { name, iterations = 3, timeout = 600_000, requiredEnvVars, sandboxOptions, destroyTimeoutMs = 15_000 } = config;
+
+  const missingVars = requiredEnvVars.filter(v => !process.env[v]);
+  if (missingVars.length > 0) {
+    return {
+      provider: name,
+      mode: 'sandbox-dax',
+      iterations: [],
+      summary: emptySummary(),
+      skipped: true,
+      skipReason: `Missing: ${missingVars.join(', ')}`,
+    };
+  }
+
+  const compute = config.createCompute();
+  const results: DaxTimingResult[] = [];
+
+  console.log(`\n--- Dax Benchmark: ${name} (${iterations} iterations) ---`);
+
+  for (let i = 0; i < iterations; i++) {
+    console.log(`  Iteration ${i + 1}/${iterations}...`);
+    let sandbox: any = null;
+
+    try {
+      sandbox = await withTimeout(compute.sandbox.create(sandboxOptions), timeout, 'Sandbox creation timed out');
+      const result = await runDaxIteration(sandbox, name, timeout);
+      results.push(result);
+      if (result.error) {
+        console.log(`    FAILED: ${result.error}`);
+      } else {
+        console.log(`    Total: ${(result.totalMs! / 1000).toFixed(2)}s | clone ${(result.cloneMs! / 1000).toFixed(2)}s | install ${(result.installMs! / 1000).toFixed(2)}s | typecheck ${(result.typecheckMs! / 1000).toFixed(2)}s`);
+      }
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      console.log(`    FAILED: ${error}`);
+      results.push({ totalMs: 0, error });
+    } finally {
+      if (sandbox) {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([
+            sandbox.destroy(),
+            new Promise((_, reject) => {
+              timer = setTimeout(() => reject(new Error('Destroy timeout')), destroyTimeoutMs);
+            }),
+          ]);
+        } catch (err) {
+          console.warn(`    [cleanup] destroy failed: ${err instanceof Error ? err.message : String(err)}`);
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
+      }
+    }
+  }
+
+  const successful = results.filter(r => !r.error);
+
+  return {
+    provider: name,
+    mode: 'sandbox-dax',
+    iterations: results,
+    summary: successful.length > 0 ? summarize(successful) : emptySummary(),
+    successRate: results.length > 0 ? successful.length / results.length : 0,
+  };
+}
+
+async function runDaxIteration(sandbox: any, providerName: string, timeout: number): Promise<DaxTimingResult> {
+  const script = String.raw`
+const { spawnSync } = require('child_process');
+const { performance } = require('perf_hooks');
+
+const scriptUrl = ${JSON.stringify(BENCH_SCRIPT_URL)};
+const provider = ${JSON.stringify(providerName)};
+
+const start = performance.now();
+
+// Download and run the dax benchmark script via curl|bash.
+// The script emits structured BENCH_PHASE / BENCH_META / BENCH_DISK / BENCH_DONE
+// lines on stdout and BENCH_ERROR on stderr that we parse below.
+// If curl is not available the script will fail (which is expected and tracked).
+const result = spawnSync('bash', ['-c', 'curl -fsSL ' + scriptUrl + ' | BENCH_PROVIDER=' + provider + ' BENCH_REGION=unknown bash'], {
+  encoding: 'utf8',
+  timeout: 540000,
+  stdio: ['ignore', 'pipe', 'pipe'],
+  env: { ...process.env, BENCH_PROVIDER: provider, BENCH_REGION: 'unknown' },
+});
+
+const totalMs = performance.now() - start;
+const stdout = result.stdout || '';
+const stderr = result.stderr || '';
+const exitCode = result.status;
+
+// Parse structured output lines
+const phases = {};
+const meta = {};
+const disk = {};
+let benchError = null;
+let doneCommit = null;
+
+for (const line of stdout.split('\n')) {
+  if (line.startsWith('BENCH_PHASE\t')) {
+    const parts = line.split('\t');
+    if (parts.length >= 3) phases[parts[1]] = parseInt(parts[2], 10);
+  } else if (line.startsWith('BENCH_META\t')) {
+    const parts = line.split('\t');
+    if (parts.length >= 3) meta[parts[1]] = parts[2];
+  } else if (line.startsWith('BENCH_DISK\t')) {
+    const parts = line.split('\t');
+    if (parts.length >= 3) disk[parts[1]] = parseInt(parts[2], 10);
+  } else if (line.startsWith('BENCH_DONE\t')) {
+    const parts = line.split('\t');
+    if (parts.length >= 2) doneCommit = parts[1];
+  }
+}
+
+for (const line of stderr.split('\n')) {
+  if (line.startsWith('BENCH_ERROR\t')) {
+    const parts = line.split('\t');
+    benchError = parts.slice(1).join(': ');
+  }
+}
+
+if (exitCode !== 0 && !benchError) {
+  // Include last few lines of stderr for diagnostics
+  const tail = stderr.trim().split('\n').slice(-3).join(' | ');
+  benchError = 'Script exited with code ' + exitCode + (tail ? ': ' + tail : '');
+}
+if (result.error) {
+  benchError = result.error.message || String(result.error);
+}
+
+console.log(JSON.stringify({
+  totalMs,
+  prepareMs: phases.prepare,
+  cacheClearMs: phases.cache_clear,
+  bunDownloadMs: phases.bun_download,
+  bunUnpackMs: phases.bun_unpack,
+  cloneMs: phases.clone,
+  installMs: phases.install,
+  typecheckMs: phases.typecheck,
+  diskAfterClone: disk.after_clone,
+  diskAfterInstall: disk.after_install,
+  diskAfterTypecheck: disk.after_typecheck,
+  commit: doneCommit || meta.commit,
+  bunVersion: meta.bun_version,
+  nodeVersion: meta.node_version,
+  architecture: meta.architecture,
+  kernel: meta.kernel,
+  logicalCpus: meta.logical_cpus,
+  cpuModel: meta.cpu_model,
+  memoryKib: meta.memory_kib,
+  ...(benchError ? { error: benchError } : {}),
+}));
+`;
+
+  const result = await withTimeout(
+    sandbox.runCommand(`node <<'NODE'\n${script}\nNODE`),
+    timeout,
+    'Dax benchmark timed out',
+  ) as { exitCode: number; stdout?: string; stderr?: string };
+
+  if (result.exitCode !== 0) {
+    throw new Error(`Dax benchmark failed with exit code ${result.exitCode}: ${result.stderr || 'Unknown error'}`);
+  }
+
+  const jsonLine = (result.stdout || '').trim().split('\n').reverse().find(line => line.trim().startsWith('{'));
+  if (!jsonLine) throw new Error('Dax benchmark did not emit JSON results');
+  return JSON.parse(jsonLine) as DaxTimingResult;
+}
+
+function summarize(results: DaxTimingResult[]): DaxBenchmarkResult['summary'] {
+  return {
+    totalMs: computeStats(results.map(r => r.totalMs)),
+    cloneMs: computeStats(results.map(r => r.cloneMs ?? 0)),
+    installMs: computeStats(results.map(r => r.installMs ?? 0)),
+    typecheckMs: computeStats(results.map(r => r.typecheckMs ?? 0)),
+  };
+}
+
+function emptySummary(): DaxBenchmarkResult['summary'] {
+  const empty = { median: 0, p95: 0, p99: 0 };
+  return { totalMs: empty, cloneMs: empty, installMs: empty, typecheckMs: empty };
+}
+
+function round(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export async function writeDaxResultsJson(results: DaxBenchmarkResult[], outPath: string): Promise<void> {
+  const cleanResults = results.map(r => ({
+    provider: r.provider,
+    mode: r.mode,
+    iterations: r.iterations.map(i => ({
+      totalMs: round(i.totalMs),
+      ...(i.prepareMs !== undefined ? { prepareMs: round(i.prepareMs) } : {}),
+      ...(i.cacheClearMs !== undefined ? { cacheClearMs: round(i.cacheClearMs) } : {}),
+      ...(i.bunDownloadMs !== undefined ? { bunDownloadMs: round(i.bunDownloadMs) } : {}),
+      ...(i.bunUnpackMs !== undefined ? { bunUnpackMs: round(i.bunUnpackMs) } : {}),
+      ...(i.cloneMs !== undefined ? { cloneMs: round(i.cloneMs) } : {}),
+      ...(i.installMs !== undefined ? { installMs: round(i.installMs) } : {}),
+      ...(i.typecheckMs !== undefined ? { typecheckMs: round(i.typecheckMs) } : {}),
+      ...(i.diskAfterClone !== undefined ? { diskAfterClone: i.diskAfterClone } : {}),
+      ...(i.diskAfterInstall !== undefined ? { diskAfterInstall: i.diskAfterInstall } : {}),
+      ...(i.diskAfterTypecheck !== undefined ? { diskAfterTypecheck: i.diskAfterTypecheck } : {}),
+      ...(i.commit ? { commit: i.commit } : {}),
+      ...(i.bunVersion ? { bunVersion: i.bunVersion } : {}),
+      ...(i.nodeVersion ? { nodeVersion: i.nodeVersion } : {}),
+      ...(i.architecture ? { architecture: i.architecture } : {}),
+      ...(i.kernel ? { kernel: i.kernel } : {}),
+      ...(i.logicalCpus ? { logicalCpus: i.logicalCpus } : {}),
+      ...(i.cpuModel ? { cpuModel: i.cpuModel } : {}),
+      ...(i.memoryKib ? { memoryKib: i.memoryKib } : {}),
+      ...(i.error ? { error: i.error } : {}),
+    })),
+    summary: Object.fromEntries(Object.entries(r.summary).map(([key, stats]) => [key, {
+      median: round(stats.median),
+      p95: round(stats.p95),
+      p99: round(stats.p99),
+    }])),
+    ...(r.successRate !== undefined ? { successRate: round(r.successRate) } : {}),
+    ...(r.skipped ? { skipped: r.skipped, skipReason: r.skipReason } : {}),
+  }));
+
+  const output = {
+    version: '1.0',
+    timestamp: new Date().toISOString(),
+    environment: { node: process.version, platform: os.platform(), arch: os.arch() },
+    config: { mode: 'sandbox-dax', timeoutMs: 600000, scriptUrl: BENCH_SCRIPT_URL },
+    results: cleanResults,
+  };
+
+  fs.writeFileSync(outPath, JSON.stringify(output, null, 2));
+  console.log(`Results written to ${outPath}`);
+}


### PR DESCRIPTION
## Summary

Adds a new `sandbox-dax` benchmark that runs the [opencode provider-benchmark.sh](https://raw.githubusercontent.com/anomalyco/opencode/provider-benchmark/script/provider-benchmark.sh) script inside each sandbox provider, measuring a cold clone + bun install + bun typecheck cycle of the opencode repository.

### What the script does
1. **prepare** - installs system packages (apt-get) + Node.js
2. **bun download/unpack** - fetches the Bun runtime
3. **clone** - `git fetch --depth=1` of opencode at a pinned commit
4. **install** - `bun install`
5. **typecheck** - `bun typecheck`

The script emits structured tab-separated lines (`BENCH_PHASE`, `BENCH_META`, `BENCH_DISK`, `BENCH_DONE`) which are parsed for per-phase timing data. On failure, the last few lines of stderr are included in the error message for diagnostics.

### Changes
- **`src/sandbox/dax.ts`** - New benchmark implementation (3 iterations, 10-min timeout per iteration)
- **`src/run.ts`** - Registered `sandbox-dax` mode (getModesToRun, modeToDir, runSandboxDax, main dispatch)
- **`package.json`** - Added `bench:sandbox:dax` script
- **`.github/workflows/sandbox-benchmarks.yml`** - Added `sandbox-dax` to workflow dispatch options, new `workload-bench` job (dax only), updated `collect` job dependencies, and dax results in PR comment table
- **`src/merge-results.ts`** - Added `sandbox-dax` to workload dirs set and modeToDir

### Usage
```bash
npm run bench:sandbox:dax                          # all providers
npm run bench -- --mode sandbox-dax --provider e2b  # single provider
```

> **Note:** The script requires curl, root/sudo, and apt-get. Providers without those capabilities will fail with diagnostic error messages (this is expected and tracked via success rate).