### PR TITLE
chore: default dax benchmark to 1 iteration

### DIFF
--- a/.github/workflows/sandbox-benchmarks.yml
+++ b/.github/workflows/sandbox-benchmarks.yml
@@ -242,7 +242,7 @@ jobs:
           npm run bench -- \
             --provider ${{ matrix.provider }} \
             --mode sandbox-dax \
-            --iterations ${{ github.event.inputs.iterations || (github.event_name == 'pull_request' && '1') || '3' }}
+            --iterations ${{ github.event.inputs.iterations || '1' }}
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Reduces dax benchmark iterations from 3 to 1 for all run types (PR, schedule, dispatch). Each iteration is expensive (apt-get + Node/Bun download + clone + install + typecheck), and 1 iteration is sufficient to see whether a provider can run the full workflow. Can still be overridden via the iterations input on manual dispatch.