### PR TITLE
dax: standardize declaw resources via node-large template

### DIFF
--- a/src/sandbox/dax.ts
+++ b/src/sandbox/dax.ts
@@ -29,6 +29,7 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   beam:         { cpu: 8, memory: 16384 },                   // cpu = cores, memory = MiB
   codesandbox:  { vmTier: VMTier.Small },                  // Small = 8 CPU, 16 GiB
   northflank:   { deploymentPlan: process.env.NORTHFLANK_DEPLOYMENT_PLAN || 'nf-compute-50' },  // resolved by scripts/find-northflank-plan.ts
+  declaw:       { templateId: 'node-large' },              // node-large template: 8 vCPU / 16 GiB RAM / 8 GiB disk
 };
 
 function getSandboxOptionsWithResources(providerName: string, baseOptions?: Record<string, any>): Record<string, any> {


### PR DESCRIPTION
Builds on #196 — adds `declaw` to `DAX_RESOURCE_OPTIONS` so it targets the same 8 vCPU / 16 GiB profile the other providers are standardized to.

declaw selects resource sizing by template rather than by per-field cpu/memory options, so the standardized profile is expressed as a template id. `node-large` provisions **8 vCPU / 16 GiB RAM** with an 8 GiB disk overlay. The `@computesdk/declaw` adapter forwards `templateId` straight through to sandbox creation, so the single map entry is all that's needed:

```ts
declaw: { templateId: 'node-large' },
```

This is targeted at the `fix/dax-standardize-resources` branch so it folds into #196 as one change rather than a competing one. Happy to retarget to `main` if you'd rather land them separately.
