### PR TITLE
feat: run lightning at cpu-8 (8 vCPU / 16 GiB) in dax benchmark

### DIFF
--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -115,6 +115,7 @@ jobs:
           HOPX_API_KEY: ${{ secrets.HOPX_API_KEY }}
           ISORUN_API_KEY: ${{ secrets.ISORUN_API_KEY }}
           LIGHTNING_API_KEY: ${{ secrets.LIGHTNING_API_KEY }}
+          LIGHTNING_INSTANCE_TYPE: cpu-8 # 8 vCPU / 16 GiB, matching the standardized dax profile
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           NORTHFLANK_TOKEN: ${{ secrets.NORTHFLANK_TOKEN }}

--- a/env.example
+++ b/env.example
@@ -106,6 +106,9 @@ CREATEOS_SANDBOX_API_KEY=your_createos_sandbox_api_key
 
 ######### LIGHTNING ########
 LIGHTNING_API_KEY=your_lightning_api_key
+# Instance type for new sandboxes (cpu-1, cpu-2, ... cpu-16). Defaults to cpu-1.
+# The dax benchmark uses cpu-8 (8 vCPU / 16 GiB) for a fair cross-provider comparison.
+LIGHTNING_INSTANCE_TYPE=cpu-1
 
 ######### AI GATEWAYS ########
 OPENROUTER_API_KEY=your_openrouter_api_key

--- a/src/sandbox/dax.ts
+++ b/src/sandbox/dax.ts
@@ -17,6 +17,8 @@ const BENCH_SCRIPT_PATH = path.resolve(import.meta.dirname, '../../scripts/dax-b
 // Each provider uses different parameter names and units, so we map per-provider.
 // Providers not listed here don't support CPU/memory configuration at sandbox creation time.
 // Note: E2B sets CPU/memory at template build time, not at sandbox creation.
+// Note: lightning is sized via LIGHTNING_INSTANCE_TYPE=cpu-8 (8 vCPU / 16 GiB), applied on
+// the provider factory in providers.ts — the SDK ignores an instanceType passed to create().
 const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   modal:        { cpu: 4, cpuLimit: 4, memoryMiB: 16384 }, // Modal: 1 core = 2 vCPUs, so 4 cores = 8 vCPUs
   tensorlake:   { cpus: 8, memoryMb: 16384 },

--- a/src/sandbox/providers.ts
+++ b/src/sandbox/providers.ts
@@ -115,7 +115,15 @@ export const providers: ProviderConfig[] = [
   {
     name: 'lightning',
     requiredEnvVars: ['LIGHTNING_API_KEY'],
-    createCompute: () => lightning({ apiKey: process.env.LIGHTNING_API_KEY! }),
+    // Lightning sizes sandboxes via `instanceType` on the provider factory (the SDK
+    // ignores an instanceType passed to sandbox.create()), so it can't be sized through
+    // DAX_RESOURCE_OPTIONS like most providers. The dax workflow sets
+    // LIGHTNING_INSTANCE_TYPE=cpu-8 for the standardized 8 vCPU / 16 GiB profile;
+    // it defaults to cpu-1 (the SDK default) everywhere else.
+    createCompute: () => lightning({
+      apiKey: process.env.LIGHTNING_API_KEY!,
+      instanceType: process.env.LIGHTNING_INSTANCE_TYPE || 'cpu-1',
+    }),
   },
   {
     name: 'modal',


### PR DESCRIPTION
## What

Sizes the **lightning** provider to **8 vCPU / 16 GiB** (`cpu-8`) in the dax benchmark, matching the standardized resource profile introduced in #196.

## Why

Lightning was already in the dax matrix but had no resource sizing, so it ran on the SDK default `cpu-1` (1 vCPU) while every other provider used 8 vCPU / 16 GiB — making its results incomparable (the same issue #196 fixed for the rest of the matrix).

## How

Lightning can't be sized through `DAX_RESOURCE_OPTIONS` like most providers. The `@computesdk/lightning` wrapper applies `instanceType` from the **provider factory config** and *overrides* any `instanceType` passed to `sandbox.create()`:

```js
const params = { ...providerOptions, instanceType: config.instanceType ?? DEFAULT_INSTANCE_TYPE };
```

So sizing has to happen at `createCompute` time. This PR:

- Reads `LIGHTNING_INSTANCE_TYPE` in `createCompute` (default `cpu-1`, the SDK default), mirroring how `northflank` reads its deployment plan from env with a fallback.
- Sets `LIGHTNING_INSTANCE_TYPE: cpu-8` in the dax workflow env, scoping the 8 vCPU sizing to the dax benchmark and leaving other modes (e.g. TTI) on the default.
- Documents the mechanism in `dax.ts` (next to the existing E2B note) and `env.example`.

## Verification

Ran the dax benchmark against lightning.ai with `cpu-8`:

```
lightning: 7/7 phases | total 41.93s | prepare 4.37s | clone 2.41s | install 12.91s | typecheck 16.04s (1/1 OK)
```

The sandbox reports **8 logical CPUs**, confirming `cpu-8` took effect, and all 7 dax phases complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)