### PR TITLE
ci: run benchmark smoketests on merge to master instead of on PRs

### DIFF
--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -1,7 +1,8 @@
 name: Browser Benchmark
 
 on:
-  pull_request:
+  push:
+    branches: [master]
     paths:
       - 'src/browser/**'
       - 'src/util/**'
@@ -70,7 +71,7 @@ jobs:
           npm run bench -- \
             --mode browser \
             --provider ${{ matrix.provider }} \
-            --iterations ${{ github.event_name == 'pull_request' && '10' || github.event.inputs.iterations || '100' }}
+            --iterations ${{ github.event_name == 'push' && '10' || github.event.inputs.iterations || '100' }}
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4
@@ -111,7 +112,7 @@ jobs:
       - name: Merge results
         run: npx tsx src/merge-results.ts --input artifacts --mode browser
       - name: Ingest results to platform
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'push'
         continue-on-error: true
         env:
           INGEST_URL: ${{ secrets.INGEST_URL }}
@@ -119,15 +120,15 @@ jobs:
         run: npx tsx src/ingest.ts --type browser
       - run: npm run generate-browser-svg
       - name: Upload SVG as artifact
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: browser-benchmark-svg
           path: browser.svg
           if-no-files-found: ignore
           retention-days: 7
-      - name: Post results to PR
-        if: github.event_name == 'pull_request'
+      - name: Post results to merged PR
+        if: github.event_name == 'push'
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -173,11 +174,29 @@ jobs:
 
             body += `---\n*[View full run](${runUrl}) · SVG available as [build artifact](${runUrl}#artifacts)*`;
 
+            // This push is a merge to master — post results to the PR it closed.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const pr = prs[0];
+            if (!pr) {
+              // Direct push with no associated PR — fall back to a commit comment.
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body,
+              });
+              return;
+            }
+
             const marker = '## Browser Benchmark Results';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: pr.number,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));
@@ -193,12 +212,12 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: pr.number,
                 body,
               });
             }
       - name: Commit and push
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -175,12 +175,15 @@ jobs:
             body += `---\n*[View full run](${runUrl}) · SVG available as [build artifact](${runUrl}#artifacts)*`;
 
             // This push is a merge to master — post results to the PR it closed.
+            // A commit can be associated with several PRs (backports, merge
+            // queue), so pick the one merged into the branch we pushed to.
+            const target = context.ref.replace('refs/heads/', '');
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
             });
-            const pr = prs[0];
+            const pr = prs.find(p => p.merged_at && p.base.ref === target);
             if (!pr) {
               // Direct push with no associated PR — fall back to a commit comment.
               await github.rest.repos.createCommitComment({
@@ -193,10 +196,11 @@ jobs:
             }
 
             const marker = '## Browser Benchmark Results';
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
+              per_page: 100,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -219,12 +219,15 @@ jobs:
             body += `---\n*[View full run](${runUrl}) · SVG available as [build artifact](${runUrl}#artifacts)*`;
 
             // This push is a merge to master — post results to the PR it closed.
+            // A commit can be associated with several PRs (backports, merge
+            // queue), so pick the one merged into the branch we pushed to.
+            const target = context.ref.replace('refs/heads/', '');
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
             });
