### PR TITLE
Adjust AI Gateway provider endpoints for consistency

### DIFF
--- a/benchmarks/ai-gateway/ai-gateway.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway.bench.ts
@@ -107,8 +107,13 @@ async function aiGatewayTask(ctx: TaskContext<AIGatewayProviderConfig>): Promise
   const steps = phaseSteps(result);
 
   if (result.error) {
+    ctx.log(`${ctx.participant.name} ${result.mode} probe failed: ${result.error}`, probeData(result));
     throw new TaskError(result.error, { code: 'probe_failed', data: probeData(result), steps });
   }
+  ctx.log(
+    `${ctx.participant.name} ${result.mode} probe: ttfb=${result.ttfbMs}ms ttft=${result.ttftMs}ms`,
+    probeData(result),
+  );
   return {
     data: probeData(result),
     steps,

--- a/benchmarks/ai-gateway/phase-probe.ts
+++ b/benchmarks/ai-gateway/phase-probe.ts
@@ -6,10 +6,13 @@ import type { AIGatewayProviderConfig, AIGatewayWireFormat, PhaseProbeResult } f
 
 const RECEIPT_HEADERS = ['x-vercel-id', 'cf-ray', 'x-request-id', 'request-id', 'anthropic-request-id'];
 
-// Matches OpenAI's `delta.content` and Anthropic's `delta.text` fields alike,
-// so we can timestamp the first content token without fully parsing every SSE
-// event on the hot path.
-const CONTENT_RE = /"(?:content|text)"\s*:\s*"[^"]/;
+// Matches OpenAI's `delta.content`, Anthropic's `delta.text`, and the
+// Responses API's flat `"delta":"…"` string alike, so we can timestamp the
+// first content token without fully parsing every SSE event on the hot path.
+// Safe to share: in the OpenAI/Anthropic formats "delta" is always an object
+// (`"delta":{…}`), never followed directly by a quote, so the added
+// alternative can't false-match those.
+const CONTENT_RE = /"(?:content|text|delta)"\s*:\s*"[^"]/;
 
 function now(): number {
   return performance.now();
@@ -24,6 +27,18 @@ function buildRequestBody(config: AIGatewayProviderConfig, prompt: string, maxTo
       temperature: 0,
       stream: true,
       stream_options: { include_usage: true },
+      ...config.extraBody,
+    });
+  }
+  if (config.wireFormat === 'responses') {
+    // OpenAI Responses API shape: flat `input` string instead of a `messages`
+    // array, `max_output_tokens` instead of `max_tokens`.
+    return JSON.stringify({
+      model: config.model,
+      input: prompt,
+      max_output_tokens: maxTokens,
+      temperature: 0,
+      stream: true,
       ...config.extraBody,
     });
   }
@@ -46,12 +61,16 @@ function extractOutputTokens(wireFormat: AIGatewayWireFormat, buf: string): numb
     const m = [...buf.matchAll(/"usage"\s*:\s*\{[^}]*"completion_tokens"\s*:\s*(\d+)/g)];
     return m.length > 0 ? Number(m[m.length - 1][1]) : undefined;
   }
-  // Anthropic streams cumulative usage on message_start/message_delta events;
-  // the last "output_tokens" seen in the buffer is the most up to date. Scoped
-  // to inside the "usage" object (allowing one level of nested {} for fields
-  // like usage.server_tool_use) so a gateway that echoes an unrelated
-  // "output_tokens" elsewhere — e.g. Concentrate's sibling `cost.breakdown[…]
-  // .output_tokens` dollar amount — can't be mistaken for the real count.
+  // Anthropic and the Responses API both stream cumulative usage under a
+  // "usage" object keyed by "output_tokens" (Anthropic: message_start/
+  // message_delta; Responses: response.completed's `response.usage`) — same
+  // shared extraction path. The last "output_tokens" seen in the buffer is
+  // the most up to date. Scoped to inside the "usage" object (allowing one
+  // level of nested {} for fields like usage.server_tool_use) so a gateway
+  // that echoes an unrelated "output_tokens" elsewhere — e.g. Concentrate's
+  // sibling `cost.breakdown[…].output_tokens` dollar amount, present on both
+  // its /messages and /responses endpoints — can't be mistaken for the real
+  // count.
   const matches = [...buf.matchAll(/"usage"\s*:\s*\{(?:[^{}]|\{[^{}]*\})*?"output_tokens"\s*:\s*(\d+)/g)];
   return matches.length > 0 ? Number(matches[matches.length - 1][1]) : undefined;
 }

