### PR TITLE
chore(deps): bump @computesdk/beam to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@azure/storage-blob": "^12.33.0",
         "@computesdk/anchorbrowser": "^0.2.4",
         "@computesdk/archil": "^0.4.7",
-        "@computesdk/beam": "^0.2.1",
+        "@computesdk/beam": "^0.3.0",
         "@computesdk/bench": "^0.1.8",
         "@computesdk/blaxel": "^1.6.18",
         "@computesdk/browserbase": "^0.3.8",
@@ -978,20 +978,20 @@
       }
     },
     "node_modules/@computesdk/beam": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@computesdk/beam/-/beam-0.2.1.tgz",
-      "integrity": "sha512-GXZN6GKNMZObddRgZYypMtAY9MvMBJU0bTKOEcctLt5kfyPQ02gYHiRQzKMm3WRNX7z3zzDMK/WOYIFzQZ4EwQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@computesdk/beam/-/beam-0.3.0.tgz",
+      "integrity": "sha512-fdKdtyCutMPnsiIopG83eAs3K7qdW7EZEEE1UA237L6XlJlG9hnfs4ZM3BrIIggtN184KyWMurg8oh+W7sSriw==",
       "license": "MIT",
       "dependencies": {
-        "@beamcloud/beam-js": "1.0.0-rc.30",
+        "@beamcloud/beam-js": "^1.0.13",
         "@computesdk/provider": "2.1.4",
         "computesdk": "4.1.4"
       }
     },
     "node_modules/@computesdk/beam/node_modules/@beamcloud/beam-js": {
-      "version": "1.0.0-rc.30",
-      "resolved": "https://registry.npmjs.org/@beamcloud/beam-js/-/beam-js-1.0.0-rc.30.tgz",
-      "integrity": "sha512-lIs9Y5yD9xK1ZpUqAY1VQEBwoxJmnaghd9aB9+DvuBcjEEoU7y7XpU42h6Jh37DKt20uYjqCWXHTauVPHFcI2Q==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@beamcloud/beam-js/-/beam-js-1.0.13.tgz",
+      "integrity": "sha512-y2DDUKNr2lK8mQbeSkeo1W6RMhTeLeZRyED8FfxjowLxYEj2QN3kgXxn2/v93OY1OCRW4mRYSe0+cHhpe65iqQ==",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@azure/storage-blob": "^12.33.0",
     "@computesdk/anchorbrowser": "^0.2.4",
     "@computesdk/archil": "^0.4.7",
-    "@computesdk/beam": "^0.2.1",
+    "@computesdk/beam": "^0.3.0",
     "@computesdk/bench": "^0.1.8",
     "@computesdk/blaxel": "^1.6.18",
     "@computesdk/browserbase": "^0.3.8",


### PR DESCRIPTION
## Summary

- Bump `@computesdk/beam` from `^0.2.1` to `^0.3.0` (now released on npm).
- Pulls in the Beam SDK upgrade and inline command completion change from computesdk/computesdk#659.

## Changes

- `package.json` — `@computesdk/beam: ^0.2.1` → `^0.3.0`
- `package-lock.json` — resolves to `@computesdk/beam@0.3.0` with transitive `@beamcloud/beam-js@1.0.13`