### PR TITLE
feat(dax): size tenki at 8 vCPU / 16 GiB

### DIFF
--- a/benchmarks/sandbox/dax.ts
+++ b/benchmarks/sandbox/dax.ts
@@ -21,7 +21,7 @@ const BENCH_SCRIPT_PATH = path.resolve(import.meta.dirname, '../scripts/dax-benc
 // the provider factory in providers.ts — the SDK ignores an instanceType passed to create().
 const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   modal:        { cpu: 4, cpuLimit: 4, memoryMiB: 16384 }, // Modal: 1 core = 2 vCPUs, so 4 cores = 8 vCPUs
-  tenki:        { cpuCores: 8, memoryMb: 16384 },          // cpuCores: 1-16, memoryMb: 512-65536
+  tenki:        { cpuCores: 8, memoryMb: 16384, diskSizeGb: 20 }, // default disk cannot hold the OpenCode install
   tensorlake:   { cpus: 8, memoryMb: 16384 },
   isorun:       { vcpus: 8, memMiB: 16384 },
   runloop:      { launch_parameters: { resource_size_request: 'CUSTOM_SIZE', custom_cpu_cores: 8, custom_gb_memory: 16 } },

--- a/benchmarks/sandbox/dax.ts
+++ b/benchmarks/sandbox/dax.ts
@@ -21,6 +21,7 @@ const BENCH_SCRIPT_PATH = path.resolve(import.meta.dirname, '../scripts/dax-benc
 // the provider factory in providers.ts — the SDK ignores an instanceType passed to create().
 const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   modal:        { cpu: 4, cpuLimit: 4, memoryMiB: 16384 }, // Modal: 1 core = 2 vCPUs, so 4 cores = 8 vCPUs
+  tenki:        { cpuCores: 8, memoryMb: 16384 },          // cpuCores: 1-16, memoryMb: 512-65536
   tensorlake:   { cpus: 8, memoryMb: 16384 },
   isorun:       { vcpus: 8, memMiB: 16384 },
   runloop:      { launch_parameters: { resource_size_request: 'CUSTOM_SIZE', custom_cpu_cores: 8, custom_gb_memory: 16 } },


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->