-            const pr = prs[0];
+            const pr = prs.find(p => p.merged_at && p.base.ref === target);
             if (!pr) {
               // Direct push with no associated PR — fall back to a commit comment.
               await github.rest.repos.createCommitComment({
@@ -237,10 +240,11 @@ jobs:
             }
 
             const marker = '## Browser Throughput Benchmark Results';
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
+              per_page: 100,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -1,7 +1,8 @@
 name: Browser Throughput Benchmark
 
 on:
-  pull_request:
+  push:
+    branches: [master]
     paths:
       - 'src/browser/**'
       - 'src/util/**'
@@ -38,7 +39,7 @@ jobs:
           # Resolve one concrete article per iteration up front so every
           # provider benchmarks against the same page in a given round — but a
           # different page each round, so we don't measure a warmed cache.
-          count=${{ github.event_name == 'pull_request' && '3' || github.event.inputs.iterations || '100' }}
+          count=${{ github.event_name == 'push' && '3' || github.event.inputs.iterations || '100' }}
           urls=()
           for i in $(seq 1 "$count"); do
             # Follow Special:Random's redirect once to a concrete article URL.
@@ -121,7 +122,7 @@ jobs:
           npm run bench -- \
             --mode browser-throughput \
             --provider ${{ matrix.provider }} \
-            --iterations ${{ github.event_name == 'pull_request' && '3' || github.event.inputs.iterations || '100' }}
+            --iterations ${{ github.event_name == 'push' && '3' || github.event.inputs.iterations || '100' }}
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4
@@ -163,15 +164,15 @@ jobs:
         run: npx tsx src/merge-results.ts --input artifacts --mode browser-throughput
       - run: npm run generate-browser-throughput-svg
       - name: Upload SVG as artifact
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: browser-throughput-benchmark-svg
           path: browser-throughput.svg
           if-no-files-found: ignore
           retention-days: 7
-      - name: Post results to PR
-        if: github.event_name == 'pull_request'
+      - name: Post results to merged PR
+        if: github.event_name == 'push'
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -217,11 +218,29 @@ jobs:
 
             body += `---\n*[View full run](${runUrl}) · SVG available as [build artifact](${runUrl}#artifacts)*`;
 
+            // This push is a merge to master — post results to the PR it closed.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const pr = prs[0];
+            if (!pr) {
+              // Direct push with no associated PR — fall back to a commit comment.
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body,
+              });
+              return;
+            }
+
             const marker = '## Browser Throughput Benchmark Results';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: pr.number,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));
@@ -237,12 +256,12 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: pr.number,
                 body,
               });
             }
       - name: Commit and push
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -1,7 +1,8 @@
 name: Sandbox Dax Benchmark
 
 on:
-  pull_request:
+  push:
+    branches: [master]
     paths:
       - 'src/sandbox/dax.ts'
       - 'src/sandbox/providers.ts'
@@ -169,14 +170,14 @@ jobs:
       - name: Merge results
         run: npx tsx src/merge-results.ts --input artifacts
       - name: Ingest results to platform
-        if: github.event_name != 'pull_request' && github.event.inputs.dry_run != 'true'
+        if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         continue-on-error: true
         env:
           INGEST_URL: ${{ secrets.INGEST_URL }}
           INGEST_SECRET: ${{ secrets.INGEST_SECRET }}
         run: npx tsx src/ingest.ts --type sandbox
-      - name: Post results to PR
-        if: github.event_name == 'pull_request'
+      - name: Post results to merged PR
+        if: github.event_name == 'push'
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -217,11 +218,29 @@ jobs:
 
             body += `---\n*[View full run](${runUrl})*`;
 
+            // This push is a merge to master — post results to the PR it closed.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const pr = prs[0];
+            if (!pr) {
+              // Direct push with no associated PR — fall back to a commit comment.
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body,
+              });
+              return;
+            }
+
             const marker = '## Sandbox Dax Benchmark Results';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: pr.number,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));
@@ -237,12 +256,12 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: pr.number,
                 body,
               });
             }
       - name: Commit and push
-        if: github.event_name != 'pull_request' && github.event.inputs.dry_run != 'true'
+        if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -219,12 +219,15 @@ jobs:
             body += `---\n*[View full run](${runUrl})*`;
 
             // This push is a merge to master — post results to the PR it closed.
+            // A commit can be associated with several PRs (backports, merge
+            // queue), so pick the one merged into the branch we pushed to.
+            const target = context.ref.replace('refs/heads/', '');
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
             });
-            const pr = prs[0];
+            const pr = prs.find(p => p.merged_at && p.base.ref === target);
             if (!pr) {
               // Direct push with no associated PR — fall back to a commit comment.
               await github.rest.repos.createCommitComment({
@@ -237,10 +240,11 @@ jobs:
             }
 
             const marker = '## Sandbox Dax Benchmark Results';
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
+              per_page: 100,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));

