### PR TITLE
fix(dax): provision tenki with 20 GB disk

### DIFF
--- a/benchmarks/sandbox/dax.ts
+++ b/benchmarks/sandbox/dax.ts
@@ -21,7 +21,7 @@ const BENCH_SCRIPT_PATH = path.resolve(import.meta.dirname, '../scripts/dax-benc
 // the provider factory in providers.ts — the SDK ignores an instanceType passed to create().
 const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   modal:        { cpu: 4, cpuLimit: 4, memoryMiB: 16384 }, // Modal: 1 core = 2 vCPUs, so 4 cores = 8 vCPUs
-  tenki:        { cpuCores: 8, memoryMb: 16384 },          // cpuCores: 1-16, memoryMb: 512-65536
+  tenki:        { cpuCores: 8, memoryMb: 16384, diskSizeGb: 20 }, // default disk cannot hold the OpenCode install
   tensorlake:   { cpus: 8, memoryMb: 16384 },
   isorun:       { vcpus: 8, memMiB: 16384 },
   runloop:      { launch_parameters: { resource_size_request: 'CUSTOM_SIZE', custom_cpu_cores: 8, custom_gb_memory: 16 } },


### PR DESCRIPTION
## Summary

- provision the Tenki DAX sandbox with a 20 GB disk in addition to the 8 vCPU / 16 GiB sizing from #230
- prevent the default disk limit from leaving the OpenCode dependency install incomplete and failing during typecheck

## Verification

- `pnpm run typecheck`
- `pnpm run bench -- --provider tenki --mode sandbox-dax --iterations 1`
  - 7/7 phases completed
  - `successRate: 1`
  - 8 logical CPUs and ~16 GiB RAM observed
  - ~3.24 GB used after install

This PR is intentionally based on `tenki-dax-cpu` so it can be merged into #230.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->