### PR TITLE
ci: drop weekly cron from 4 more sandbox workflows

### DIFF
--- a/.github/workflows/sandbox-dns.yml
+++ b/.github/workflows/sandbox-dns.yml
@@ -12,8 +12,6 @@ on:
       - 'benchmarks/scripts/load-vault-secrets.sh'
       - 'package.json'
       - '.github/workflows/sandbox-dns.yml'
-  schedule:
-    - cron: '30 4 * * 5'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-download.yml
+++ b/.github/workflows/sandbox-download.yml
@@ -12,8 +12,6 @@ on:
       - 'benchmarks/scripts/load-vault-secrets.sh'
       - 'package.json'
       - '.github/workflows/sandbox-download.yml'
-  schedule:
-    - cron: '0 5 * * 5'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-latency.yml
+++ b/.github/workflows/sandbox-latency.yml
@@ -12,8 +12,6 @@ on:
       - 'benchmarks/scripts/load-vault-secrets.sh'
       - 'package.json'
       - '.github/workflows/sandbox-latency.yml'
-  schedule:
-    - cron: '0 4 * * 5'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-realworld.yml
+++ b/.github/workflows/sandbox-realworld.yml
@@ -12,8 +12,6 @@ on:
       - 'benchmarks/scripts/load-vault-secrets.sh'
       - 'package.json'
       - '.github/workflows/sandbox-realworld.yml'
-  schedule:
-    - cron: '30 3 * * 5'
   workflow_dispatch:
     inputs:
       replicas:


### PR DESCRIPTION
Drop the Friday cron from these 4 workflows (each keeps `push: branches: [master]` + `workflow_dispatch`):

- `.github/workflows/sandbox-realworld.yml`  `cron: '30 3 * * 5'`
- `.github/workflows/sandbox-latency.yml`    `cron: '0 4 * * 5'`
- `.github/workflows/sandbox-dns.yml`        `cron: '30 4 * * 5'`
- `.github/workflows/sandbox-download.yml`   `cron: '0 5 * * 5'`

Independent of #250 (also branches off master). Once both merge, 11 of the 18 original weekly crons will be gone. The 7 that remain: ai-gateway, browser, browser-throughput, sandbox-dax, sandbox-tti, snapshot-fork, storage.

YAML re-parses; `schedule:` block absent on all 4 edited workflows, `on` is `{ push: …, workflow_dispatch: null }`. 8 lines removed total.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->