--- a/.github/workflows/sandbox-tti-benchmarks.yml
+++ b/.github/workflows/sandbox-tti-benchmarks.yml
@@ -266,12 +266,15 @@ jobs:
             body += `---\n*[View full run](${runUrl}) · SVGs available as [build artifacts](${runUrl}#artifacts)*`;
 
             // This push is a merge to master — post results to the PR it closed.
+            // A commit can be associated with several PRs (backports, merge
+            // queue), so pick the one merged into the branch we pushed to.
+            const target = context.ref.replace('refs/heads/', '');
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
             });
-            const pr = prs[0];
+            const pr = prs.find(p => p.merged_at && p.base.ref === target);
             if (!pr) {
               // Direct push with no associated PR — fall back to a commit comment.
               await github.rest.repos.createCommitComment({
@@ -285,10 +288,11 @@ jobs:
 
             // Find and update existing comment or create new one
             const marker = '## Sandbox Benchmark Results';
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
+              per_page: 100,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));

--- a/.github/workflows/sandbox-tti-benchmarks.yml
+++ b/.github/workflows/sandbox-tti-benchmarks.yml
@@ -1,7 +1,8 @@
 name: Sandbox TTI Benchmark
 
 on:
-  pull_request:
+  push:
+    branches: [master]
     paths:
       - 'src/sandbox/**'
       - 'src/util/**'
@@ -149,8 +150,8 @@ jobs:
           fi
           npm run bench -- \
             --provider ${{ matrix.provider }} \
-            --iterations ${{ github.event.inputs.iterations || (github.event_name == 'pull_request' && '10') || '100' }} \
-            --concurrency ${{ github.event.inputs.concurrency || (github.event_name == 'pull_request' && '10') || '100' }} \
+            --iterations ${{ github.event.inputs.iterations || (github.event_name == 'push' && '10') || '100' }} \
+            --concurrency ${{ github.event.inputs.concurrency || (github.event_name == 'push' && '10') || '100' }} \
             $MODE_FLAG
       - name: Upload results
         if: always() && (github.event_name != 'workflow_dispatch' || github.event.inputs.provider == '' || github.event.inputs.provider == matrix.provider)
@@ -192,7 +193,7 @@ jobs:
       - name: Merge results
         run: npx tsx src/merge-results.ts --input artifacts
       - name: Ingest results to platform
-        if: github.event_name != 'pull_request' && github.event.inputs.dry_run != 'true'
+        if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         continue-on-error: true
         env:
           INGEST_URL: ${{ secrets.INGEST_URL }}
@@ -201,7 +202,7 @@ jobs:
       - run: npm run generate-svg
       - run: npm run generate-pricing-svg
       - name: Upload SVGs as artifacts
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: sandbox-benchmark-svgs
@@ -211,8 +212,8 @@ jobs:
             pricing.svg
           if-no-files-found: ignore
           retention-days: 7
-      - name: Post results to PR
-        if: github.event_name == 'pull_request'
+      - name: Post results to merged PR
+        if: github.event_name == 'push'
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -264,12 +265,30 @@ jobs:
 
             body += `---\n*[View full run](${runUrl}) · SVGs available as [build artifacts](${runUrl}#artifacts)*`;
 
+            // This push is a merge to master — post results to the PR it closed.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const pr = prs[0];
+            if (!pr) {
+              // Direct push with no associated PR — fall back to a commit comment.
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body,
+              });
+              return;
+            }
+
             // Find and update existing comment or create new one
             const marker = '## Sandbox Benchmark Results';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: pr.number,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));
@@ -285,12 +304,12 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: pr.number,
                 body,
               });
             }
       - name: Commit and push
-        if: github.event_name != 'pull_request' && github.event.inputs.dry_run != 'true'
+        if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/snapshot-fork-benchmarks.yml
+++ b/.github/workflows/snapshot-fork-benchmarks.yml
@@ -256,12 +256,15 @@ jobs:
             body += `---\n*[View full run](${runUrl})*`;
 
             // This push is a merge to master — post results to the PR it closed.
