### PR TITLE
fix: lower daytona dax benchmark resources to limit

### DIFF
--- a/src/sandbox/dax.ts
+++ b/src/sandbox/dax.ts
@@ -27,7 +27,7 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   blaxel:       { memory: 16384 },                          // CPU derived: cores = memory_MB / 2048 = 8
   beam:         { cpu: 8, memory: 16384 },                   // cpu = cores, memory = MiB
   codesandbox:  { vmTier: VMTier.Small },                  // Small = 8 CPU, 16 GiB
-  daytona:      { resources: { cpu: 8, memory: 16 } },     // memory in GiB; requires image-based creation (see providers.ts)
+  daytona:      { resources: { cpu: 4, memory: 8 } },      // memory in GiB; requires image-based creation (see providers.ts)
   northflank:   { deploymentPlan: process.env.NORTHFLANK_DEPLOYMENT_PLAN || 'nf-compute-50' },  // resolved by scripts/find-northflank-plan.ts
   declaw:       { templateId: 'node-large' },              // node-large template: 8 vCPU / 16 GiB RAM / 8 GiB disk
   superserve:   { templateId: 'node22-8cpu-16gb' },           // 8 vCPU / 16 GiB template built in the pre-step


### PR DESCRIPTION
## Problem

The Daytona dax benchmark was failing with `Daytona quota exceeded. Please check your usage at https://daytona.io/` on every run. The actual cause was a **resource limit**, not a quota: the benchmark requested 8 CPU / 16 GiB, which exceeds the allowed resources for the current Daytona tier.

## Fix

Lower the Daytona dax resource request from 8 CPU / 16 GiB to 4 CPU / 8 GiB in `src/sandbox/dax.ts`.

## Verification

Smoke test confirms the sandbox now creates successfully and completes 6/7 phases (the remaining typecheck failure is a separate `turbo.json` / bun issue affecting multiple providers).