### PR TITLE
feat: add create-bench CLI scaffolding tool

### DIFF
--- a/.changeset/create-bench-initial.md
+++ b/.changeset/create-bench-initial.md
@@ -1,0 +1,5 @@
+---
+"create-bench": patch
+---
+
+Initial publication of `create-bench`, a CLI scaffolding tool for new ComputeSDK benchmark projects. Run `npx create-bench my-benchmark` to bootstrap a worker with `@benchsdk/client`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,16 @@ jobs:
 
       - name: Build packages
         # The root typecheck consumes the built dist output, so build
-        # @benchsdk/client before running typecheck.
-        run: pnpm --filter @benchsdk/client run build
+        # @benchsdk/client and create-bench before running typecheck.
+        run: |
+          pnpm --filter @benchsdk/client run build
+          pnpm --filter create-bench run build
 
       - name: Typecheck
         run: pnpm typecheck
 
       - name: Test
         run: pnpm --filter @benchsdk/client run test
+
+      - name: Test create-bench
+        run: pnpm --filter create-bench run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,14 @@ jobs:
         run: pnpm install --ignore-scripts
 
       - name: Build packages
-        run: pnpm --filter @benchsdk/client run build
+        run: |
+          pnpm --filter @benchsdk/client run build
+          pnpm --filter create-bench run build
 
       - name: Test
-        run: pnpm --filter @benchsdk/client run test
+        run: |
+          pnpm --filter @benchsdk/client run test
+          pnpm --filter create-bench run test
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/packages/create-bench/README.md
+++ b/packages/create-bench/README.md
@@ -1,0 +1,32 @@
+# create-bench
+
+Scaffold a new ComputeSDK benchmark project that uses [`@benchsdk/client`](https://github.com/computesdk/benchmarks/tree/master/packages/benchsdk).
+
+## Usage
+
+```sh
+npx create-bench my-benchmark
+```
+
+Or with npm:
+
+```sh
+npm create bench my-benchmark
+```
+
+## What gets created
+
+The CLI creates a directory with the given project name and writes:
+
+- `package.json` — with `@benchsdk/client`, `tsx`, and benchmark scripts
+- `tsconfig.json` — basic TypeScript configuration
+- `bench.ts` — a minimal benchmark worker using `defineWorker`, `defineTask`, and `defineStep`
+- `.env.example` — environment variables to configure the worker
+- `README.md` — instructions for the new project
+
+## Next steps
+
+1. `cd my-benchmark`
+2. `pnpm install`
+3. Copy `.env.example` to `.env` and fill in the required values
+4. `pnpm bench`

--- a/packages/create-bench/package.json
+++ b/packages/create-bench/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "create-bench",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "description": "Scaffold a new ComputeSDK benchmark project with @benchsdk/client",
+  "author": "Garrison",
+  "license": "MIT",
+  "bin": {
+    "create-bench": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "prepare": "tsup",
+    "pretest": "tsup",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "create",
+    "scaffold",
+    "benchmark",
+    "computesdk",
+    "benchsdk",
+    "cli"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/benchmarks.git",
+    "directory": "packages/create-bench"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/benchmarks/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/create-bench/src/__tests__/cli.test.ts
+++ b/packages/create-bench/src/__tests__/cli.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createBench } from '../index';
+
+describe('create-bench CLI', () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-bench-test-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('scaffolds the expected files', async () => {
+    await createBench(tempDir);
+
+    const expectedFiles = [
+      'package.json',
+      'bench.ts',
+      'tsconfig.json',
+      '.env.example',
+      'README.md',
+    ];
+
+    for (const file of expectedFiles) {
+      expect(fs.existsSync(path.join(tempDir, file))).toBe(true);
+    }
+
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(tempDir, 'package.json'), 'utf8'),
+    );
+
+    expect(pkg.name).toBe(path.basename(tempDir));
+    expect(pkg.dependencies['@benchsdk/client']).toBe('^0.2.0');
+  });
+});

