### PR TITLE
ci: drop weekly cron from 7 sandbox workflows

### DIFF
--- a/.github/workflows/sandbox-cpu-node.yml
+++ b/.github/workflows/sandbox-cpu-node.yml
@@ -12,8 +12,6 @@ on:
       - 'benchmarks/scripts/load-vault-secrets.sh'
       - 'package.json'
       - '.github/workflows/sandbox-cpu-node.yml'
-  schedule:
-    - cron: '0 0 * * 5'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-disk.yml
+++ b/.github/workflows/sandbox-disk.yml
@@ -12,8 +12,6 @@ on:
       - 'benchmarks/scripts/load-vault-secrets.sh'
       - 'package.json'
       - '.github/workflows/sandbox-disk.yml'
-  schedule:
-    - cron: '0 1 * * 5'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-memory.yml
+++ b/.github/workflows/sandbox-memory.yml
@@ -12,8 +12,6 @@ on:
       - 'benchmarks/scripts/load-vault-secrets.sh'
       - 'package.json'
       - '.github/workflows/sandbox-memory.yml'
-  schedule:
-    - cron: '30 0 * * 5'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-network-localhost.yml
+++ b/.github/workflows/sandbox-network-localhost.yml
@@ -12,8 +12,6 @@ on:
       - 'benchmarks/scripts/load-vault-secrets.sh'
       - 'package.json'
       - '.github/workflows/sandbox-network-localhost.yml'
-  schedule:
-    - cron: '0 2 * * 5'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-network-wan.yml
+++ b/.github/workflows/sandbox-network-wan.yml
@@ -12,8 +12,6 @@ on:
       - 'benchmarks/scripts/load-vault-secrets.sh'
       - 'package.json'
       - '.github/workflows/sandbox-network-wan.yml'
-  schedule:
-    - cron: '30 2 * * 5'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-pgbench.yml
+++ b/.github/workflows/sandbox-pgbench.yml
@@ -12,8 +12,6 @@ on:
       - 'benchmarks/scripts/load-vault-secrets.sh'
       - 'package.json'
       - '.github/workflows/sandbox-pgbench.yml'
-  schedule:
-    - cron: '0 3 * * 5'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-system.yml
+++ b/.github/workflows/sandbox-system.yml
@@ -12,8 +12,6 @@ on:
       - 'benchmarks/scripts/load-vault-secrets.sh'
       - 'package.json'
       - '.github/workflows/sandbox-system.yml'
-  schedule:
-    - cron: '30 1 * * 5'
   workflow_dispatch:
     inputs:
       replicas:


### PR DESCRIPTION
Drop the Friday weekly cron from these 7 workflows (each keeps `push: branches: [master]` + `workflow_dispatch`):

- `.github/workflows/sandbox-memory.yml`            `cron: '30 0 * * 5'`
- `.github/workflows/sandbox-cpu-node.yml`          `cron: '0 0 * * 5'`
- `.github/workflows/sandbox-system.yml`            `cron: '30 1 * * 5'`
- `.github/workflows/sandbox-disk.yml`              `cron: '0 1 * * 5'`
- `.github/workflows/sandbox-network-localhost.yml` `cron: '0 2 * * 5'`
- `.github/workflows/sandbox-network-wan.yml`       `cron: '30 2 * * 5'`
- `.github/workflows/sandbox-pgbench.yml`           `cron: '0 3 * * 5'`

11 workflows still carry a weekly cron: ai-gateway, browser, browser-throughput, sandbox-dax, sandbox-dns, sandbox-download, sandbox-latency, sandbox-realworld, sandbox-tti, snapshot-fork, storage.

YAML re-validated; `schedule:` block absent on all 7 edited workflows, `on` parses to `{ push: …, workflow_dispatch: null }`. 14 lines removed total (2 per workflow).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->