### PR TITLE
ci: drop push:master trigger from 4 orphan sandbox workflows

### DIFF
--- a/.github/workflows/sandbox-dns.yml
+++ b/.github/workflows/sandbox-dns.yml
@@ -1,17 +1,6 @@
 name: Dns Benchmark
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'benchmarks/sandbox/dns/**'
-      - 'benchmarks/scripts/smoke.ts'
-      - 'benchmarks/scripts/build-bundles.ts'
-      - 'benchmarks/scripts/ensure-bundle.ts'
-      - 'benchmarks/src/run.ts'
-      - 'benchmarks/scripts/load-vault-secrets.sh'
-      - 'package.json'
-      - '.github/workflows/sandbox-dns.yml'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-download.yml
+++ b/.github/workflows/sandbox-download.yml
@@ -1,17 +1,6 @@
 name: Download Benchmark
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'benchmarks/sandbox/download/**'
-      - 'benchmarks/scripts/smoke.ts'
-      - 'benchmarks/scripts/build-bundles.ts'
-      - 'benchmarks/scripts/ensure-bundle.ts'
-      - 'benchmarks/src/run.ts'
-      - 'benchmarks/scripts/load-vault-secrets.sh'
-      - 'package.json'
-      - '.github/workflows/sandbox-download.yml'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-latency.yml
+++ b/.github/workflows/sandbox-latency.yml
@@ -1,17 +1,6 @@
 name: Latency Benchmark
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'benchmarks/sandbox/latency/**'
-      - 'benchmarks/scripts/smoke.ts'
-      - 'benchmarks/scripts/build-bundles.ts'
-      - 'benchmarks/scripts/ensure-bundle.ts'
-      - 'benchmarks/src/run.ts'
-      - 'benchmarks/scripts/load-vault-secrets.sh'
-      - 'package.json'
-      - '.github/workflows/sandbox-latency.yml'
   workflow_dispatch:
     inputs:
       replicas:

--- a/.github/workflows/sandbox-realworld.yml
+++ b/.github/workflows/sandbox-realworld.yml
@@ -1,17 +1,6 @@
 name: Realworld Benchmark
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'benchmarks/sandbox/realworld/**'
-      - 'benchmarks/scripts/smoke.ts'
-      - 'benchmarks/scripts/build-bundles.ts'
-      - 'benchmarks/scripts/ensure-bundle.ts'
-      - 'benchmarks/src/run.ts'
-      - 'benchmarks/scripts/load-vault-secrets.sh'
-      - 'package.json'
-      - '.github/workflows/sandbox-realworld.yml'
   workflow_dispatch:
     inputs:
       replicas:


### PR DESCRIPTION
Strip the master push trigger from the 4 orphan sandbox workflows that the user pointed at as failing on merge:

- `.github/workflows/sandbox-realworld.yml`
- `.github/workflows/sandbox-latency.yml`
- `.github/workflows/sandbox-dns.yml`
- `.github/workflows/sandbox-download.yml`

Each now has only `workflow_dispatch:` — no path filter → never re-triggers from a master push → stops the matrix-per-provider failure shower seen on the recent merge.

PR #251 had only removed the cron; master kept `push: branches: [master]` with paths pointing at `benchmarks/sandbox/{dns,download,latency,realworld}/**` and the now-deleted `scripts/smoke.ts`, `scripts/build-bundles.ts`, `scripts/ensure-bundle.ts`, `src/run.ts`. Any push that touches the workflow file re-ran the broken job.

11 deletions per file (44 total). YAML re-parses: `on = { workflow_dispatch: null }`.

Same fix still outstanding for 7 other orphan workflows whose merge push remains: sandbox-disk, sandbox-memory, sandbox-network-localhost, sandbox-network-wan, sandbox-pgbench, sandbox-system (all cron-removed in #250), plus sandbox-cpu-node (also cron-removed in #250 but functional — its push is real, just unwanted per current policy). Happy to do that in a follow-up.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->