### PR TITLE
Use Beam JS 1.0.17 in sandbox benchmarks

### DIFF
--- a/benchmarks/sandbox/providers.ts
+++ b/benchmarks/sandbox/providers.ts
@@ -47,7 +47,11 @@ export const providers: ProviderConfig[] = [
     // Activated in daily + PR benchmarks once BEAM_TOKEN / BEAM_WORKSPACE_ID secrets landed.
     name: 'beam',
     requiredEnvVars: ['BEAM_TOKEN', 'BEAM_WORKSPACE_ID'],
-    createCompute: () => beam({ token: process.env.BEAM_TOKEN!, workspaceId: process.env.BEAM_WORKSPACE_ID! }),
+    createCompute: () => beam({
+      token: process.env.BEAM_TOKEN!,
+      workspaceId: process.env.BEAM_WORKSPACE_ID!,
+      gatewayUrl: process.env.BEAM_GATEWAY_URL,
+    }),
     sandboxOptions: { name: 'computesdk-benchmarks', runtime: 'node' },
   },
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -454,8 +454,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@beamcloud/beam-js@1.0.13':
-    resolution: {integrity: sha512-y2DDUKNr2lK8mQbeSkeo1W6RMhTeLeZRyED8FfxjowLxYEj2QN3kgXxn2/v93OY1OCRW4mRYSe0+cHhpe65iqQ==}
+  '@beamcloud/beam-js@1.0.17':
+    resolution: {integrity: sha512-LcgLeUDYZajTOktXXwRiWH6waE7ikWdaM5PjVv0bctjEOxwwFuUEtEc2iyj3SYAXaCJaXDiWs1LSB5frIkzBhQ==}
     peerDependencies:
       typescript: ^5.0.0
 
@@ -5327,6 +5327,9 @@ packages:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
 
+  yazl@3.3.1:
+    resolution: {integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -5707,21 +5710,18 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@beamcloud/beam-js@1.0.13(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
+  '@beamcloud/beam-js@1.0.17(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      archiver: 7.0.1
       axios: 1.18.1
       commander: 12.1.0
       ignore: 7.0.6
       strip-ansi: 7.2.0
       typescript: 6.0.3
       ws: 8.21.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      yazl: 3.3.1
     transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
       - bufferutil
       - debug
-      - react-native-b4a
       - supports-color
       - utf-8-validate
 
@@ -5989,15 +5989,12 @@ snapshots:
 
   '@computesdk/beam@0.3.0(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@beamcloud/beam-js': 1.0.13(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      '@beamcloud/beam-js': 1.0.17(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)
       '@computesdk/provider': 2.1.4
       computesdk: 4.1.4
     transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
       - bufferutil
       - debug
-      - react-native-b4a
       - supports-color
       - typescript
       - utf-8-validate
@@ -11200,6 +11197,10 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yazl@3.3.1:
+    dependencies:
+      buffer-crc32: 1.0.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

- resolve Beam sandbox benchmarks with published `@beamcloud/beam-js@1.0.17`
- allow Beam benchmarks to target staging through `BEAM_GATEWAY_URL`

## Why

Beam JS 1.0.17 contains the prepared-sandbox fast path and image-aware preparation keys. It also removes the ambiguous `download`/`downloadFile` aliases that triggered a supply-chain heuristic while preserving native reads through `readBytes`/`readText`. Updating the frozen lockfile makes PR runs reproducible without package overrides.

Related provider optimization: computesdk/computesdk#678.

## Validation

- one commit over current upstream `master`
- frozen lockfile install passed with no overrides
- dependency graph resolves `@computesdk/beam@0.3.0` to `@beamcloud/beam-js@1.0.17`
- repository typecheck passed
