### PR TITLE
ci: pass TILION_API_KEY and TILION_BASE_URL secrets to browser workflows

### DIFF
--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -67,6 +67,8 @@ jobs:
           KERNEL_API_KEY: ${{ secrets.KERNEL_API_KEY }}
           NOTTE_API_KEY: ${{ secrets.NOTTE_API_KEY }}
           STEEL_API_KEY: ${{ secrets.STEEL_API_KEY }}
+          TILION_API_KEY: ${{ secrets.TILION_API_KEY }}
+          TILION_BASE_URL: ${{ secrets.TILION_BASE_URL }}
           # ANCHORBROWSER_API_KEY: ${{ secrets.ANCHORBROWSER_API_KEY }}
         run: |
           npm run bench -- \

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -119,6 +119,8 @@ jobs:
           KERNEL_API_KEY: ${{ secrets.KERNEL_API_KEY }}
           NOTTE_API_KEY: ${{ secrets.NOTTE_API_KEY }}
           STEEL_API_KEY: ${{ secrets.STEEL_API_KEY }}
+          TILION_API_KEY: ${{ secrets.TILION_API_KEY }}
+          TILION_BASE_URL: ${{ secrets.TILION_BASE_URL }}
         run: |
           npm run bench -- \
             --mode browser-throughput \


### PR DESCRIPTION
Wires the Tilion API key and base URL secrets into the browser benchmark workflows so the activated Tilion provider stops being skipped for missing env vars.

- browser-benchmarks.yml: add TILION_API_KEY and TILION_BASE_URL to the benchmark step env
- browser-throughput-benchmarks.yml: add TILION_API_KEY and TILION_BASE_URL to the benchmark step env