### PR TITLE
chore(ci): align benchmark workflow schedules with CDT hours

### DIFF
--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -10,7 +10,7 @@ on:
       - 'package.json'
       - '.github/workflows/ai-gateway-benchmarks.yml'
   schedule:
-    - cron: '0 6 * * 5' # Weekly on Friday at 6am UTC
+    - cron: '0 9 * * 5' # Weekly on Friday at 9am UTC (4am CDT)
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'benchmarks/src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 0 * * 5' # Weekly on Friday at midnight UTC
+    - cron: '0 10 * * 5' # Weekly on Friday at 10am UTC (5am CDT)
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'benchmarks/src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 3 * * 5' # Weekly on Friday at 03:00 UTC (offset from main browser benchmark)
+    - cron: '0 10 * * 5' # Weekly on Friday at 10am UTC (5am CDT)
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'benchmarks/src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 10 * * 5' # Weekly on Friday at 10am UTC (5am CDT)
+    - cron: '30 10 * * 5' # Weekly on Friday at 10:30am UTC (5:30am CDT, offset from main browser benchmark to avoid provider contention)
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -13,7 +13,7 @@ on:
       - 'package.json'
       - '.github/workflows/sandbox-dax-benchmarks.yml'
   schedule:
-    - cron: '0 0 * * 5' # Weekly on Friday at midnight UTC
+    - cron: '0 13 * * 5' # Weekly on Friday at 1pm UTC (8am CDT)
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -13,7 +13,7 @@ on:
       - 'package.json'
       - '.github/workflows/sandbox-dax-benchmarks.yml'
   schedule:
-    - cron: '0 13 * * 5' # Weekly on Friday at 1pm UTC (8am CDT)
+    - cron: '30 13 * * 5' # Weekly on Friday at 1:30pm UTC (8:30am CDT, offset from TTI to avoid provider contention)
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/sandbox-tti-benchmarks.yml
+++ b/.github/workflows/sandbox-tti-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'benchmarks/src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 0 * * 5' # Weekly on Friday at midnight UTC
+    - cron: '0 13 * * 5' # Weekly on Friday at 1pm UTC (8am CDT)
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/snapshot-fork-benchmarks.yml
+++ b/.github/workflows/snapshot-fork-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'benchmarks/src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 11 * * 5' # Weekly on Friday at 11am UTC (6am CDT)
+    - cron: '30 11 * * 5' # Weekly on Friday at 11:30am UTC (6:30am CDT, offset from storage to avoid racing pushes to master)
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/snapshot-fork-benchmarks.yml
+++ b/.github/workflows/snapshot-fork-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'benchmarks/src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 7 * * 5' # Weekly on Friday at 7am UTC (offset from the storage benchmark at 6am to avoid racing pushes to master)
+    - cron: '0 11 * * 5' # Weekly on Friday at 11am UTC (6am CDT)
   workflow_dispatch:
     inputs:
       iterations:

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -9,7 +9,7 @@ on:
       - 'benchmarks/src/merge-results.ts'
       - 'package.json'
   schedule:
-    - cron: '0 6 * * 5' # Weekly on Friday at 6am UTC
+    - cron: '0 11 * * 5' # Weekly on Friday at 11am UTC (6am CDT)
   workflow_dispatch:
     inputs:
       iterations:


### PR DESCRIPTION
## Summary

Updates the weekly Friday cron schedules for all benchmark workflows to match the requested Central Daylight Time (CDT, UTC-5) start times, with 30-minute offsets between paired workflows to avoid provider contention and git push races:

| Benchmark | CDT time | UTC time | Workflow |
|---|---|---|---|
| AI Gateway | 4:00am | 09:00 | `ai-gateway-benchmarks.yml` |
| Browser | 5:00am | 10:00 | `browser-benchmarks.yml` |
| Browser Throughput | 5:30am | 10:30 | `browser-throughput-benchmarks.yml` |
| Storage | 6:00am | 11:00 | `storage-benchmarks.yml` |
| Snapshot/Fork | 6:30am | 11:30 | `snapshot-fork-benchmarks.yml` |
| Sandbox TTI | 8:00am | 13:00 | `sandbox-tti-benchmarks.yml` |
| Sandbox Dax | 8:30am | 13:30 | `sandbox-dax-benchmarks.yml` |

Link to Devin session: https://app.devin.ai/sessions/fb19f02d026544d18b26d41cb4e509b6
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->