### PR TITLE
feat: activate opencomputer sandbox provider

### DIFF
--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -62,7 +62,7 @@ jobs:
           - modal
           - namespace
           - northflank
-          # - opencomputer
+          - opencomputer
           - runloop
           - superserve
           - tenki
@@ -121,6 +121,8 @@ jobs:
           NORTHFLANK_TOKEN: ${{ secrets.NORTHFLANK_TOKEN }}
           NSC_TOKEN: ${{ secrets.NSC_TOKEN }}
           NORTHFLANK_PROJECT_ID: ${{ secrets.NORTHFLANK_PROJECT_ID }}
+          OPENCOMPUTER_API_KEY: ${{ secrets.OPENCOMPUTER_API_KEY }}
+          OPENCOMPUTER_API_URL: ${{ secrets.OPENCOMPUTER_API_URL }}
           RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
           SUPERSERVE_API_KEY: ${{ secrets.SUPERSERVE_API_KEY }}
           TENKI_API_KEY: ${{ secrets.TENKI_API_KEY }}

--- a/.github/workflows/sandbox-tti-benchmarks.yml
+++ b/.github/workflows/sandbox-tti-benchmarks.yml
@@ -76,7 +76,7 @@ jobs:
           - modal
           # - namespace
           - northflank
-          # - opencomputer
+          - opencomputer
           # - quilt
           # - railway
           - runloop
@@ -132,6 +132,8 @@ jobs:
           # NSC_TOKEN: ${{ secrets.NSC_TOKEN }}
           NORTHFLANK_TOKEN: ${{ secrets.NORTHFLANK_TOKEN }}
           NORTHFLANK_PROJECT_ID: ${{ secrets.NORTHFLANK_PROJECT_ID }}
+          OPENCOMPUTER_API_KEY: ${{ secrets.OPENCOMPUTER_API_KEY }}
+          OPENCOMPUTER_API_URL: ${{ secrets.OPENCOMPUTER_API_URL }}
           # QUILT_API_KEY: ${{ secrets.QUILT_API_KEY }}
           # QUILT_BASE_URL: ${{ secrets.QUILT_BASE_URL }}
           # RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}

--- a/env.example
+++ b/env.example
@@ -108,8 +108,8 @@ CREATEOS_SANDBOX_API_KEY=your_createos_sandbox_api_key
 LIGHTNING_API_KEY=your_lightning_api_key
 
 ######### OPENCOMPUTER ########
-# OPENCOMPUTER_API_KEY=your_opencomputer_api_key
-# OPENCOMPUTER_API_URL=https://app.opencomputer.dev
+OPENCOMPUTER_API_KEY=your_opencomputer_api_key
+OPENCOMPUTER_API_URL=https://app.opencomputer.dev
 
 ######### TILION ########
 TILION_API_KEY=your_tilion_api_key

--- a/src/sandbox/dax.ts
+++ b/src/sandbox/dax.ts
@@ -32,7 +32,7 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   declaw:       { templateId: 'node-large' },              // node-large template: 8 vCPU / 16 GiB RAM / 8 GiB disk
   superserve:   { vcpu: 8, memoryMib: 16384 },               // vcpu = cores, memoryMib = MiB; overrides template defaults
   createos:     { shape: 's-8vcpu-16gb', ephemeralDiskMb: 61440 }, // 8 vCPU, 16 GiB RAM, 60 GiB disk
-  // opencomputer: { cpuCount: 8, memoryMB: 16384, timeout: 600_000 },
+  opencomputer: { cpuCount: 8, memoryMB: 16384, timeout: 600_000 },
 };
 
 function getSandboxOptionsWithResources(providerName: string, baseOptions?: Record<string, any>): Record<string, any> {

--- a/src/sandbox/providers.ts
+++ b/src/sandbox/providers.ts
@@ -16,7 +16,7 @@ import { lightning } from '@computesdk/lightning';
 import { modal } from '@computesdk/modal';
 import { namespace } from '@computesdk/namespace';
 import { northflank } from '@computesdk/northflank';
-// import { opencomputer } from '@computesdk/opencomputer';
+import { opencomputer } from '@computesdk/opencomputer';
 // import { quilt } from '@computesdk/quilt';
 // import { railway } from '@computesdk/railway';
 import { runloop } from '@computesdk/runloop';
@@ -143,12 +143,12 @@ export const providers: ProviderConfig[] = [
       runtime: 'node',
     }),
   },
