### PR TITLE
fix: use stateful mode for cloud-run and handle missing packages

### DIFF
--- a/benchmarks/sandbox/providers.ts
+++ b/benchmarks/sandbox/providers.ts
@@ -57,7 +57,13 @@ export const providers: ProviderConfig[] = [
   {
     name: 'cloud-run',
     requiredEnvVars: ['CLOUD_RUN_SANDBOX_URL', 'CLOUD_RUN_SANDBOX_SECRET'],
-    createCompute: () => cloudRun({ sandboxUrl: process.env.CLOUD_RUN_SANDBOX_URL!, sandboxSecret: process.env.CLOUD_RUN_SANDBOX_SECRET! }),
+    createCompute: () => cloudRun({
+      sandboxUrl: process.env.CLOUD_RUN_SANDBOX_URL!,
+      sandboxSecret: process.env.CLOUD_RUN_SANDBOX_SECRET!,
+      executionMode: 'stateful',
+      write: true,
+      allowEgress: true,
+    }),
   },
   {
     name: 'cloudflare',

--- a/benchmarks/scripts/dax-benchmark.sh
+++ b/benchmarks/scripts/dax-benchmark.sh
@@ -138,21 +138,27 @@ prepare() {
   case "$PKG_MANAGER" in
     apt)
       "${SUDO[@]}" apt-get update -qq
-      # Required packages — must succeed.
-      "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
-        bash build-essential ca-certificates curl git python3
-      # Optional packages — not available on all minimal images (e.g. cloud-run).
-      "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
-        python3-setuptools unzip 2>/dev/null || true
+      # python3-setuptools and unzip are missing from some minimal images (e.g.
+      # cloud-run's gVisor rootfs), and apt-get installs *nothing* when any
+      # argument is unknown, so drop unavailable ones instead of losing the
+      # whole transaction. unzip has a Python fallback in unpack_bun().
+      local packages=(bash build-essential ca-certificates curl git python3)
+      local optional
+      for optional in python3-setuptools unzip; do
+        if apt-cache show "$optional" >/dev/null 2>&1; then
+          packages+=("$optional")
+        fi
+      done
+      "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "${packages[@]}"
       ;;
     dnf)
       "${SUDO[@]}" dnf makecache --quiet
-      # Required packages — must succeed.
       "${SUDO[@]}" dnf install -y --allowerasing \
         bash gcc gcc-c++ make ca-certificates curl git python3
-      # Optional packages — not available on all minimal images.
-      "${SUDO[@]}" dnf install -y --allowerasing \
-        python3-setuptools unzip 2>/dev/null || true
+      local optional
+      for optional in python3-setuptools unzip; do
+        "${SUDO[@]}" dnf install -y --allowerasing "$optional" || true
+      done
       ;;
     apk)
       # build-base is Alpine's meta-package for gcc/g++/make/libc-dev.
@@ -200,15 +206,16 @@ unpack_bun() {
   if command -v unzip >/dev/null 2>&1; then
     unzip -q -j "$ROOT/bun.zip" "$BUN_INTERNAL_PATH" -d "$BUN_INSTALL/bin"
   else
-    # Fallback for minimal images without unzip (e.g. cloud-run gVisor).
-    python3 -c "
-import zipfile, os, sys
-with zipfile.ZipFile('$ROOT/bun.zip') as z:
-    data = z.read('$BUN_INTERNAL_PATH')
-    os.makedirs('$BUN_INSTALL/bin', exist_ok=True)
-    with open(os.path.join('$BUN_INSTALL/bin', 'bun'), 'wb') as f:
-        f.write(data)
-"
+    # Fallback for minimal images without unzip (e.g. cloud-run's gVisor rootfs).
+    python3 - "$ROOT/bun.zip" "$BUN_INTERNAL_PATH" "$BUN_INSTALL/bin" <<'PY'
+import os, shutil, sys, zipfile
+
+archive, member, dest_dir = sys.argv[1:4]
+os.makedirs(dest_dir, exist_ok=True)
+with zipfile.ZipFile(archive) as z, z.open(member) as src:
+    with open(os.path.join(dest_dir, 'bun'), 'wb') as dst:
+        shutil.copyfileobj(src, dst)
+PY
   fi
   chmod +x "$BUN_INSTALL/bin/bun"
 }

--- a/benchmarks/scripts/dax-benchmark.sh
+++ b/benchmarks/scripts/dax-benchmark.sh
@@ -138,13 +138,21 @@ prepare() {
   case "$PKG_MANAGER" in
     apt)
       "${SUDO[@]}" apt-get update -qq
