### PR TITLE
fix(runner): fall back to getBenchmark when org key cannot upsert metadata

### DIFF
--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -15,6 +15,7 @@
  *     per participant.
  */
 import {
+  BenchmarkApiError,
   BenchmarkReporter,
   createBenchmarkClient,
   filterParticipantsByEnv,
@@ -369,10 +370,22 @@ export async function runBenchmark<T extends BaseParticipant>(
     !args.benchmark ||
     args.benchmark === fileConfig.benchmarkSlug;
   if (identityIsOurs) {
-    await client.upsertBenchmark(config.benchmarkSlug, {
-      name: config.benchmarkName,
-      ...(config.benchmarkKind ? { kind: config.benchmarkKind } : {}),
-    });
+    try {
+      await client.upsertBenchmark(config.benchmarkSlug, {
+        name: config.benchmarkName,
+        ...(config.benchmarkKind ? { kind: config.benchmarkKind } : {}),
+      });
+    } catch (error) {
+      // Org-scoped platform keys cannot update benchmark metadata (it's an
+      // admin-only route), but they can still run it. Verify the benchmark
+      // exists and continue; if it doesn't, getBenchmark will surface the
+      // right error.
+      if (error instanceof BenchmarkApiError && error.status === 403) {
+        await client.getBenchmark(config.benchmarkSlug);
+      } else {
+        throw error;
+      }
+    }
   }
 
   let runId: string;


### PR DESCRIPTION
## Summary

The `bench run` CLI uses `BENCHMARKS_PLATFORM_API_KEY` (an org-scoped `bp_` key), but the platform's `PUT /benchmarks/{slug}` route is admin-only. This caused every CI run to fail immediately with `Benchmark API request failed: 403 Forbidden` when the runner tried to materialize the benchmark metadata.

Now, when `upsertBenchmark` returns a 403, the runner verifies the benchmark exists via `getBenchmark` and continues. If the benchmark is missing, `getBenchmark` will surface the appropriate 404 instead. Admin-only benchmark creation still works for callers with `COMPUTESDK_ADMIN_API_KEY`.

```ts
// runner.ts
if (identityIsOurs) {
  try {
    await client.upsertBenchmark(config.benchmarkSlug, { ... });
  } catch (error) {
    if (error instanceof BenchmarkApiError && error.status === 403) {
      await client.getBenchmark(config.benchmarkSlug);
    } else {
      throw error;
    }
  }
}
```

Link to Devin session: https://app.devin.ai/sessions/e8407a875a5c47cbaeb3aa22b2bc5103
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->