### PR TITLE
feat(database): CRUD benchmark domain with Postgres

### DIFF
--- a/benchmarks/database/README.md
+++ b/benchmarks/database/README.md
@@ -30,5 +30,8 @@ DATABASE_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:5433/benchmark \
 The payload defaults to 1 KiB and can be changed with `--payload-size`, for
 example `--payload-size 4096`.
 
+Results are written to `results/database/<YYYY-MM-DD>.json` and
+`results/database/latest.json`.
+
 To add a provider, add one entry to `providers.ts` and implement its
 `DatabaseClient` in a client module.

--- a/benchmarks/database/README.md
+++ b/benchmarks/database/README.md
@@ -1,0 +1,34 @@
+# Database CRUD benchmark
+
+This benchmark measures a create → read → update → read → delete cycle against
+each configured database provider. Postgres is currently the only provider.
+
+## Configuration
+
+Required:
+
+- `DATABASE_POSTGRES_URL`
+
+Optional:
+
+- `DATABASE_BENCH_TABLE` — table name, default `benchmark_crud`
+
+Run a local Postgres target with:
+
+```bash
+docker run --rm --name database-benchmark-postgres -p 5433:5432 \
+  -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=benchmark postgres:16
+```
+
+Then run the benchmark:
+
+```bash
+DATABASE_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:5433/benchmark \
+  pnpm bench:database:postgres
+```
+
+The payload defaults to 1 KiB and can be changed with `--payload-size`, for
+example `--payload-size 4096`.
+
+To add a provider, add one entry to `providers.ts` and implement its
+`DatabaseClient` in a client module.