--- a/packages/create-bench/src/index.ts
+++ b/packages/create-bench/src/index.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline/promises';
+import { fileURLToPath } from 'node:url';
+
+function scaffold(targetDir: string, projectName: string): void {
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  const packageJson = {
+    name: projectName,
+    version: '0.0.0',
+    private: true,
+    type: 'module',
+    scripts: {
+      bench: 'tsx bench.ts',
+      typecheck: 'tsc --noEmit',
+    },
+    dependencies: {
+      '@benchsdk/client': '^0.2.0',
+    },
+    devDependencies: {
+      tsx: '^4.22.4',
+      typescript: '^5.0.0',
+    },
+  };
+
+  fs.writeFileSync(
+    path.join(targetDir, 'package.json'),
+    `${JSON.stringify(packageJson, null, 2)}\n`,
+  );
+
+  const tsconfigJson = {
+    compilerOptions: {
+      target: 'ES2022',
+      module: 'ESNext',
+      moduleResolution: 'bundler',
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+      resolveJsonModule: true,
+      noEmit: true,
+    },
+    include: ['**/*.ts'],
+  };
+
+  fs.writeFileSync(
+    path.join(targetDir, 'tsconfig.json'),
+    `${JSON.stringify(tsconfigJson, null, 2)}\n`,
+  );
+
+  const benchTs = `import { defineStep, defineTask, defineWorker } from '@benchsdk/client';
+
+const worker = defineWorker({
+  benchmarkSlug: process.env.BENCHMARK_SLUG ?? 'scale',
+  runId: process.env.BENCHMARK_RUN_ID!,
+  participantSlug: process.env.BENCHMARK_PARTICIPANT_SLUG ?? 'local',
+  processKind: 'container',
+  processKey: process.env.HOSTNAME ?? 'local',
+  concurrency: 1,
+  task: defineTask('example.lifecycle', [
+    defineStep('start', async ({ assignment }) => {
+      console.log(\`Worker \${assignment.workerId} starting task \${assignment.taskRange.start}\`);
+    }),
+    defineStep('work', async () => {
+      // Replace with your benchmark logic
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }),
+    defineStep('done', async () => {
+      console.log('Task complete');
+    }),
+  ]),
+});
+
+await worker.run();
+`;
+
+  fs.writeFileSync(path.join(targetDir, 'bench.ts'), benchTs);
+
+  const envExample = `# Copy to .env and fill in your values
+COMPUTESDK_ADMIN_API_KEY=
+BENCHMARK_SLUG=scale
+BENCHMARK_RUN_ID=
+BENCHMARK_PARTICIPANT_SLUG=local
+`;
+
+  fs.writeFileSync(path.join(targetDir, '.env.example'), envExample);
+
+  const readme = `# ${projectName}
+
+This project was scaffolded by [\`create-bench\`](https://github.com/computesdk/benchmarks/tree/master/packages/create-bench).
+
+## Getting started
+
+1. Install dependencies:
+
+   \`\`\`sh
+   pnpm install
+   \`\`\`
+
+2. Copy \`.env.example\` to \`.env\` and fill in the required values.
+
+3. Run the benchmark worker:
+
+   \`\`\`sh
+   pnpm bench
+   \`\`\`
+`;
+
+  fs.writeFileSync(path.join(targetDir, 'README.md'), readme);
+}
+
+async function askProjectName(): Promise<string | undefined> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    const answer = await rl.question('Project name: ');
+    return answer.trim() || undefined;
+  } finally {
+    rl.close();
+  }
+}
+
+export async function createBench(projectName?: string): Promise<void> {
+  const resolvedName = projectName ?? (await askProjectName());
+
+  if (!resolvedName) {
+    throw new Error('A project name is required.');
+  }
+
+  const targetDir = path.isAbsolute(resolvedName)
+    ? resolvedName
+    : path.resolve(process.cwd(), resolvedName);
+  const packageName = path.basename(targetDir);
+
+  if (fs.existsSync(targetDir) && fs.readdirSync(targetDir).length > 0) {
+    throw new Error(`Directory ${targetDir} is not empty.`);
+  }
+
+  scaffold(targetDir, packageName);
+
+  console.log(`Created ${packageName} at ${targetDir}`);
+  console.log('Next steps:');
+  console.log(`  cd ${path.relative(process.cwd(), targetDir) || packageName}`);
+  console.log('  pnpm install');
+  console.log('  cp .env.example .env');
+  console.log('  pnpm bench');
+}
+
+async function main(): Promise<void> {
+  const projectName = process.argv[2];
+  await createBench(projectName);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/create-bench/tsconfig.json
+++ b/packages/create-bench/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/create-bench/tsup.config.ts
+++ b/packages/create-bench/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+  },
+  format: ['esm'],
+  dts: false,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,24 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
+  packages/create-bench:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.43
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.21)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.43)
+
 packages:
 
   '@alcalzone/ansi-tokenize@0.3.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - packages/benchsdk
+  - packages/create-bench


### PR DESCRIPTION
A self-contained CLI that scaffolds a new benchmark project with `@benchsdk/client`.

## Usage
```sh
npx create-bench my-benchmark
```

Scaffolds a project with:
- `bench.ts` — minimal worker using `defineWorker`/`defineTask`/`defineStep`
- `package.json` — with `@benchsdk/client` dependency
- `tsconfig.json`, `.env.example`, `README.md`

## Package
- `create-bench` v0.1.0, ESM-only, no runtime dependencies
- `#!/usr/bin/env node` shebang for `npx` / `npm create bench` usage
- tsup build, vitest test

## Changes
- `packages/create-bench/` — new package (CLI + test)
- `pnpm-workspace.yaml` — registers new package
- `ci.yml` / `release.yml` — builds and tests create-bench alongside @benchsdk/client
- `.changeset/create-bench-initial.md` — patch release changeset

## Validation
- `pnpm install` ✓
- `pnpm --filter create-bench run build` ✓
- `pnpm --filter create-bench run typecheck` ✓
- `pnpm --filter create-bench run test` ✓ (1 passed)
- `pnpm --filter @benchsdk/client run test` ✓ (126 passed, 1 skipped)
- `pnpm typecheck` ✓
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->