### PR TITLE
chore(createos): update sandbox resource for dax tests

### DIFF
--- a/src/sandbox/dax.ts
+++ b/src/sandbox/dax.ts
@@ -31,6 +31,7 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   northflank:   { deploymentPlan: process.env.NORTHFLANK_DEPLOYMENT_PLAN || 'nf-compute-50' },  // resolved by scripts/find-northflank-plan.ts
   declaw:       { templateId: 'node-large' },              // node-large template: 8 vCPU / 16 GiB RAM / 8 GiB disk
   superserve:   { vcpu: 8, memoryMib: 16384 },               // vcpu = cores, memoryMib = MiB; overrides template defaults
+  createos:     { shape: 's-8vcpu-16gb', ephemeralDiskMb: 61440 }, // 8 vCPU, 16 GiB RAM, 60 GiB disk
 };
 
 function getSandboxOptionsWithResources(providerName: string, baseOptions?: Record<string, any>): Record<string, any> {


### PR DESCRIPTION
## Summary

- Add CreateOS to `DAX_RESOURCE_OPTIONS` with `s-8vcpu-16gb` shape and 60 GiB disk for fair comparison with other providers (all standardized to 8 vCPU / 16 GiB RAM)
- `ephemeralDiskMb: 61440` ensures enough disk space for the full `bun install` (~2.5GB node_modules)

## Test plan

- [x] Verified locally: CreateOS achieves 7/7 phases with these resource settings
- [x] Clone: ~4s, Install: ~13s, Typecheck: ~37s, Total workload: ~55s
- [x] Resource options only apply to dax benchmarks, not TTI benchmarks