### PR TITLE
feat: activate tilion browser provider with TILION_BASE_URL support

### DIFF
--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
           - kernel
           - notte
           - steel
-          # - tilion
+          - tilion
           # - anchorbrowser
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -93,7 +93,7 @@ jobs:
           - kernel
           - notte
           - steel
-          # - tilion
+          - tilion
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/env.example
+++ b/env.example
@@ -112,7 +112,8 @@ LIGHTNING_API_KEY=your_lightning_api_key
 # OPENCOMPUTER_API_URL=https://app.opencomputer.dev
 
 ######### TILION ########
-# TILION_API_KEY=your_tilion_api_key
+TILION_API_KEY=your_tilion_api_key
+TILION_BASE_URL=https://api.tilion.dev
 
 ######### AI GATEWAYS ########
 OPENROUTER_API_KEY=your_openrouter_api_key

--- a/src/browser/providers.ts
+++ b/src/browser/providers.ts
@@ -4,7 +4,7 @@ import { hyperbrowser } from '@computesdk/hyperbrowser';
 import { kernel } from '@computesdk/kernel';
 import { notte } from '@computesdk/notte';
 import { steel } from '@computesdk/steel';
-// import { tilion } from '@computesdk/tilion';
+import { tilion } from '@computesdk/tilion';
 import type { BrowserProviderConfig } from './types.js';
 
 /**
@@ -73,13 +73,14 @@ export const browserProviders: BrowserProviderConfig[] = [
     }),
     sessionCreateOptions: { stealth: false },
   },
-  // {
-  //   name: 'tilion',
-  //   requiredEnvVars: ['TILION_API_KEY'],
-  //   createBrowserProvider: () => tilion({
-  //     apiKey: process.env.TILION_API_KEY!
-  //   }),
-  //   sessionCreateOptions: { stealth: false },
-  // },
+  {
+    name: 'tilion',
+    requiredEnvVars: ['TILION_API_KEY', 'TILION_BASE_URL'],
+    createBrowserProvider: () => tilion({
+      apiKey: process.env.TILION_API_KEY!,
+      baseUrl: process.env.TILION_BASE_URL!,
+    }),
+    sessionCreateOptions: { stealth: false },
+  },
   // add browser providers above
 ];

--- a/src/browser/throughput-providers.ts
+++ b/src/browser/throughput-providers.ts
@@ -4,7 +4,7 @@ import { hyperbrowser } from '@computesdk/hyperbrowser';
 import { kernel } from '@computesdk/kernel';
 import { notte } from '@computesdk/notte';
 import { steel } from '@computesdk/steel';
-// import { tilion } from '@computesdk/tilion';
+import { tilion } from '@computesdk/tilion';
 import type { ThroughputProviderConfig } from './throughput-types.js';
 
 /**
@@ -99,17 +99,18 @@ export const throughputProviders: ThroughputProviderConfig[] = [
       viewport: VIEWPORT,
     },
   },
-  // {
-  //   name: 'tilion',
-  //   requiredEnvVars: ['TILION_API_KEY'],
-  //   createBrowserProvider: () => tilion({
-  //     apiKey: process.env.TILION_API_KEY!,
-  //   }),
-  //   sessionCreateOptions: {
-  //     stealth: false,
-  //     proxies: false,
-  //     headless: true,
-  //     viewport: VIEWPORT,
-  //   },
-  // },
+  {
+    name: 'tilion',
+    requiredEnvVars: ['TILION_API_KEY', 'TILION_BASE_URL'],
+    createBrowserProvider: () => tilion({
+      apiKey: process.env.TILION_API_KEY!,
+      baseUrl: process.env.TILION_BASE_URL!,
+    }),
+    sessionCreateOptions: {
+      stealth: false,
+      proxies: false,
+      headless: true,
+      viewport: VIEWPORT,
+    },
+  },
 ];


### PR DESCRIPTION
Activates the previously prepared @computesdk/tilion browser provider for both browser and browser-throughput benchmarks.

Changes:
- src/browser/providers.ts and src/browser/throughput-providers.ts: uncomment tilion config and require TILION_BASE_URL alongside TILION_API_KEY
- env.example: uncomment TILION_API_KEY and add TILION_BASE_URL
- .github/workflows/browser-benchmarks.yml and browser-throughput-benchmarks.yml: uncomment tilion in the CI matrices

The benchmark now recognizes tilion and skips gracefully when TILION_API_KEY / TILION_BASE_URL are not set.