+            // A commit can be associated with several PRs (backports, merge
+            // queue), so pick the one merged into the branch we pushed to.
+            const target = context.ref.replace('refs/heads/', '');
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
             });
-            const pr = prs[0];
+            const pr = prs.find(p => p.merged_at && p.base.ref === target);
             if (!pr) {
               // Direct push with no associated PR — fall back to a commit comment.
               await github.rest.repos.createCommitComment({
@@ -275,10 +278,11 @@ jobs:
 
             // Find and update existing comment or create new one
             const marker = '## Snapshot/Fork Benchmark Results';
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
+              per_page: 100,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));

--- a/.github/workflows/snapshot-fork-benchmarks.yml
+++ b/.github/workflows/snapshot-fork-benchmarks.yml
@@ -1,7 +1,8 @@
 name: Snapshot/Fork Benchmark
 
 on:
-  pull_request:
+  push:
+    branches: [master]
     paths:
       - 'src/storage/**'
       - 'src/util/**'
@@ -112,7 +113,7 @@ jobs:
             --mode snapshot-fork \
             --provider ${{ matrix.provider }} \
             --dataset ${{ github.event.inputs.dataset || 'small' }} \
-            --iterations ${{ (github.event_name == 'schedule' && '100') || github.event.inputs.iterations || (github.event_name == 'pull_request' && '1') || '3' }}
+            --iterations ${{ (github.event_name == 'schedule' && '100') || github.event.inputs.iterations || (github.event_name == 'push' && '1') || '3' }}
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4
@@ -169,15 +170,15 @@ jobs:
             echo "No snapshot/fork results to render"
           fi
       - name: Upload SVGs as artifacts
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: snapshot-fork-benchmark-svgs
           path: snapshot_fork_*.svg
           if-no-files-found: ignore
           retention-days: 7
-      - name: Post snapshot/fork results to PR
-        if: github.event_name == 'pull_request'
+      - name: Post snapshot/fork results to merged PR
+        if: github.event_name == 'push'
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -254,12 +255,30 @@ jobs:
 
             body += `---\n*[View full run](${runUrl})*`;
 
+            // This push is a merge to master — post results to the PR it closed.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const pr = prs[0];
+            if (!pr) {
+              // Direct push with no associated PR — fall back to a commit comment.
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body,
+              });
+              return;
+            }
+
             // Find and update existing comment or create new one
             const marker = '## Snapshot/Fork Benchmark Results';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: pr.number,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));
@@ -275,12 +294,12 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: pr.number,
                 body,
               });
             }
       - name: Commit and push
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -220,12 +220,15 @@ jobs:
             body += `---\n*[View full run](${runUrl}) · SVGs available as [build artifacts](${runUrl}#artifacts)*`;
 
             // This push is a merge to master — post results to the PR it closed.
+            // A commit can be associated with several PRs (backports, merge
+            // queue), so pick the one merged into the branch we pushed to.
+            const target = context.ref.replace('refs/heads/', '');
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
             });
