### PR TITLE
fix: reduce namespace resource specs to 8 vCPU / 16 GiB

### DIFF
--- a/src/sandbox/providers.ts
+++ b/src/sandbox/providers.ts
@@ -128,8 +128,8 @@ export const providers: ProviderConfig[] = [
     createCompute: () =>
       namespace({
         token: process.env.NSC_TOKEN!,
-        virtualCpu: 16,
-        memoryMegabytes: 32768,
+        virtualCpu: 8,
+        memoryMegabytes: 16384,
       }),
     // Use namespace's builtin:base image (default in @computesdk/namespace@1.6.14+)
   },


### PR DESCRIPTION
## Summary

Namespace was configured with 16 vCPU and 32 GiB RAM — 2x the standard target of 8 vCPU / 16 GiB used by all other providers in the dax benchmark suite.

This change aligns namespace with the rest of the providers for fair comparison.

## Changes
- `src/sandbox/providers.ts`: `virtualCpu: 16 → 8`, `memoryMegabytes: 32768 → 16384`

## Context
Follow-up to PR #198 which was merged with the namespace provider addition.