+      # Required packages — must succeed.
       "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
-        bash build-essential ca-certificates curl git python3 python3-setuptools unzip
+        bash build-essential ca-certificates curl git python3
+      # Optional packages — not available on all minimal images (e.g. cloud-run).
+      "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+        python3-setuptools unzip 2>/dev/null || true
       ;;
     dnf)
       "${SUDO[@]}" dnf makecache --quiet
+      # Required packages — must succeed.
       "${SUDO[@]}" dnf install -y --allowerasing \
-        bash gcc gcc-c++ make ca-certificates curl git python3 python3-setuptools unzip
+        bash gcc gcc-c++ make ca-certificates curl git python3
+      # Optional packages — not available on all minimal images.
+      "${SUDO[@]}" dnf install -y --allowerasing \
+        python3-setuptools unzip 2>/dev/null || true
       ;;
     apk)
       # build-base is Alpine's meta-package for gcc/g++/make/libc-dev.
@@ -189,7 +197,19 @@ download_bun() {
 }
 
 unpack_bun() {
-  unzip -q -j "$ROOT/bun.zip" "$BUN_INTERNAL_PATH" -d "$BUN_INSTALL/bin"
+  if command -v unzip >/dev/null 2>&1; then
+    unzip -q -j "$ROOT/bun.zip" "$BUN_INTERNAL_PATH" -d "$BUN_INSTALL/bin"
+  else
+    # Fallback for minimal images without unzip (e.g. cloud-run gVisor).
+    python3 -c "
+import zipfile, os, sys
+with zipfile.ZipFile('$ROOT/bun.zip') as z:
+    data = z.read('$BUN_INTERNAL_PATH')
+    os.makedirs('$BUN_INSTALL/bin', exist_ok=True)
+    with open(os.path.join('$BUN_INSTALL/bin', 'bun'), 'wb') as f:
+        f.write(data)
+"
+  fi
   chmod +x "$BUN_INSTALL/bin/bun"
 }
 


### PR DESCRIPTION
## Summary

Gets cloud-run past 2/7 phases in the dax benchmark. Two independent causes:

1. **No filesystem persistence.** The default `ephemeral` mode runs each command via `sandbox do` in a fresh sandbox, so nothing the script writes survives. `cloud-run` now uses `executionMode: 'stateful'` (`sandbox run`/`exec`/`delete`) plus `write: true` and `allowEgress: true` for the bun/node downloads and `git clone`.

2. **`apt-get` is all-or-nothing.** cloud-run's gVisor rootfs has no `python3-setuptools` or `unzip`, and a single unknown argument makes apt install *nothing* — which is why the log showed `curl: command not found` after the apt failure. The fix filters unavailable optionals out of one install invocation rather than adding a second (`prepare` is a timed phase):

```diff
-apt-get install -y -qq bash build-essential ca-certificates curl git python3 python3-setuptools unzip
+packages=(bash build-essential ca-certificates curl git python3)
+for optional in python3-setuptools unzip; do
+  apt-cache show "$optional" >/dev/null 2>&1 && packages+=("$optional")
+done
+apt-get install -y -qq "${packages[@]}"
```

`dnf` installs the same two optionals one at a time with `|| true` (same all-or-nothing problem, but dnf providers are rare enough that the extra round trip doesn't matter). `apk` is unchanged — Alpine ships both.

`unpack_bun()` falls back to `python3` + `zipfile` when `unzip` is absent, via a quoted heredoc with paths passed as `sys.argv` so nothing is interpolated into the Python source. Verified locally against a synthetic zip with `unzip` removed from `PATH`: byte-identical output to the `unzip -j` path.

## Note for reviewers

`benchmarks/sandbox/providers.ts` is shared by every sandbox mode (`benchmarks/src/run.ts`), so the stateful switch also affects cloud-run's sequential/staggered TTI numbers (currently 91.5, 10/10) — `sandbox do` and `sandbox run`/`exec` are different code paths. Worth sanity-checking the benchmark comment on this PR for a TTI regression before merging.

Rebased onto the post-#207 layout (`scripts/` → `benchmarks/scripts/`, `src/sandbox/` → `benchmarks/sandbox/`); the previous merge conflict is gone. `pnpm typecheck` passes.

Link to Devin session: https://app.devin.ai/sessions/5bbf1eb8873f49b5b41a78351c86c70a
Requested by: @HeyGarrison