--- a/benchmarks/ai-gateway/providers.ts
+++ b/benchmarks/ai-gateway/providers.ts
@@ -43,20 +43,24 @@ export const providers: AIGatewayProviderConfig[] = [
     // serve via Bedrock/Vertex/its own "claudeaws" credential. `providerOptions
     // .gateway.order: ['anthropic']` sets Anthropic as first choice while
     // still allowing fallback to those other providers if Anthropic itself
-    // fails, on the REST/OpenAI-compatible path (the same field the AI SDK
-    // exposes as `providerOptions.gateway`, just inlined in the raw request
-    // body here since this benchmark doesn't use the SDK). Confirmed live: a
-    // streamed response carries `resolvedProvider` inside
-    // `choices[0].delta.provider_metadata.gateway.routing` on its final
-    // chunk (alongside usage) — extracted below into `resolvedProvider` for
-    // the same visibility-over-silence reason as OpenRouter above. See
-    // https://vercel.com/docs/ai-gateway/models-and-providers/provider-filtering-and-ordering.
+    // fails. Unlike OpenRouter, Vercel also exposes a genuine native Anthropic
+    // Messages API passthrough (`/v1/messages`, spec-identical per Vercel's
+    // own docs) — confirmed live to still honor `providerOptions.gateway.order`
+    // on this path, so we use it instead of the OpenAI-compatible
+    // `/v1/chat/completions` to avoid the request/response translation that
+    // path implies (same rationale as Cloudflare/Pydantic below). Confirmed
+    // live: a streamed response carries `resolvedProvider` inside the final
+    // `message_delta` event's `provider_metadata.gateway.routing` (alongside
+    // usage) — extracted below into `resolvedProvider` for the same
+    // visibility-over-silence reason as OpenRouter above. See
+    // https://vercel.com/docs/ai-gateway/sdks-and-apis/anthropic-messages-api
+    // and https://vercel.com/docs/ai-gateway/models-and-providers/provider-filtering-and-ordering.
     name: 'vercel-ai-gateway',
     requiredEnvVars: ['VERCEL_AI_GATEWAY_API_KEY'],
-    wireFormat: 'openai',
+    wireFormat: 'anthropic',
     model: 'anthropic/claude-haiku-4.5',
     host: 'ai-gateway.vercel.sh',
-    path: '/v1/chat/completions',
+    path: '/v1/messages',
     buildHeaders: () => ({
       Authorization: `Bearer ${process.env.VERCEL_AI_GATEWAY_API_KEY}`,
     }),
@@ -84,15 +88,21 @@ export const providers: AIGatewayProviderConfig[] = [
     // `anthropic/` here is LLM Gateway's provider-pinning syntax (provider/model),
     // so requests route to Anthropic itself — the same underlying model and
     // deployment as the other participants, addressed in this gateway's own
-    // catalog naming convention.
+    // catalog naming convention. LLM Gateway also exposes a native Anthropic
+    // Messages API passthrough (`/v1/messages`, listed alongside
+    // `/v1/chat/completions` in their own API reference) — confirmed live
+    // with a genuine Anthropic-shaped streamed response, so we use that
+    // instead of the OpenAI-compatible route to avoid the translation layer
+    // (same rationale as Cloudflare/Pydantic/Vercel).
     name: 'llmgateway',
     requiredEnvVars: ['LLM_GATEWAY_API_KEY'],
-    wireFormat: 'openai',
+    wireFormat: 'anthropic',
     model: 'anthropic/claude-haiku-4-5',
     host: 'api.llmgateway.io',
-    path: '/v1/chat/completions',
+    path: '/v1/messages',
     buildHeaders: () => ({
       Authorization: `Bearer ${process.env.LLM_GATEWAY_API_KEY}`,
+      'anthropic-version': '2023-06-01',
     }),
   },
   {
@@ -119,26 +129,31 @@ export const providers: AIGatewayProviderConfig[] = [
     }),
   },
   {
-    // Concentrate AI exposes an Anthropic-Messages-API-compatible endpoint
-    // (`/v1/messages/`, confirmed against its published OpenAPI spec at
-    // concentrate.ai/docs/api-reference/openapi.json) alongside a separate
-    // OpenAI-compatible `/v1/chat/completions/`. We use the Anthropic-shaped
-    // one so this sits in the same wireFormat group as Cloudflare/Pydantic/
-    // anthropic-direct. `anthropic/` is this gateway's provider-prefix syntax
-    // (same idea as llmgateway's pinning above) to route to Anthropic itself
-    // rather than Azure or Bedrock, which Concentrate's own "model fortress"
-    // catalog also lists as routing options for this model
+    // Concentrate AI exposes three endpoints: an Anthropic-Messages-compatible
+    // `/v1/messages/`, an OpenAI-Chat-Completions-compatible
+    // `/v1/chat/completions/`, and `/v1/responses/` — their own first-party,
+    // stable API (titled "Responses API" in their published OpenAPI spec at
+    // concentrate.ai/docs/api-reference/openapi.json), implementing OpenAI's
+    // Responses API shape. Concentrate has confirmed directly that
+    // `/v1/messages/` is a beta compatibility shim, not their production
+    // surface — it's also where we found the output_tokens/cost.breakdown
+    // field-collision bug (see phase-probe.ts), which reproduces identically
+    // on `/v1/responses/` too (same `cost.breakdown[…].output_tokens` dollar
+    // field, confirmed live), so this benchmark's usage-scoped token
+    // extraction still applies. `anthropic/` is this gateway's provider-prefix
+    // syntax (same idea as llmgateway's pinning above) to route to Anthropic
+    // itself rather than Azure or Bedrock, which Concentrate's own "model
+    // fortress" catalog also lists as routing options for this model
     // (anthropic/claude-haiku-4-5, azure/claude-haiku-4-5,
     // bedrock/claude-haiku-4-5).
     name: 'concentrate-ai-gateway',
     requiredEnvVars: ['CONCENTRATE_AI_GATEWAY_API_KEY'],
-    wireFormat: 'anthropic',
+    wireFormat: 'responses',
     model: 'anthropic/claude-haiku-4-5-20251001',
     host: 'api.concentrate.ai',
-    path: '/v1/messages/',
+    path: '/v1/responses/',
     buildHeaders: () => ({
       Authorization: `Bearer ${process.env.CONCENTRATE_AI_GATEWAY_API_KEY}`,
-      'anthropic-version': '2023-06-01',
     }),
   },
   {

--- a/benchmarks/ai-gateway/types.ts
+++ b/benchmarks/ai-gateway/types.ts
@@ -1,4 +1,4 @@
-export type AIGatewayWireFormat = 'openai' | 'anthropic';
+export type AIGatewayWireFormat = 'openai' | 'anthropic' | 'responses';
 
 export interface AIGatewayProviderConfig {
   /** Provider name */

--- a/packages/benchsdk/src/reporter.ts
+++ b/packages/benchsdk/src/reporter.ts
@@ -87,7 +87,11 @@ export class BenchmarkReporter {
         processKey: cfg.processKey,
       });
       return assignment ? new BenchmarkReporter(client, cfg, assignment) : null;
-    } catch {
+    } catch (error) {
+      console.warn(
+        `[benchsdk] failed to claim worker for ${cfg.benchmarkSlug}/${cfg.participantSlug}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      );
       return null;
     }
   }
@@ -169,7 +173,13 @@ export class BenchmarkReporter {
       contentType: input.contentType,
       metadata: input.metadata,
       body: input.body,
-    }).catch(() => null);
+    }).catch((error) => {
+      console.warn(
+        `[benchsdk] failed to upload ${input.kind} artifact for worker ${this.assignment.workerId}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    });
   }
 
   flush(isFinal = false): Promise<void> {


### PR DESCRIPTION
Anthropic: /v1/messages (only option, no change)
Cloudflare: /v1/messages (no change)
Pydantic: /v1/messages (no change)
OpenRouter: /chat/completions (only option, no change)

Changed:
**Concentrate:** /v1/messages -> /v1/responses (/messages and /chat/completions are beta as of now)
**LLMGateway:** /chat/completions -> /v1/messages (changed for consistency)
**Vercel:** /chat/completions -> /v1/messages (changed for consistency)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->