--- a/benchmarks/database/benchmark.ts
+++ b/benchmarks/database/benchmark.ts
@@ -1,0 +1,158 @@
+import { writeFileSync } from 'node:fs';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { computeStats } from '../src/util/stats.js';
+import type { DatabaseClient, DatabaseDocument, DatabaseBenchmarkResult, DatabaseTimingResult } from './types.js';
+
+interface StepContext {
+  step<R>(name: string, fn: () => Promise<R> | R): Promise<R>;
+  verify?<R>(fn: () => Promise<R> | R): Promise<R>;
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function roundStats(stats: { median: number; p95: number; p99: number }) {
+  return {
+    median: round(stats.median),
+    p95: round(stats.p95),
+    p99: round(stats.p99),
+  };
+}
+
+function randomId(): string {
+  return Math.random().toString(36).slice(2, 15);
+}
+
+function makePayload(size: number): string {
+  const bytes = Math.ceil(size * 3 / 4);
+  return Buffer.from(crypto.randomBytes(bytes)).toString('base64').slice(0, size);
+}
+
+function assertDocument(actual: DatabaseDocument | null, expected: DatabaseDocument, phase: string): void {
+  if (
+    !actual ||
+    actual.id !== expected.id ||
+    actual.name !== expected.name ||
+    actual.payload !== expected.payload ||
+    actual.version !== expected.version
+  ) {
+    throw new Error(`${phase} verification failed`);
+  }
+}
+
+export async function runCrudCycle(
+  client: DatabaseClient,
+  ctx: StepContext,
+  payloadBytes: number,
+): Promise<DatabaseTimingResult> {
+  const totalStart = performance.now();
+  const id = `benchmark-${Date.now()}-${randomId()}`;
+  const payload = makePayload(payloadBytes);
+  const updatedPayload = makePayload(payloadBytes);
+  const document: DatabaseDocument = { id, name: 'database benchmark', payload, version: 1 };
+  const updatedDocument: DatabaseDocument = {
+    ...document,
+    name: 'database benchmark updated',
+    payload: updatedPayload,
+    version: 2,
+  };
+
+  try {
+    const createStart = performance.now();
+    await ctx.step('create', () => client.create(document));
+    const createMs = performance.now() - createStart;
+
+    const readStart = performance.now();
+    const readDocument = await ctx.step('read', () => client.read(id));
+    const readMs = performance.now() - readStart;
+    assertDocument(readDocument, document, 'create/read');
+
+    const updateStart = performance.now();
+    await ctx.step('update', () => client.update(id, {
+      name: updatedDocument.name,
+      payload: updatedDocument.payload,
+      version: updatedDocument.version,
+    }));
+    const updateMs = performance.now() - updateStart;
+
+    const readAfterUpdateStart = performance.now();
+    const readAfterUpdateDocument = await ctx.step('read-after-update', () => client.read(id));
+    const readAfterUpdateMs = performance.now() - readAfterUpdateStart;
+    assertDocument(readAfterUpdateDocument, updatedDocument, 'update/read');
+
+    const deleteStart = performance.now();
+    await ctx.step('delete', () => client.delete(id));
+    const deleteMs = performance.now() - deleteStart;
+
+    const afterDelete = await (ctx.verify ? ctx.verify(() => client.read(id)) : client.read(id));
+    if (afterDelete !== null) {
+      throw new Error('delete verification failed');
+    }
+
+    return {
+      createMs,
+      readMs,
+      updateMs,
+      readAfterUpdateMs,
+      deleteMs,
+      totalMs: performance.now() - totalStart,
+      payloadBytes,
+    };
+  } catch (error) {
+    try {
+      await client.delete(id);
+    } catch {
+      // Best-effort cleanup after a failed cycle.
+    }
+    throw error;
+  }
+}
+
+export async function writeDatabaseResultsJson(
+  results: DatabaseBenchmarkResult[],
+  outPath: string,
+): Promise<void> {
+  const cleanResults = results.map((result) => ({
+    provider: result.provider,
+    mode: result.mode,
+    ...(result.database ? { database: result.database } : {}),
+    table: result.table,
+    payloadBytes: result.payloadBytes,
+    iterations: result.iterations.map((iteration) => ({
+      createMs: round(iteration.createMs),
+      readMs: round(iteration.readMs),
+      updateMs: round(iteration.updateMs),
+      readAfterUpdateMs: round(iteration.readAfterUpdateMs),
+      deleteMs: round(iteration.deleteMs),
+      totalMs: round(iteration.totalMs),
+      payloadBytes: iteration.payloadBytes,
+      ...(iteration.error ? { error: iteration.error } : {}),
+    })),
+    summary: {
+      createMs: roundStats(result.summary.createMs),
+      readMs: roundStats(result.summary.readMs),
+      updateMs: roundStats(result.summary.updateMs),
+      readAfterUpdateMs: roundStats(result.summary.readAfterUpdateMs),
+      deleteMs: roundStats(result.summary.deleteMs),
+      totalMs: roundStats(result.summary.totalMs),
+    },
+    ...(result.compositeScore !== undefined ? { compositeScore: round(result.compositeScore) } : {}),
+    ...(result.successRate !== undefined ? { successRate: round(result.successRate) } : {}),
+    ...(result.skipped ? { skipped: result.skipped, skipReason: result.skipReason } : {}),
+  }));
+
+  const output = {
+    version: '1.0',
+    timestamp: new Date().toISOString(),
+    environment: { node: process.version, platform: os.platform(), arch: os.arch() },
+    config: {
+      iterations: results[0]?.iterations.length || 0,
+      timeoutMs: 30_000,
+    },
+    results: cleanResults,
+  };
+  writeFileSync(outPath, JSON.stringify(output, null, 2));
+  console.log(`Results written to ${outPath}`);
+}

--- a/benchmarks/database/benchmark.ts
+++ b/benchmarks/database/benchmark.ts
@@ -6,6 +6,7 @@ import type { DatabaseClient, DatabaseDocument, DatabaseBenchmarkResult } from '
 
 interface StepContext {
   step<R>(name: string, fn: () => Promise<R> | R): Promise<R>;
+  cleanup(fn: () => Promise<unknown> | unknown): Promise<unknown>;
 }
 
 function round(value: number): number {
@@ -99,7 +100,7 @@ export async function runCrudCycle(
     };
   } catch (error) {
     try {
-      await client.delete(id);
+      await ctx.cleanup(() => client.delete(id));
     } catch {
       // Best-effort cleanup after a failed cycle.
     }

--- a/benchmarks/database/benchmark.ts
+++ b/benchmarks/database/benchmark.ts
@@ -2,11 +2,10 @@ import { writeFileSync } from 'node:fs';
 import os from 'node:os';
 import crypto from 'node:crypto';
 import { computeStats } from '../src/util/stats.js';
-import type { DatabaseClient, DatabaseDocument, DatabaseBenchmarkResult, DatabaseTimingResult } from './types.js';
+import type { DatabaseClient, DatabaseDocument, DatabaseBenchmarkResult } from './types.js';
 
 interface StepContext {
   step<R>(name: string, fn: () => Promise<R> | R): Promise<R>;
-  verify?<R>(fn: () => Promise<R> | R): Promise<R>;
 }
 
 function round(value: number): number {
@@ -46,7 +45,7 @@ export async function runCrudCycle(
   client: DatabaseClient,
   ctx: StepContext,
   payloadBytes: number,
-): Promise<DatabaseTimingResult> {
+) {
   const totalStart = performance.now();
   const id = `benchmark-${Date.now()}-${randomId()}`;
   const payload = makePayload(payloadBytes);
@@ -83,12 +82,10 @@ export async function runCrudCycle(
     assertDocument(readAfterUpdateDocument, updatedDocument, 'update/read');
 
     const deleteStart = performance.now();
-    await ctx.step('delete', () => client.delete(id));
+    const deleted = await ctx.step('delete', () => client.delete(id));
     const deleteMs = performance.now() - deleteStart;
-
-    const afterDelete = await (ctx.verify ? ctx.verify(() => client.read(id)) : client.read(id));
-    if (afterDelete !== null) {
-      throw new Error('delete verification failed');
+    if (deleted !== 1) {
+      throw new Error(`delete verification failed: removed ${deleted} rows`);
     }
 
     return {
@@ -117,7 +114,6 @@ export async function writeDatabaseResultsJson(
   const cleanResults = results.map((result) => ({
     provider: result.provider,
     mode: result.mode,
-    ...(result.database ? { database: result.database } : {}),
     table: result.table,
     payloadBytes: result.payloadBytes,
     iterations: result.iterations.map((iteration) => ({

--- a/benchmarks/database/crud.bench.ts
+++ b/benchmarks/database/crud.bench.ts
@@ -75,6 +75,7 @@ export const task = defineTask<DatabaseProviderConfig>(async (ctx) => {
       client,
       {
         step: (name, fn) => step(name, () => withTimeout(Promise.resolve(fn()), timeout, `${name} timed out`)),
+        cleanup: (fn) => withTimeout(Promise.resolve(fn()), 10_000, 'Delete timed out'),
       },
       payloadBytes,
     );

--- a/benchmarks/database/crud.bench.ts
+++ b/benchmarks/database/crud.bench.ts
@@ -1,0 +1,100 @@
+/**
+ * Database CRUD benchmark: create → read → update → read → delete cycles.
+ * Declarative — exports `config` + `task`; `bench run` owns the entrypoint.
+ * The custom `--payload-size` flag is scanned from argv here.
+ *
+ *   bench run benchmarks/database/crud.bench.ts
+ *   bench run benchmarks/database/crud.bench.ts --payload-size 4096 --iterations 10
+ *   bench run benchmarks/database/crud.bench.ts --payload-size 1024 --provider postgres
+ */
+import '../src/env.js';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineBenchmarkConfig, defineTask, TaskError } from '@benchsdk/runner';
+import { withTimeout } from '../src/util/timeout.js';
+import { formatError } from '../src/util/error.js';
+import { databaseProviders } from './providers.js';
+import { writeDatabaseLegacyResults } from './legacy-results.js';
+import { runCrudCycle } from './benchmark.js';
+import type { DatabaseClient, DatabaseProviderConfig } from './types.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function getArgValue(argv: string[], flag: string): string | undefined {
+  const idx = argv.indexOf(flag);
+  if (idx !== -1 && idx + 1 < argv.length) return argv[idx + 1];
+  const equals = argv.find((arg) => arg.startsWith(`${flag}=`));
+  return equals?.slice(flag.length + 1);
+}
+
+const payloadSizeArg = getArgValue(process.argv.slice(2), '--payload-size');
+const payloadBytes = payloadSizeArg === undefined ? 1024 : Number(payloadSizeArg);
+if (!Number.isInteger(payloadBytes) || payloadBytes < 1) {
+  console.error(`Invalid --payload-size "${payloadSizeArg}". Provide a positive integer.`);
+  process.exit(1);
+}
+
+const clients = new Map<string, DatabaseClient>();
+const setupPromises = new Map<string, Promise<void>>();
+
+export const config = defineBenchmarkConfig({
+  benchmarkSlug: 'database-crud-local',
+  benchmarkName: 'Database CRUD (local)',
+  benchmarkKind: 'database',
+  iterations: 10,
+  concurrency: 1,
+  participants: databaseProviders,
+  onComplete: async (outcome) => {
+    await writeDatabaseLegacyResults(outcome.participants, {
+      resultsDir: path.resolve(__dirname, '../../results/database'),
+      providers: databaseProviders,
+      payloadBytes,
+    });
+    await Promise.all([...clients.values()].map((client) => client.close()));
+  },
+});
+
+export const task = defineTask<DatabaseProviderConfig>(async (ctx) => {
+  const { participant, step, measure } = ctx;
+  const timeout = participant.timeout ?? 30_000;
+  let client = clients.get(participant.name);
+  if (!client) {
+    client = participant.createClient();
+    clients.set(participant.name, client);
+  }
+
+  try {
+    let setup = setupPromises.get(participant.name);
+    if (!setup) {
+      setup = withTimeout(client.setup(), timeout, 'Database setup timed out');
+      setupPromises.set(participant.name, setup);
+    }
+    await setup;
+
+    const result = await runCrudCycle(
+      client,
+      {
+        step: (name, fn) => step(name, () => withTimeout(Promise.resolve(fn()), timeout, `${name} timed out`)),
+        verify: (fn) => withTimeout(Promise.resolve(fn()), timeout, 'Delete verification timed out'),
+      },
+      payloadBytes,
+    );
+    const data = { ...result };
+    measure(data);
+    return { data };
+  } catch (error) {
+    const message = formatError(error);
+    throw new TaskError(message, {
+      code: 'DATABASE_ERROR',
+      data: {
+        createMs: 0,
+        readMs: 0,
+        updateMs: 0,
+        readAfterUpdateMs: 0,
+        deleteMs: 0,
+        totalMs: 0,
+        payloadBytes,
+      },
+    });
+  }
+});

--- a/benchmarks/database/crud.bench.ts
+++ b/benchmarks/database/crud.bench.ts
@@ -55,7 +55,7 @@ export const config = defineBenchmarkConfig({
 });
 
 export const task = defineTask<DatabaseProviderConfig>(async (ctx) => {
-  const { participant, step, measure } = ctx;
+  const { participant, step } = ctx;
   const timeout = participant.timeout ?? 30_000;
   let client = clients.get(participant.name);
   if (!client) {
@@ -75,13 +75,10 @@ export const task = defineTask<DatabaseProviderConfig>(async (ctx) => {
       client,
       {
         step: (name, fn) => step(name, () => withTimeout(Promise.resolve(fn()), timeout, `${name} timed out`)),
-        verify: (fn) => withTimeout(Promise.resolve(fn()), timeout, 'Delete verification timed out'),
       },
       payloadBytes,
     );
-    const data = { ...result };
-    measure(data);
-    return { data };
+    return { data: result };
   } catch (error) {
     const message = formatError(error);
     throw new TaskError(message, {

--- a/benchmarks/database/legacy-results.ts
+++ b/benchmarks/database/legacy-results.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, copyFileSync } from 'node:fs';
+import path from 'node:path';
+import type { ParticipantRecords } from '@benchsdk/runner';
+import type { JsonObject } from '@benchsdk/client';
+import { byTaskIndex } from '../src/util/records.js';
+import { computeStats } from '../src/util/stats.js';
+import { computeDatabaseCompositeScores } from './scoring.js';
+import { writeDatabaseResultsJson } from './benchmark.js';
+import type {
+  DatabaseBenchmarkResult,
+  DatabaseProviderConfig,
+  DatabaseTimingResult,
+} from './types.js';
+
+function num(value: unknown): number {
+  return typeof value === 'number' ? value : 0;
+}
+
+export function recordsToDatabaseResults(
+  participants: ParticipantRecords[],
+  opts: { payloadBytes: number; providers: DatabaseProviderConfig[] },
+): DatabaseBenchmarkResult[] {
+  return participants.map((participant) => {
+    const provider = opts.providers.find((p) => p.name === participant.participant);
+    const iterations = byTaskIndex(participant.records).map((record): DatabaseTimingResult => {
+      const data = (record.data ?? {}) as JsonObject;
+      const base = {
+        createMs: num(data.createMs),
+        readMs: num(data.readMs),
+        updateMs: num(data.updateMs),
+        readAfterUpdateMs: num(data.readAfterUpdateMs),
+        deleteMs: num(data.deleteMs),
+        totalMs: num(data.totalMs),
+        payloadBytes: num(data.payloadBytes) || opts.payloadBytes,
+      };
+      return record.status === 'error'
+        ? { ...base, error: record.errorCode ?? 'error' }
+        : base;
+    });
+    const successful = iterations.filter((iteration) => !iteration.error);
+    const summary = {
+      createMs: computeStats(successful.map((i) => i.createMs)),
+      readMs: computeStats(successful.map((i) => i.readMs)),
+      updateMs: computeStats(successful.map((i) => i.updateMs)),
+      readAfterUpdateMs: computeStats(successful.map((i) => i.readAfterUpdateMs)),
+      deleteMs: computeStats(successful.map((i) => i.deleteMs)),
+      totalMs: computeStats(successful.map((i) => i.totalMs)),
+    };
+    return {
+      provider: participant.participant,
+      mode: 'database',
+      database: provider?.database,
+      table: process.env.DATABASE_BENCH_TABLE || 'benchmark_crud',
+      payloadBytes: opts.payloadBytes,
+      iterations,
+      summary,
+    };
+  });
+}
+
+/**
+ * Map records -> database results and write the dated and latest files.
+ * TEMPORARY BRIDGE until the platform read API exposes per-iteration data.
+ */
+export async function writeDatabaseLegacyResults(
+  participants: ParticipantRecords[],
+  opts: { resultsDir: string; providers: DatabaseProviderConfig[]; payloadBytes: number },
+): Promise<void> {
+  const results = recordsToDatabaseResults(participants, opts);
+  computeDatabaseCompositeScores(results);
+  mkdirSync(opts.resultsDir, { recursive: true });
+  const timestamp = new Date().toISOString().slice(0, 10);
+  const outPath = path.join(opts.resultsDir, `${timestamp}.json`);
+  await writeDatabaseResultsJson(results, outPath);
+  const latestPath = path.join(opts.resultsDir, 'latest.json');
+  copyFileSync(outPath, latestPath);
+  console.log(`Copied latest: ${latestPath}`);
+}

--- a/benchmarks/database/legacy-results.ts
+++ b/benchmarks/database/legacy-results.ts
@@ -49,8 +49,7 @@ export function recordsToDatabaseResults(
     return {
       provider: participant.participant,
       mode: 'database',
-      database: provider?.database,
-      table: process.env.DATABASE_BENCH_TABLE || 'benchmark_crud',
+      table: provider?.table ?? 'benchmark_crud',
       payloadBytes: opts.payloadBytes,
       iterations,
       summary,

--- a/benchmarks/database/postgres.ts
+++ b/benchmarks/database/postgres.ts
@@ -1,0 +1,71 @@
+import { Pool } from 'pg';
+import type { DatabaseClient, DatabaseDocument } from './types.js';
+
+const IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function quoteIdentifier(identifier: string): string {
+  if (!IDENTIFIER_PATTERN.test(identifier)) {
+    throw new Error(
+      `Invalid database table name "${identifier}"; use letters, numbers, and underscores`,
+    );
+  }
+  return `"${identifier}"`;
+}
+
+export function createPostgresClient(
+  connectionString = process.env.DATABASE_POSTGRES_URL,
+  tableName = process.env.DATABASE_BENCH_TABLE || 'benchmark_crud',
+): DatabaseClient {
+  if (!connectionString) {
+    throw new Error('DATABASE_POSTGRES_URL is required');
+  }
+
+  const table = quoteIdentifier(tableName);
+  const pool = new Pool({ connectionString, max: 1 });
+
+  return {
+    async setup() {
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS ${table} (
+          id text primary key,
+          name text not null,
+          payload text not null,
+          version integer not null,
+          updated_at timestamptz not null default now()
+        )
+      `);
+    },
+
+    async create(doc: DatabaseDocument) {
+      await pool.query(
+        `INSERT INTO ${table} (id, name, payload, version) VALUES ($1, $2, $3, $4)`,
+        [doc.id, doc.name, doc.payload, doc.version],
+      );
+    },
+
+    async read(id: string) {
+      const result = await pool.query<DatabaseDocument>(
+        `SELECT id, name, payload, version FROM ${table} WHERE id = $1`,
+        [id],
+      );
+      return result.rows[0] ?? null;
+    },
+
+    async update(id: string, patch: Pick<DatabaseDocument, 'name' | 'payload' | 'version'>) {
+      await pool.query(
+        `UPDATE ${table}
+         SET name = $1, payload = $2, version = $3, updated_at = now()
+         WHERE id = $4`,
+        [patch.name, patch.payload, patch.version, id],
+      );
+    },
+
+    async delete(id: string) {
+      await pool.query(`DELETE FROM ${table} WHERE id = $1`, [id]);
+    },
+
+    async close() {
+      await pool.end();
+    },
+  };
+}

--- a/benchmarks/database/postgres.ts
+++ b/benchmarks/database/postgres.ts
@@ -13,9 +13,9 @@ function quoteIdentifier(identifier: string): string {
 }
 
 export function createPostgresClient(
-  connectionString = process.env.DATABASE_POSTGRES_URL,
-  tableName = process.env.DATABASE_BENCH_TABLE || 'benchmark_crud',
+  options: { connectionString?: string; table: string },
 ): DatabaseClient {
+  const { connectionString, table: tableName } = options;
   if (!connectionString) {
     throw new Error('DATABASE_POSTGRES_URL is required');
   }
@@ -61,7 +61,8 @@ export function createPostgresClient(
     },
 
     async delete(id: string) {
-      await pool.query(`DELETE FROM ${table} WHERE id = $1`, [id]);
+      const result = await pool.query(`DELETE FROM ${table} WHERE id = $1`, [id]);
+      return result.rowCount ?? 0;
     },
 
     async close() {

--- a/benchmarks/database/providers.ts
+++ b/benchmarks/database/providers.ts
@@ -1,15 +1,17 @@
 import type { DatabaseProviderConfig } from './types.js';
 import { createPostgresClient } from './postgres.js';
 
+const table = process.env.DATABASE_BENCH_TABLE || 'benchmark_crud';
+
 /** Database provider configurations. Add future providers above the sentinel. */
 export const databaseProviders: DatabaseProviderConfig[] = [
   {
     name: 'postgres',
     requiredEnvVars: ['DATABASE_POSTGRES_URL'],
-    table: process.env.DATABASE_BENCH_TABLE || 'benchmark_crud',
+    table,
     createClient: () => createPostgresClient({
       connectionString: process.env.DATABASE_POSTGRES_URL,
-      table: process.env.DATABASE_BENCH_TABLE || 'benchmark_crud',
+      table,
     }),
   },
   //

--- a/benchmarks/database/providers.ts
+++ b/benchmarks/database/providers.ts
@@ -1,0 +1,12 @@
+import type { DatabaseProviderConfig } from './types.js';
+import { createPostgresClient } from './postgres.js';
+
+export const databaseProviders: DatabaseProviderConfig[] = [
+  {
+    name: 'postgres',
+    requiredEnvVars: ['DATABASE_POSTGRES_URL'],
+    createClient: () => createPostgresClient(),
+  },
+  //
+  // add providers above
+];

--- a/benchmarks/database/providers.ts
+++ b/benchmarks/database/providers.ts
@@ -1,11 +1,16 @@
 import type { DatabaseProviderConfig } from './types.js';
 import { createPostgresClient } from './postgres.js';
 
+/** Database provider configurations. Add future providers above the sentinel. */
 export const databaseProviders: DatabaseProviderConfig[] = [
   {
     name: 'postgres',
     requiredEnvVars: ['DATABASE_POSTGRES_URL'],
-    createClient: () => createPostgresClient(),
+    table: process.env.DATABASE_BENCH_TABLE || 'benchmark_crud',
+    createClient: () => createPostgresClient({
+      connectionString: process.env.DATABASE_POSTGRES_URL,
+      table: process.env.DATABASE_BENCH_TABLE || 'benchmark_crud',
+    }),
   },
   //
   // add providers above

--- a/benchmarks/database/scoring.ts
+++ b/benchmarks/database/scoring.ts
@@ -1,0 +1,77 @@
+import type { DatabaseBenchmarkResult } from './types.js';
+
+export interface DatabaseScoringWeights {
+  readMedian: number;
+  readP95: number;
+  readP99: number;
+  readAfterUpdateMedian: number;
+  readAfterUpdateP95: number;
+  readAfterUpdateP99: number;
+  createMedian: number;
+  createP95: number;
+  updateMedian: number;
+  updateP95: number;
+  deleteMedian: number;
+}
+
+export const DEFAULT_DATABASE_WEIGHTS: DatabaseScoringWeights = {
+  readMedian: 0.2,
+  readP95: 0.1,
+  readP99: 0.05,
+  readAfterUpdateMedian: 0.15,
+  readAfterUpdateP95: 0.08,
+  readAfterUpdateP99: 0.02,
+  createMedian: 0.12,
+  createP95: 0.08,
+  updateMedian: 0.08,
+  updateP95: 0.07,
+  deleteMedian: 0.05,
+};
+
+// CRUD requests are much faster than multi-megabyte storage operations.
+const LATENCY_CEILING_MS = 2_000;
+
+function scoreLatency(valueMs: number): number {
+  return Math.max(0, 100 * (1 - valueMs / LATENCY_CEILING_MS));
+}
+
+export function computeDatabaseSuccessRate(result: DatabaseBenchmarkResult): number {
+  if (result.skipped || result.iterations.length === 0) return 0;
+  return result.iterations.filter((iteration) => !iteration.error).length / result.iterations.length;
+}
+
+export function computeDatabaseCompositeScores(
+  results: DatabaseBenchmarkResult[],
+  weights: DatabaseScoringWeights = DEFAULT_DATABASE_WEIGHTS,
+): void {
+  for (const result of results) {
+    const successRate = computeDatabaseSuccessRate(result);
+    result.successRate = successRate;
+    if (result.skipped || successRate === 0) {
+      result.compositeScore = 0;
+      continue;
+    }
+
+    const score =
+      weights.readMedian * scoreLatency(result.summary.readMs.median) +
+      weights.readP95 * scoreLatency(result.summary.readMs.p95) +
+      weights.readP99 * scoreLatency(result.summary.readMs.p99) +
+      weights.readAfterUpdateMedian * scoreLatency(result.summary.readAfterUpdateMs.median) +
+      weights.readAfterUpdateP95 * scoreLatency(result.summary.readAfterUpdateMs.p95) +
+      weights.readAfterUpdateP99 * scoreLatency(result.summary.readAfterUpdateMs.p99) +
+      weights.createMedian * scoreLatency(result.summary.createMs.median) +
+      weights.createP95 * scoreLatency(result.summary.createMs.p95) +
+      weights.updateMedian * scoreLatency(result.summary.updateMs.median) +
+      weights.updateP95 * scoreLatency(result.summary.updateMs.p95) +
+      weights.deleteMedian * scoreLatency(result.summary.deleteMs.median);
+    result.compositeScore = Math.round(score * successRate * 100) / 100;
+  }
+}
+
+export function sortDatabaseByCompositeScore(results: DatabaseBenchmarkResult[]): DatabaseBenchmarkResult[] {
+  return [...results].sort((a, b) => {
+    if (a.skipped && !b.skipped) return 1;
+    if (!a.skipped && b.skipped) return -1;
+    return (b.compositeScore ?? 0) - (a.compositeScore ?? 0);
+  });
+}

--- a/benchmarks/database/types.ts
+++ b/benchmarks/database/types.ts
@@ -1,30 +1,52 @@
+/** Row/document used by the CRUD workload. */
 export interface DatabaseDocument {
+  /** Stable identifier for the row/document. */
   id: string;
+  /** Human-readable value under test. */
   name: string;
+  /** Fixed-size random payload used for comparable measurements. */
   payload: string;
+  /** Application-managed version, incremented by the update phase. */
   version: number;
 }
 
+/**
+ * Local abstraction for a database SDK that does not exist yet.
+ * `setup()` creates provider resources once per participant and is untimed.
+ */
 export interface DatabaseClient {
+  /** Create the benchmark table/collection; called once per participant. */
   setup(): Promise<void>;
+  /** Insert a row/document. */
   create(doc: DatabaseDocument): Promise<void>;
+  /** Read a row/document by identifier. */
   read(id: string): Promise<DatabaseDocument | null>;
+  /** Update the mutable fields of a row/document. */
   update(
     id: string,
     patch: Pick<DatabaseDocument, 'name' | 'payload' | 'version'>,
   ): Promise<void>;
-  delete(id: string): Promise<void>;
+  /** Delete by identifier and return the number of removed rows/documents. */
+  delete(id: string): Promise<number>;
+  /** Close provider resources. */
   close(): Promise<void>;
 }
 
+/** Configuration for one database benchmark participant. */
 export interface DatabaseProviderConfig {
+  /** Provider name shown in benchmark output. */
   name: string;
+  /** Environment variables required before this participant can run. */
   requiredEnvVars: string[];
+  /** Table/collection name used by this participant. */
+  table: string;
+  /** Create the participant's database client. */
   createClient: () => DatabaseClient;
+  /** Timeout per database operation in milliseconds. */
   timeout?: number;
-  database?: string;
 }
 
+/** Timings and payload size recorded for one CRUD cycle. */
 export interface DatabaseTimingResult {
   createMs: number;
   readMs: number;
@@ -36,6 +58,7 @@ export interface DatabaseTimingResult {
   error?: string;
 }
 
+/** Median and tail latency statistics for each CRUD phase. */
 export interface DatabaseStats {
   createMs: { median: number; p95: number; p99: number };
   readMs: { median: number; p95: number; p99: number };
@@ -45,10 +68,10 @@ export interface DatabaseStats {
   totalMs: { median: number; p95: number; p99: number };
 }
 
+/** Aggregate benchmark results for one database provider. */
 export interface DatabaseBenchmarkResult {
   provider: string;
   mode: 'database';
-  database?: string;
   table: string;
   payloadBytes: number;
   iterations: DatabaseTimingResult[];

--- a/benchmarks/database/types.ts
+++ b/benchmarks/database/types.ts
@@ -1,0 +1,60 @@
+export interface DatabaseDocument {
+  id: string;
+  name: string;
+  payload: string;
+  version: number;
+}
+
+export interface DatabaseClient {
+  setup(): Promise<void>;
+  create(doc: DatabaseDocument): Promise<void>;
+  read(id: string): Promise<DatabaseDocument | null>;
+  update(
+    id: string,
+    patch: Pick<DatabaseDocument, 'name' | 'payload' | 'version'>,
+  ): Promise<void>;
+  delete(id: string): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface DatabaseProviderConfig {
+  name: string;
+  requiredEnvVars: string[];
+  createClient: () => DatabaseClient;
+  timeout?: number;
+  database?: string;
+}
+
+export interface DatabaseTimingResult {
+  createMs: number;
+  readMs: number;
+  updateMs: number;
+  readAfterUpdateMs: number;
+  deleteMs: number;
+  totalMs: number;
+  payloadBytes: number;
+  error?: string;
+}
+
+export interface DatabaseStats {
+  createMs: { median: number; p95: number; p99: number };
+  readMs: { median: number; p95: number; p99: number };
+  updateMs: { median: number; p95: number; p99: number };
+  readAfterUpdateMs: { median: number; p95: number; p99: number };
+  deleteMs: { median: number; p95: number; p99: number };
+  totalMs: { median: number; p95: number; p99: number };
+}
+
+export interface DatabaseBenchmarkResult {
+  provider: string;
+  mode: 'database';
+  database?: string;
+  table: string;
+  payloadBytes: number;
+  iterations: DatabaseTimingResult[];
+  summary: DatabaseStats;
+  compositeScore?: number;
+  successRate?: number;
+  skipped?: boolean;
+  skipReason?: string;
+}

--- a/package.json
+++ b/package.json
@@ -88,7 +88,9 @@
     "bench:ai-gateway:pydantic": "tsx packages/benchsdk-runner/dist/bin.js run benchmarks/ai-gateway/ai-gateway.bench.ts --provider pydantic-ai-gateway",
     "bench:ai-gateway:concentrate": "tsx packages/benchsdk-runner/dist/bin.js run benchmarks/ai-gateway/ai-gateway.bench.ts --provider concentrate-ai-gateway",
     "bench:ai-gateway:anthropic": "tsx packages/benchsdk-runner/dist/bin.js run benchmarks/ai-gateway/ai-gateway.bench.ts --provider anthropic-direct",
-    "generate-ai-gateway-svg": "tsx benchmarks/ai-gateway/generate-svg.ts"
+    "generate-ai-gateway-svg": "tsx benchmarks/ai-gateway/generate-svg.ts",
+    "bench:database": "tsx packages/benchsdk-runner/dist/bin.js run benchmarks/database/crud.bench.ts",
+    "bench:database:postgres": "tsx packages/benchsdk-runner/dist/bin.js run benchmarks/database/crud.bench.ts --provider postgres"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1076.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "benchmarks/sandbox/**/*.ts",
     "benchmarks/browser/**/*.ts",
     "benchmarks/storage/**/*.ts",
+    "benchmarks/database/**/*.ts",
     "benchmarks/ai-gateway/**/*.ts",
     "benchmarks/scale/**/*.ts"
   ],


### PR DESCRIPTION
## Summary

New `benchmarks/database/` domain measuring a create → read → update → read → delete cycle, with Postgres as the only provider. Same shape as `benchmarks/storage/`: `types.ts` / `providers.ts` / `benchmark.ts` / `scoring.ts` / `legacy-results.ts` + a declarative `crud.bench.ts` (`config` + `task`, `bench run` owns the entrypoint, `--provider` selects one provider). Root scripts `bench:database` and `bench:database:postgres` sit next to `bench:storage*`. Runs against a plain local Postgres container — no cloud credentials.

### Abstraction choice: (a), a provider interface local to the domain

There is no database equivalent of `@storagesdk/core`, so `types.ts` defines the smallest interface the workload needs, mirroring storage's `createStorage()` with a `createClient()` factory on the provider config:

```ts
interface DatabaseClient {
  setup(): Promise<void>;                 // create table/collection, once per participant, untimed
  create(doc: DatabaseDocument): Promise<void>;
  read(id: string): Promise<DatabaseDocument | null>;
  update(id, patch: Pick<DatabaseDocument, 'name'|'payload'|'version'>): Promise<void>;
  delete(id: string): Promise<number>;    // rows removed — doubles as delete verification
  close(): Promise<void>;
}
```

Why not something else: publishing a package was out of scope, and a query-level abstraction (raw SQL, or an ORM like Drizzle) would not carry over to MongoDB/Firestore, which is the whole point of the registry. Everything provider-specific — the `pg.Pool`, the table DDL, the parameterised statements — lives in `postgres.ts` behind this interface, so adding MongoDB later is one entry in `providers.ts` plus one client module, and swapping in a real SDK later means reimplementing `createClient` only. `delete` returning a count rather than `void` lets the cycle assert the row is gone without an extra untimed round trip.

### Workload

Each phase is its own `ctx.step` **and** separately timed into `data` (`createMs`, `readMs`, `updateMs`, `readAfterUpdateMs`, `deleteMs`, `totalMs`, `payloadBytes`), following how storage reports `uploadMs`/`downloadMs`, so the platform can chart per-phase latency. Reads are verified, not just timed: the post-create read must match the written document and the post-update read must observe the new `version`/`payload`, otherwise the iteration fails with `DATABASE_ERROR`. Payload size is a `--payload-size` flag parsed from argv the same way storage parses `--file-size` (default 1 KiB).

### Env vars

- `DATABASE_POSTGRES_URL` (required)
- `DATABASE_BENCH_TABLE` (optional, default `benchmark_crud`)

```bash
docker run --rm --name database-benchmark-postgres -p 5433:5432 \
  -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=benchmark postgres:16
DATABASE_POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:5433/benchmark pnpm bench:database:postgres
```

`tsconfig.json` gains `benchmarks/database/**/*.ts` — the `include` list is per-domain, so without it `pnpm typecheck` would silently skip every new file.

## Local run

`pnpm typecheck` passes. Run end to end against a local Postgres (5433) with a local benchmarks-platform stack (per `.agents/skills/local-platform-e2e`) as the reporting target; the platform's ClickHouse import of this run also succeeded (`imported: 1, failed: 0, records: 10, steps: 50`).

```text
> tsx packages/benchsdk-runner/dist/bin.js run benchmarks/database/crud.bench.ts --provider postgres --payload-size 1024

Database CRUD (local) (self-contained)
Knobs: iterations=10, concurrency=1, staggerDelayMs=0, groupBy=participant

Run created: 2c83bad6-b0d8-480b-88ec-48d0cf1b61fd
======================================================================
  Participant: postgres
======================================================================
  [postgres] Task 1/10: success {"createMs":6.687896,"readMs":1.478172,"updateMs":0.958039,"readAfterUpdateMs":2.871194,"deleteMs":0.73118,"totalMs":13.013246,"payloadBytes":1024}
  [postgres] Task 2/10: success {"createMs":0.644397,"readMs":0.599691,"updateMs":4.261675,"readAfterUpdateMs":0.784018,"deleteMs":0.657754,"totalMs":7.040833,"payloadBytes":1024}
  [postgres] Task 3/10: success {"createMs":0.514186,"readMs":0.574232,"updateMs":0.568213,"readAfterUpdateMs":0.481009,"deleteMs":1.532547,"totalMs":3.758292,"payloadBytes":1024}
  [postgres] Task 4/10: success {"createMs":0.625934,"readMs":0.431872,"updateMs":3.817789,"readAfterUpdateMs":2.656433,"deleteMs":1.263329,"totalMs":8.912508,"payloadBytes":1024}
  [postgres] Task 5/10: success {"createMs":0.946772,"readMs":0.480355,"updateMs":1.260775,"readAfterUpdateMs":0.534825,"deleteMs":0.513826,"totalMs":3.839468,"payloadBytes":1024}
  [postgres] Task 6/10: success {"createMs":0.526541,"readMs":0.448021,"updateMs":0.40638,"readAfterUpdateMs":0.330008,"deleteMs":0.367934,"totalMs":2.164837,"payloadBytes":1024}
  [postgres] Task 7/10: success {"createMs":0.477204,"readMs":0.389678,"updateMs":0.462877,"readAfterUpdateMs":0.40343,"deleteMs":0.52297,"totalMs":2.371259,"payloadBytes":1024}
  [postgres] Task 8/10: success {"createMs":0.4964,"readMs":0.901417,"updateMs":0.549923,"readAfterUpdateMs":0.420781,"deleteMs":0.416062,"totalMs":2.876798,"payloadBytes":1024}
  [postgres] Task 9/10: success {"createMs":0.487472,"readMs":0.373107,"updateMs":0.414609,"readAfterUpdateMs":0.348502,"deleteMs":0.395219,"totalMs":2.080819,"payloadBytes":1024}
  [postgres] Task 10/10: success {"createMs":0.455437,"readMs":0.455036,"updateMs":0.548529,"readAfterUpdateMs":0.455374,"deleteMs":0.530378,"totalMs":2.519572,"payloadBytes":1024}
  Done: 10/10 succeeded.

Results written to results/database/2026-08-01.json
Copied latest: results/database/latest.json
```

Task 1 carries the cold-connection cost; the generated `results/database/*.json` are not committed.

Link to Devin session: https://app.devin.ai/sessions/2fd0b29d80ee433eb61bc9d7e015ed80
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->