### PR TITLE
fix(dax): support Alpine/musl sandboxes in the dax benchmark

### DIFF
--- a/scripts/dax-benchmark.sh
+++ b/scripts/dax-benchmark.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Cold OpenCode clone/install/typecheck benchmark for a fresh VM (Debian/Ubuntu x86_64 or aarch64).
+# Cold OpenCode clone/install/typecheck benchmark for a fresh VM.
+# Supports Debian/Ubuntu (apt), RHEL/Fedora (dnf), and Alpine (apk) on x86_64 or aarch64.
 
 set -euo pipefail
 
@@ -32,15 +33,27 @@ case "$ARCH" in
     exit 1
     ;;
 esac
-BUN_FILENAME="bun-linux-${BUN_ARCH}${BUN_BASELINE_SUFFIX}.zip"
-BUN_INTERNAL_PATH="bun-linux-${BUN_ARCH}${BUN_BASELINE_SUFFIX}/bun"
+# Detect the C library. Alpine (and other minimal images) ship musl instead of
+# glibc, and Bun publishes separate `-musl` release assets that must be used
+# there — the default glibc binary segfaults on musl. Node.js has no official
+# musl build, but Alpine images ship Node pre-installed, so prepare() reuses it.
+BUN_MUSL_SUFFIX=""
+if [ -f /lib/ld-musl-x86_64.so.1 ] || [ -f /lib/ld-musl-aarch64.so.1 ] || (ldd --version 2>&1 | grep -qi musl); then
+  BUN_MUSL_SUFFIX="-musl"
+fi
 
-# Detect the available package manager (apt-get on Debian/Ubuntu, dnf on RHEL/Fedora).
+BUN_FILENAME="bun-linux-${BUN_ARCH}${BUN_MUSL_SUFFIX}${BUN_BASELINE_SUFFIX}.zip"
+BUN_INTERNAL_PATH="bun-linux-${BUN_ARCH}${BUN_MUSL_SUFFIX}${BUN_BASELINE_SUFFIX}/bun"
+
+# Detect the available package manager (apt-get on Debian/Ubuntu, dnf on
+# RHEL/Fedora, apk on Alpine).
 PKG_MANAGER=""
 if command -v apt-get >/dev/null 2>&1; then
   PKG_MANAGER="apt"
 elif command -v dnf >/dev/null 2>&1; then
   PKG_MANAGER="dnf"
+elif command -v apk >/dev/null 2>&1; then
+  PKG_MANAGER="apk"
 else
   printf 'BENCH_ERROR\tprepare\tno_package_manager_found\n' >&2
   exit 1
@@ -48,8 +61,18 @@ fi
 
 declare -A PHASE_MS=()
 
+# Return a nanosecond epoch timestamp. GNU coreutils `date` supports %N and
+# yields a 19-digit value. BusyBox `date` (Alpine) does not expand %N, emitting
+# only the 10-digit seconds (or a literal "N"), which would collapse every phase
+# delta to 0. In that case fall back to bash's builtin EPOCHREALTIME
+# (seconds.microseconds, locale radix normalized to a dot), padded to ns.
 timestamp() {
-  date +%s%N
+  local ns="$(date +%s%N 2>/dev/null)"
+  if [[ "$ns" == *[!0-9]* || ${#ns} -lt 19 ]]; then
+    local real="${EPOCHREALTIME/,/.}"
+    ns="${real%.*}${real#*.}000"
+  fi
+  printf '%s' "$ns"
 }
 
 phase() {
@@ -122,6 +145,11 @@ prepare() {
       "${SUDO[@]}" dnf makecache --quiet
       "${SUDO[@]}" dnf install -y --allowerasing \
         bash gcc gcc-c++ make ca-certificates curl git python3 python3-setuptools unzip
+      ;;
+    apk)
+      # build-base is Alpine's meta-package for gcc/g++/make/libc-dev.
+      "${SUDO[@]}" apk add --no-cache \
+        bash build-base ca-certificates curl git python3 py3-setuptools unzip
       ;;
   esac
 


### PR DESCRIPTION
The blaxel provider defaults to `blaxel/base-image:latest`, which is Alpine Linux (musl libc). The dax benchmark script assumed a Debian/RHEL glibc environment, so every blaxel iteration failed with `prepare: no_package_manager_found` (0/7 phases) in CI.

Fixing the immediate crash uncovered two further Alpine-specific bugs that would have produced silently wrong results, so all three are addressed here:

1. Package manager: detection only knew apt-get/dnf and bailed before doing any work on Alpine. Add `apk` detection plus an `apk add` branch in prepare() (build-base, python3, py3-setuptools, etc.).

2. Bun binary: the download hard-coded the glibc asset (bun-linux-x64-baseline.zip), which segfaults on musl. Detect musl via /lib/ld-musl-* (or `ldd`) and append the `-musl` suffix to the Bun asset name and its internal extraction path.

3. Phase timings: Alpine's `date` is BusyBox, which does not expand `%N`, so `(end - start) / 1000000` collapsed every phase to 0ms. Phases reported "OK" while the clone/install/typecheck numbers — the entire point of the benchmark — were zero. (Total was unaffected because dax.ts measures it separately via Date.now().) Fall back to bash's builtin EPOCHREALTIME (microsecond precision, locale radix normalized to a dot) when `date +%s%N` doesn't yield real nanoseconds.

Node.js needs no change: Alpine ships it preinstalled and prepare() already skips the download when `node` exists — correct, since nodejs.org publishes no musl build.

glibc providers are unaffected: the musl suffix stays empty and `date +%s%N` is still used whenever available.

Verified end-to-end against the live blaxel sandbox: 7/7 phases | prepare 2.21s | clone 2.15s | install 12.33s | typecheck 39.45s