-            const pr = prs[0];
+            const pr = prs.find(p => p.merged_at && p.base.ref === target);
             if (!pr) {
               // Direct push with no associated PR — fall back to a commit comment.
               await github.rest.repos.createCommitComment({
@@ -239,10 +242,11 @@ jobs:
 
             // Find and update existing comment or create new one
             const marker = '## Storage Benchmark Results';
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
+              per_page: 100,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -1,7 +1,8 @@
 name: Storage Benchmark
 
 on:
-  pull_request:
+  push:
+    branches: [master]
     paths:
       - 'src/storage/**'
       - 'src/util/**'
@@ -55,7 +56,7 @@ jobs:
           - vercel-blob
           - gcs
           - azure-blob
-        file_size: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.file_size != '' && fromJson(format('["{0}"]', github.event.inputs.file_size))) || (github.event_name == 'pull_request' && fromJson('["1MB"]')) || fromJson('["1MB","4MB","10MB","16MB"]') }}
+        file_size: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.file_size != '' && fromJson(format('["{0}"]', github.event.inputs.file_size))) || (github.event_name == 'push' && fromJson('["1MB"]')) || fromJson('["1MB","4MB","10MB","16MB"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -99,8 +100,8 @@ jobs:
             --mode storage \
             --provider ${{ matrix.provider }} \
             --file-size $FILE_SIZE \
-            --storage-concurrency ${{ (github.event_name == 'schedule' && '16') || (github.event_name == 'pull_request' && '8') || github.event.inputs.storage_concurrency || '1' }} \
-            --iterations ${{ (github.event_name == 'schedule' && '110') || (github.event_name == 'pull_request' && '10') || github.event.inputs.iterations || '100' }}
+            --storage-concurrency ${{ (github.event_name == 'schedule' && '16') || (github.event_name == 'push' && '8') || github.event.inputs.storage_concurrency || '1' }} \
+            --iterations ${{ (github.event_name == 'schedule' && '110') || (github.event_name == 'push' && '10') || github.event.inputs.iterations || '100' }}
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4
@@ -141,7 +142,7 @@ jobs:
       - name: Merge results
         run: npx tsx src/merge-results.ts --input artifacts --mode storage
       - name: Ingest results to platform
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'push'
         continue-on-error: true
         env:
           INGEST_URL: ${{ secrets.INGEST_URL }}
@@ -149,15 +150,15 @@ jobs:
         run: npx tsx src/ingest.ts --type storage
       - run: npm run generate-storage-svg
       - name: Upload SVGs as artifacts
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: storage-benchmark-svgs
           path: storage_*.svg
           if-no-files-found: ignore
           retention-days: 7
-      - name: Post results to PR
-        if: github.event_name == 'pull_request'
+      - name: Post results to merged PR
+        if: github.event_name == 'push'
         continue-on-error: true
         uses: actions/github-script@v7
         with:
@@ -218,12 +219,30 @@ jobs:
 
             body += `---\n*[View full run](${runUrl}) · SVGs available as [build artifacts](${runUrl}#artifacts)*`;
 
+            // This push is a merge to master — post results to the PR it closed.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const pr = prs[0];
+            if (!pr) {
+              // Direct push with no associated PR — fall back to a commit comment.
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body,
+              });
+              return;
+            }
+
             // Find and update existing comment or create new one
             const marker = '## Storage Benchmark Results';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: pr.number,
             });
 
             const existing = comments.find(c => c.body.startsWith(marker));
@@ -239,12 +258,12 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: pr.number,
                 body,
               });
             }
       - name: Commit and push
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Move the lightweight benchmark smoketests off pull_request commits and onto push-to-master, so the validation runs once the code actually lands rather than on every push to an open PR.

Applies to all six benchmark workflows:
  - browser-benchmarks
  - browser-throughput-benchmarks
  - sandbox-dax-benchmarks
  - sandbox-tti-benchmarks
  - snapshot-fork-benchmarks
  - storage-benchmarks

Changes per workflow:
  - Trigger: replace `pull_request` with `push` to `master`, keeping the same `paths:` filters. `schedule` (weekly) and `workflow_dispatch` are unchanged.
  - Keep runs lightweight: the reduced iteration/concurrency/file-size values that were keyed on the `pull_request` event are now keyed on `push`, so a merge runs the same small smoketest (not the weekly full run).
  - Keep it a pure smoketest: the ingest and commit-results steps were gated `!= 'pull_request'` and are now gated `!= 'push'`, so merge runs neither ingest nor commit results. The weekly scheduled run remains the sole source of committed benchmark data and SVGs.
  - Repoint SVG artifact uploads to the `push` event.
  - Replace the old "Post results to PR" step (which relied on PR issue context that doesn't exist on push) with a step that resolves the merged PR from the push commit via listPullRequestsAssociatedWithCommit and posts the result tables to that PR's conversation, updating an existing marker-matched comment on re-runs. Falls back to a commit comment when no PR is associated with the commit (e.g. a direct push to master).

Because checkout defaults to the pushed commit, the smoketest runs against master at the merge commit, i.e. the merged code. Bot result commits carry `[skip ci]`, so the weekly run's push does not re-trigger these workflows.