### PR TITLE
ci: drop push:master trigger from workflows without a weekly schedule

### DIFF
--- a/.github/workflows/pricing-svg.yml
+++ b/.github/workflows/pricing-svg.yml
@@ -1,10 +1,6 @@
 name: Pricing SVG
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'pricing.json'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches: ["master"]
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/scale-image.yml
+++ b/.github/workflows/scale-image.yml
@@ -1,11 +1,6 @@
 name: Scale Image
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'benchmarks/scale/**'
   pull_request:
     paths:
       - 'benchmarks/scale/**'


### PR DESCRIPTION
Policy: only workflows with a weekly cron block run on push to master — the weekly pipeline is the merge smoke test. This strips the master push trigger from the three workflows that lacked a schedule block.

Removed `push: branches: [master]` from:
- .github/workflows/pricing-svg.yml (was master-only on pricing.json)
- .github/workflows/scale-image.yml (was master + PR + dispatch on benchmarks/scale/**; kept PR for image-build PR validation, kept dispatch for manual run)
- .github/workflows/release.yml (was master only; now dispatch-only — heads-up: auto-release on merge turns off; releases will run only via `workflow_dispatch` or a future scheduled re-run)

Untouched: every workflow that already had `schedule: cron: ... * * 5` keeps its master push (the 9 functional benchmarks + 10 orphan sandbox-* crons). ci.yml is unaffected (PR-only).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->