-  // {
-  //   name: 'opencomputer',
-  //   requiredEnvVars: ['OPENCOMPUTER_API_KEY'],
-  //   createCompute: () => opencomputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! }),
-  //   sandboxOptions: { timeout: 600_000 },
-  // },
+  {
+    name: 'opencomputer',
+    requiredEnvVars: ['OPENCOMPUTER_API_KEY'],
+    createCompute: () => opencomputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! }),
+    sandboxOptions: { timeout: 600_000 },
+  },
   // {
   //   name: 'quilt',
   //   requiredEnvVars: ['QUILT_API_KEY', 'QUILT_BASE_URL'],

--- a/src/sandbox/providers.ts
+++ b/src/sandbox/providers.ts
@@ -145,8 +145,11 @@ export const providers: ProviderConfig[] = [
   },
   {
     name: 'opencomputer',
-    requiredEnvVars: ['OPENCOMPUTER_API_KEY'],
-    createCompute: () => opencomputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! }),
+    requiredEnvVars: ['OPENCOMPUTER_API_KEY', 'OPENCOMPUTER_API_URL'],
+    createCompute: () => opencomputer({
+      apiKey: process.env.OPENCOMPUTER_API_KEY!,
+      apiUrl: process.env.OPENCOMPUTER_API_URL!,
+    }),
     sandboxOptions: { timeout: 600_000 },
   },
   // {

--- a/src/scale/providers.ts
+++ b/src/scale/providers.ts
@@ -4,7 +4,7 @@ import { e2b } from '@computesdk/e2b';
 import { isorun } from '@computesdk/isorun';
 import { modal } from '@computesdk/modal';
 import { northflank } from '@computesdk/northflank';
-// import { opencomputer } from '@computesdk/opencomputer';
+import { opencomputer } from '@computesdk/opencomputer';
 import { runloop } from '@computesdk/runloop';
 import { tensorlake } from '@computesdk/tensorlake';
 //import { vercel } from '@computesdk/vercel';
@@ -99,14 +99,14 @@ export const providers: BurstProviderConfig[] = [
     concurrencyTarget: 100_000,
     perRequestTimeoutMs: 120_000,
   },
-  // {
-  //   name: 'opencomputer',
-  //   requiredEnvVars: ['OPENCOMPUTER_API_KEY'],
-  //   createCompute: () => opencomputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! }),
-  //   concurrencyTarget: 100_000,
-  //   perRequestTimeoutMs: 120_000,
-  //   sandboxOptions: { timeout: KEEP_ALIVE_MS },
-  // },
+  {
+    name: 'opencomputer',
+    requiredEnvVars: ['OPENCOMPUTER_API_KEY'],
+    createCompute: () => opencomputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! }),
+    concurrencyTarget: 100_000,
+    perRequestTimeoutMs: 120_000,
+    sandboxOptions: { timeout: KEEP_ALIVE_MS },
+  },
   // {
   //   name: 'vercel',
   //   requiredEnvVars: ['VERCEL_TOKEN', 'VERCEL_TEAM_ID', 'VERCEL_PROJECT_ID'],

--- a/src/scale/providers.ts
+++ b/src/scale/providers.ts
@@ -101,8 +101,11 @@ export const providers: BurstProviderConfig[] = [
   },
   {
     name: 'opencomputer',
-    requiredEnvVars: ['OPENCOMPUTER_API_KEY'],
-    createCompute: () => opencomputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! }),
+    requiredEnvVars: ['OPENCOMPUTER_API_KEY', 'OPENCOMPUTER_API_URL'],
+    createCompute: () => opencomputer({
+      apiKey: process.env.OPENCOMPUTER_API_KEY!,
+      apiUrl: process.env.OPENCOMPUTER_API_URL!,
+    }),
     concurrencyTarget: 100_000,
     perRequestTimeoutMs: 120_000,
     sandboxOptions: { timeout: KEEP_ALIVE_MS },


### PR DESCRIPTION
Activates the previously prepared @computesdk/opencomputer sandbox provider for TTI, DAX, and scale/burst benchmarks.

Changes:
- src/sandbox/providers.ts: uncomment and enable opencomputer config
- src/scale/providers.ts: uncomment and enable opencomputer config for 100k burst
- src/sandbox/dax.ts: uncomment opencomputer resource sizing (8 vCPU / 16 GiB / 600s timeout)
- env.example: uncomment OPENCOMPUTER_API_KEY and OPENCOMPUTER_API_URL
- .github/workflows/sandbox-tti-benchmarks.yml: uncomment opencomputer in matrix and pass OPENCOMPUTER_API_KEY / OPENCOMPUTER_API_URL secrets
- .github/workflows/sandbox-dax-benchmarks.yml: uncomment opencomputer in matrix and pass OPENCOMPUTER_API_KEY / OPENCOMPUTER_API_URL secrets

The benchmark now recognizes opencomputer and skips gracefully when OPENCOMPUTER_API_KEY is not set.