### PR TITLE
fix(storage): require AWS_REGION so the daily-bench vault loader pulls it

### DIFF
--- a/benchmarks/scripts/provider-vars.json
+++ b/benchmarks/scripts/provider-vars.json
@@ -141,6 +141,7 @@
     "aws-s3": [
       "AWS_ACCESS_KEY_ID",
       "AWS_SECRET_ACCESS_KEY",
+      "AWS_REGION",
       "S3_BUCKET"
     ],
     "cloudflare-r2": [
@@ -216,6 +217,9 @@
     "pydantic-ai-gateway": [
       "PYDANTIC_AI_GATEWAY_API_KEY"
     ],
+    "concentrate-ai-gateway": [
+      "CONCENTRATE_AI_GATEWAY_API_KEY"
+    ],
     "anthropic-direct": [
       "ANTHROPIC_API_KEY"
     ]
@@ -224,6 +228,7 @@
     "aws-s3": [
       "AWS_ACCESS_KEY_ID",
       "AWS_SECRET_ACCESS_KEY",
+      "AWS_REGION",
       "S3_BUCKET",
       "S3_SNAPSHOT_ACCESS_KEY_ID",
       "S3_SNAPSHOT_SECRET_ACCESS_KEY",

--- a/benchmarks/storage/providers.ts
+++ b/benchmarks/storage/providers.ts
@@ -16,7 +16,7 @@ import type { StorageProviderConfig } from './types.js';
 export const storageProviders: StorageProviderConfig[] = [
   {
     name: 'aws-s3',
-    requiredEnvVars: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'S3_BUCKET'],
+    requiredEnvVars: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_REGION', 'S3_BUCKET'],
     bucket: process.env.S3_BUCKET!,
     createStorage: () => new Storage({
       adapter: s3({
@@ -34,7 +34,7 @@ export const storageProviders: StorageProviderConfig[] = [
     // permission — broader than the object-only creds used for upload/download.
     // Uses a dedicated bucket so the sibling-bucket churn is isolated.
     snapshotFork: {
-      requiredEnvVars: ['S3_SNAPSHOT_ACCESS_KEY_ID', 'S3_SNAPSHOT_SECRET_ACCESS_KEY', 'S3_SNAPSHOT_BUCKET'],
+      requiredEnvVars: ['S3_SNAPSHOT_ACCESS_KEY_ID', 'S3_SNAPSHOT_SECRET_ACCESS_KEY', 'AWS_REGION', 'S3_SNAPSHOT_BUCKET'],
       bucket: process.env.S3_SNAPSHOT_BUCKET!,
       createStorage: () => new Storage({
         adapter: s3({


### PR DESCRIPTION
The recent drop of AWS_REGION from requiredEnvVars (#75838c5) let the bench run when AWS_REGION was unset, but it also made the provider-scoped Namespace vault loader (load-ns-secrets.mjs) skip that entry entirely — provider-vars.json was regenerated without it. The bench then defaulted to 'us-east-1' on disk, and every aws-s3 upload/download got a 301 PermanentRedirect from s3-benchmark-computesdk because the bucket lives in us-east-2.

This restores AWS_REGION to both aws-s3 and its snapshotFork requiredEnvVars and regenerates provider-vars.json so:
- the provider-scoped daily-bench loader (load-ns-secrets.mjs --provider aws-s3) requests it (matches the lookup we just diffed in the failed job's masked output, which only listed AWS_ACCESS_KEY_ID + S3_BUCKET);
- the regex-scoped upstream loader (load-vault-secrets.sh, KEYS already includes AWS_REGION) is a no-op but stays consistent.

Regenerate also picks up concentrate-ai-gateway in the ai-gateway manifest mode — previously missing from provider-vars.json despite being declared in ai-gateway/providers.ts.

Files touched:
- benchmarks/storage/providers.ts (aws-s3 + snapshotFork lists)
- benchmarks/scripts/provider-vars.json (regenerated)

Verified: pnpm run typecheck clean. Pure additive diff (4 line insertions, 2 line deletions in providers.ts; 3 entries added to provider-vars.json).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->