### PR TITLE
fix: restore daytona dax resources to 8 CPU / 16 GiB

### DIFF
--- a/src/sandbox/dax.ts
+++ b/src/sandbox/dax.ts
@@ -27,7 +27,7 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   blaxel:       { memory: 16384 },                          // CPU derived: cores = memory_MB / 2048 = 8
   beam:         { cpu: 8, memory: 16384 },                   // cpu = cores, memory = MiB
   codesandbox:  { vmTier: VMTier.Small },                  // Small = 8 CPU, 16 GiB
-  daytona:      { resources: { cpu: 4, memory: 8 } },      // memory in GiB; requires image-based creation (see providers.ts)
+  daytona:      { resources: { cpu: 8, memory: 16 } },     // memory in GiB; requires image-based creation (see providers.ts)
   northflank:   { deploymentPlan: process.env.NORTHFLANK_DEPLOYMENT_PLAN || 'nf-compute-50' },  // resolved by scripts/find-northflank-plan.ts
   declaw:       { templateId: 'node-large' },              // node-large template: 8 vCPU / 16 GiB RAM / 8 GiB disk
   superserve:   { templateId: 'node22-8cpu-16gb' },           // 8 vCPU / 16 GiB template built in the pre-step


### PR DESCRIPTION
Daytona limit now allows for 8 CPU / 16 GiB, so this reverts the temporary resource reduction from 4 CPU / 8 GiB (PR #221) back to the standard 8 CPU / 16 GiB used by other providers.