### PR TITLE
fix: configure Sandbox0 benchmark resources and lifetime

### DIFF
--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -74,7 +74,9 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   superserve:   { templateId: 'node22-8cpu-16gb' },           // 8 vCPU / 16 GiB template built in the pre-step
   createos:     { shape: 's-8vcpu-16gb', ephemeralDiskMb: 61440 }, // 8 vCPU, 16 GiB RAM, 60 GiB disk
   opencomputer: { cpuCount: 4, memoryMB: 16384, timeout: 600_000 },
-  sandbox0:    { memory: 16384 },  // Sandbox0 exposes only `memory`
+  // Sandbox0 exposes only memory. Override the 128 MiB TTI size;
+  // getSandboxOptionsWithResources preserves hardTtl from providers.ts.
+  sandbox0:     { memory: 16384 },
 };
 
 function getSandboxOptionsWithResources(providerName: string, baseOptions?: Record<string, any>): Record<string, any> {

--- a/benchmarks/sandbox/providers.ts
+++ b/benchmarks/sandbox/providers.ts
@@ -184,8 +184,10 @@ export const providers: ProviderConfig[] = [
     name: 'sandbox0',
     requiredEnvVars: ['SANDBOX0_TOKEN'],
     createCompute: () => sandbox0({ token: process.env.SANDBOX0_TOKEN! }),
+    // TTI modes (sequential, staggered, and burst) use 128 MiB for Sandbox0.
+    // DAX overrides memory to 16 GiB while preserving this hard TTL.
     // Outlive the 10-minute DAX timeout without leaving a zombie sandbox if cleanup cannot run.
-    sandboxOptions: { hardTtl: 900 },
+    sandboxOptions: { memory: 128, hardTtl: 900 },
   },
   {
     name: 'sprites',

--- a/benchmarks/sandbox/providers.ts
+++ b/benchmarks/sandbox/providers.ts
@@ -184,6 +184,8 @@ export const providers: ProviderConfig[] = [
     name: 'sandbox0',
     requiredEnvVars: ['SANDBOX0_TOKEN'],
     createCompute: () => sandbox0({ token: process.env.SANDBOX0_TOKEN! }),
+    // Outlive the 10-minute DAX timeout without leaving a zombie sandbox if cleanup cannot run.
+    sandboxOptions: { hardTtl: 900 },
   },
   {
     name: 'sprites',


### PR DESCRIPTION
## What changed

- Size Sandbox0 sequential, staggered, and burst TTI sandboxes at 128 MiB.
- Keep Sandbox0 DAX sandboxes at the standardized 16 GiB profile through the existing DAX resource override.
- Set a 15-minute hard TTL on every Sandbox0 benchmark sandbox while retaining the existing best-effort destroy path.

## Why

The TTI workloads only create a sandbox and run the first `node -v` readiness command. They do not need the 16 GiB footprint used by the DAX build workload, especially when staggered and burst runs create up to 100 sandboxes.

A cancelled GitHub Actions job can also terminate the Node.js process before its `finally` block calls `destroy()`. Without a hard TTL, that can leave a claimed Sandbox0 sandbox running indefinitely.

DAX allows up to 10 minutes per sandbox, so a 15-minute hard TTL leaves cleanup headroom. The DAX option merge overrides the 128 MiB base memory with 16 GiB while preserving the hard TTL.

## Sandbox0 resource profile

| Mode | Memory | Hard TTL |
| --- | ---: | ---: |
| Sequential TTI | 128 MiB | 15 minutes |
| Staggered TTI | 128 MiB | 15 minutes |
| Burst TTI | 128 MiB | 15 minutes |
| DAX | 16 GiB | 15 minutes |

Normal runs still call `destroy()` immediately. The hard TTL is only a server-side fallback for interrupted or failed cleanup.

## Impact

This only changes Sandbox0 benchmark sandboxes. Other providers are unaffected.

## Validation

- `pnpm typecheck`
- Built `@benchsdk/client`, `@benchsdk/runner`, and `create-bench`
- `@benchsdk/client` tests: 118 passed, 1 skipped
- `@benchsdk/runner` tests: 56 passed
- `create-bench` tests: 1 passed
- No live provider benchmark was run and no provider credentials were used for this change
