### PR TITLE
fix: commit benchmark results via PR to satisfy branch protection

### DIFF
--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -203,3 +203,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh ai-gateway-benchmarks 'ai-gateway.svg' 'results/ai-gateway/'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -202,25 +202,4 @@ jobs:
             }
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add ai-gateway.svg results/ai-gateway/
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update ai gateway benchmark results [skip ci]"
-
-          # Remote master can advance during the run (concurrent benchmark
-          # workflows push to master too), so a plain push fails non-fast-forward.
-          # Rebase onto the latest remote and retry a few times before giving up.
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
-          exit 1
+        run: benchmarks/scripts/commit-results.sh ai-gateway-benchmarks 'ai-gateway.svg' 'results/ai-gateway/'

--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -224,28 +224,4 @@ jobs:
             }
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json pnpm-lock.yaml browser.svg results/browser/
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update browser benchmark results [skip ci]"
-
-          # Remote master can advance during the run (concurrent benchmark
-          # workflows push to master too), so a plain push fails non-fast-forward.
-          # Rebase onto the latest remote and retry a few times before giving up.
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            # Rebase before each attempt (including the last) so every rebase
-            # is followed by a push — otherwise the final iteration's rebase
-            # would be wasted and a resolvable non-fast-forward could still fail.
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
-          exit 1
+        run: benchmarks/scripts/commit-results.sh browser-benchmarks 'package.json' 'pnpm-lock.yaml' 'browser.svg' 'results/browser/'

--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -225,3 +225,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh browser-benchmarks 'package.json' 'pnpm-lock.yaml' 'browser.svg' 'results/browser/'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -272,3 +272,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh browser-throughput-benchmarks 'package.json' 'pnpm-lock.yaml' 'browser-throughput.svg' 'results/browser-throughput/'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -271,28 +271,4 @@ jobs:
             }
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json pnpm-lock.yaml browser-throughput.svg results/browser-throughput/
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update browser throughput benchmark results [skip ci]"
-
-          # Remote master can advance during the run (concurrent benchmark
-          # workflows push to master too), so a plain push fails non-fast-forward.
-          # Rebase onto the latest remote and retry a few times before giving up.
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            # Rebase before each attempt (including the last) so every rebase
-            # is followed by a push — otherwise the final iteration's rebase
-            # would be wasted and a resolvable non-fast-forward could still fail.
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
-          exit 1
+        run: benchmarks/scripts/commit-results.sh browser-throughput-benchmarks 'package.json' 'pnpm-lock.yaml' 'browser-throughput.svg' 'results/browser-throughput/'

--- a/.github/workflows/pricing-svg.yml
+++ b/.github/workflows/pricing-svg.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   generate:
@@ -20,11 +21,4 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run generate-pricing-svg
       - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pricing.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update pricing SVG [skip ci]"
-          git pull --rebase
-          git push
+        run: benchmarks/scripts/commit-results.sh pricing-svg 'pricing.svg'

--- a/.github/workflows/pricing-svg.yml
+++ b/.github/workflows/pricing-svg.yml
@@ -22,3 +22,5 @@ jobs:
       - run: pnpm run generate-pricing-svg
       - name: Commit and push
         run: benchmarks/scripts/commit-results.sh pricing-svg 'pricing.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-cpu-node.yml
+++ b/.github/workflows/sandbox-cpu-node.yml
@@ -166,21 +166,4 @@ jobs:
           npx tsx benchmarks/src/ingest.ts --type cpu-node
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/ cpu_node.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update cpu-node benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
+        run: benchmarks/scripts/commit-results.sh sandbox-cpu-node 'results/' 'cpu_node.svg'

--- a/.github/workflows/sandbox-cpu-node.yml
+++ b/.github/workflows/sandbox-cpu-node.yml
@@ -167,3 +167,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-cpu-node 'results/' 'cpu_node.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -259,3 +259,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-dax-benchmarks 'results/sandbox-dax/' 'dax.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -258,22 +258,4 @@ jobs:
             }
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/sandbox-dax/ dax.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update dax benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
-          exit 1
+        run: benchmarks/scripts/commit-results.sh sandbox-dax-benchmarks 'results/sandbox-dax/' 'dax.svg'

--- a/.github/workflows/sandbox-disk.yml
+++ b/.github/workflows/sandbox-disk.yml
@@ -167,3 +167,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-disk 'results/' 'disk.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-disk.yml
+++ b/.github/workflows/sandbox-disk.yml
@@ -166,21 +166,4 @@ jobs:
           npx tsx benchmarks/src/ingest.ts --type disk
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/ disk.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update disk benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
+        run: benchmarks/scripts/commit-results.sh sandbox-disk 'results/' 'disk.svg'

--- a/.github/workflows/sandbox-dns.yml
+++ b/.github/workflows/sandbox-dns.yml
@@ -155,21 +155,4 @@ jobs:
           npx tsx benchmarks/src/ingest.ts --type dns
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/ dns.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update dns benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
+        run: benchmarks/scripts/commit-results.sh sandbox-dns 'results/' 'dns.svg'

--- a/.github/workflows/sandbox-dns.yml
+++ b/.github/workflows/sandbox-dns.yml
@@ -156,3 +156,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-dns 'results/' 'dns.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-download.yml
+++ b/.github/workflows/sandbox-download.yml
@@ -155,21 +155,4 @@ jobs:
           npx tsx benchmarks/src/ingest.ts --type download
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/ download.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update download benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
+        run: benchmarks/scripts/commit-results.sh sandbox-download 'results/' 'download.svg'

--- a/.github/workflows/sandbox-download.yml
+++ b/.github/workflows/sandbox-download.yml
@@ -156,3 +156,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-download 'results/' 'download.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-latency.yml
+++ b/.github/workflows/sandbox-latency.yml
@@ -155,21 +155,4 @@ jobs:
           npx tsx benchmarks/src/ingest.ts --type latency
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/ latency.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update latency benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
+        run: benchmarks/scripts/commit-results.sh sandbox-latency 'results/' 'latency.svg'

--- a/.github/workflows/sandbox-latency.yml
+++ b/.github/workflows/sandbox-latency.yml
@@ -156,3 +156,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-latency 'results/' 'latency.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-memory.yml
+++ b/.github/workflows/sandbox-memory.yml
@@ -166,21 +166,4 @@ jobs:
           npx tsx benchmarks/src/ingest.ts --type memory
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/ memory.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update memory benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
+        run: benchmarks/scripts/commit-results.sh sandbox-memory 'results/' 'memory.svg'

--- a/.github/workflows/sandbox-memory.yml
+++ b/.github/workflows/sandbox-memory.yml
@@ -167,3 +167,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-memory 'results/' 'memory.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-network-localhost.yml
+++ b/.github/workflows/sandbox-network-localhost.yml
@@ -166,21 +166,4 @@ jobs:
           npx tsx benchmarks/src/ingest.ts --type network-localhost
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/ network_localhost.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update network-localhost benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
+        run: benchmarks/scripts/commit-results.sh sandbox-network-localhost 'results/' 'network_localhost.svg'

--- a/.github/workflows/sandbox-network-localhost.yml
+++ b/.github/workflows/sandbox-network-localhost.yml
@@ -167,3 +167,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-network-localhost 'results/' 'network_localhost.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-network-wan.yml
+++ b/.github/workflows/sandbox-network-wan.yml
@@ -167,3 +167,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-network-wan 'results/' 'network_wan.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-network-wan.yml
+++ b/.github/workflows/sandbox-network-wan.yml
@@ -166,21 +166,4 @@ jobs:
           npx tsx benchmarks/src/ingest.ts --type network-wan
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/ network_wan.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update network-wan benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
+        run: benchmarks/scripts/commit-results.sh sandbox-network-wan 'results/' 'network_wan.svg'

--- a/.github/workflows/sandbox-pgbench.yml
+++ b/.github/workflows/sandbox-pgbench.yml
@@ -166,21 +166,4 @@ jobs:
           npx tsx benchmarks/src/ingest.ts --type pgbench
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/ pgbench.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update pgbench benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
+        run: benchmarks/scripts/commit-results.sh sandbox-pgbench 'results/' 'pgbench.svg'

--- a/.github/workflows/sandbox-pgbench.yml
+++ b/.github/workflows/sandbox-pgbench.yml
@@ -167,3 +167,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-pgbench 'results/' 'pgbench.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-realworld.yml
+++ b/.github/workflows/sandbox-realworld.yml
@@ -155,21 +155,4 @@ jobs:
           npx tsx benchmarks/src/ingest.ts --type realworld
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/ realworld.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update realworld benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
+        run: benchmarks/scripts/commit-results.sh sandbox-realworld 'results/' 'realworld.svg'

--- a/.github/workflows/sandbox-realworld.yml
+++ b/.github/workflows/sandbox-realworld.yml
@@ -156,3 +156,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-realworld 'results/' 'realworld.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-system.yml
+++ b/.github/workflows/sandbox-system.yml
@@ -166,21 +166,4 @@ jobs:
           npx tsx benchmarks/src/ingest.ts --type system
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/ system.svg
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update system benchmark results [skip ci]"
-
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
+        run: benchmarks/scripts/commit-results.sh sandbox-system 'results/' 'system.svg'

--- a/.github/workflows/sandbox-system.yml
+++ b/.github/workflows/sandbox-system.yml
@@ -167,3 +167,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-system 'results/' 'system.svg'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-tti-benchmarks.yml
+++ b/.github/workflows/sandbox-tti-benchmarks.yml
@@ -306,3 +306,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh sandbox-tti-benchmarks 'package.json' 'pnpm-lock.yaml' 'results.svg' '*_tti.svg' 'pricing.svg' 'results/'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-tti-benchmarks.yml
+++ b/.github/workflows/sandbox-tti-benchmarks.yml
@@ -305,28 +305,4 @@ jobs:
             }
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json pnpm-lock.yaml results.svg *_tti.svg pricing.svg results/
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update benchmark results [skip ci]"
-
-          # Remote master can advance during the run (concurrent runs / other
-          # commits), so a plain push fails non-fast-forward. Rebase onto the
-          # latest remote and retry a few times before giving up.
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            # Rebase before each attempt (including the last) so every rebase
-            # is followed by a push — otherwise the final iteration's rebase
-            # would be wasted and a resolvable non-fast-forward could still fail.
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
-          exit 1
+        run: benchmarks/scripts/commit-results.sh sandbox-tti-benchmarks 'package.json' 'pnpm-lock.yaml' 'results.svg' '*_tti.svg' 'pricing.svg' 'results/'

--- a/.github/workflows/snapshot-fork-benchmarks.yml
+++ b/.github/workflows/snapshot-fork-benchmarks.yml
@@ -283,28 +283,4 @@ jobs:
             }
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json pnpm-lock.yaml snapshot_fork_*.svg results/snapshot-fork/
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update snapshot/fork benchmark results [skip ci]"
-
-          # Remote master can advance during the run (concurrent benchmark
-          # workflows push to master too), so a plain push fails non-fast-forward.
-          # Rebase onto the latest remote and retry a few times before giving up.
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            # Rebase before each attempt (including the last) so every rebase
-            # is followed by a push — otherwise the final iteration's rebase
-            # would be wasted and a resolvable non-fast-forward could still fail.
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
-          exit 1
+        run: benchmarks/scripts/commit-results.sh snapshot-fork-benchmarks 'package.json' 'pnpm-lock.yaml' 'snapshot_fork_*.svg' 'results/snapshot-fork/'

--- a/.github/workflows/snapshot-fork-benchmarks.yml
+++ b/.github/workflows/snapshot-fork-benchmarks.yml
@@ -284,3 +284,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh snapshot-fork-benchmarks 'package.json' 'pnpm-lock.yaml' 'snapshot_fork_*.svg' 'results/snapshot-fork/'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -260,28 +260,4 @@ jobs:
             }
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json pnpm-lock.yaml storage_*.svg results/storage/
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore: update storage benchmark results [skip ci]"
-
-          # Remote master can advance during the run (concurrent benchmark
-          # workflows push to master too), so a plain push fails non-fast-forward.
-          # Rebase onto the latest remote and retry a few times before giving up.
-          branch="${GITHUB_REF#refs/heads/}"
-          for attempt in 1 2 3 4 5; do
-            # Rebase before each attempt (including the last) so every rebase
-            # is followed by a push — otherwise the final iteration's rebase
-            # would be wasted and a resolvable non-fast-forward could still fail.
-            git fetch origin "${branch}"
-            git rebase --autostash "origin/${branch}" || { git rebase --abort; exit 1; }
-            if git push origin "HEAD:${branch}"; then
-              echo "Pushed on attempt ${attempt}"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}); will rebase and retry"
-          done
-          echo "Failed to push after multiple attempts" >&2
-          exit 1
+        run: benchmarks/scripts/commit-results.sh storage-benchmarks 'package.json' 'pnpm-lock.yaml' 'storage_*.svg' 'results/storage/'

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -261,3 +261,5 @@ jobs:
       - name: Commit and push
         if: github.event_name != 'push' && github.event.inputs.dry_run != 'true'
         run: benchmarks/scripts/commit-results.sh storage-benchmarks 'package.json' 'pnpm-lock.yaml' 'storage_*.svg' 'results/storage/'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/benchmarks/scripts/commit-results.sh
+++ b/benchmarks/scripts/commit-results.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Commit benchmark results to a temporary branch, open a pull request, and
+# merge it. This works around repository rulesets that require changes via
+# pull request while still landing results on the base branch automatically.
+#
+# Usage:
+#   benchmarks/scripts/commit-results.sh <workflow-slug> <path>...
+#
+# GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_REF, GITHUB_RUN_ID, and
+# GITHUB_RUN_ATTEMPT must be available in the environment.
+
+set -euo pipefail
+
+shopt -s nullglob
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <workflow-slug> <path>..." >&2
+  exit 1
+fi
+
+slug="$1"
+shift
+
+if [ -z "${GITHUB_TOKEN:-}" ] || [ -z "${GITHUB_REPOSITORY:-}" ] || [ -z "${GITHUB_REF:-}" ]; then
+  echo "GITHUB_TOKEN, GITHUB_REPOSITORY, and GITHUB_REF are required" >&2
+  exit 1
+fi
+
+base_branch="${GITHUB_REF#refs/heads/}"
+base_branch="${base_branch:-master}"
+run_id="${GITHUB_RUN_ID:-unknown}"
+run_attempt="${GITHUB_RUN_ATTEMPT:-1}"
+branch="bench-results/${slug}/${run_id}-${run_attempt}"
+title="chore: update benchmark results [skip ci]"
+body="Automated benchmark results from workflow \`${slug}\` (run ${run_id}, attempt ${run_attempt})."
+
+api_url="${GITHUB_API_URL:-https://api.github.com}"
+
+# Resolve files to add. Arguments may contain globs; nullglob ensures an
+# unmatched glob expands to nothing instead of a literal string.
+files=()
+for pattern in "$@"; do
+  # shellcheck disable=SC2086
+  for f in $pattern; do
+    files+=("$f")
+  done
+done
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "No files matched the provided patterns"
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+if ! git add "${files[@]}"; then
+  echo "Failed to stage files" >&2
+  exit 1
+fi
+
+if git diff --cached --quiet; then
+  echo "No changes to commit"
+  exit 0
+fi
+
+git checkout -b "$branch"
+git commit -m "$title"
+
+# Fetch the latest base before pushing to minimize the chance the PR branch
+# is behind. This handles the common stale checkout case.
+git fetch origin "$base_branch"
+git rebase "origin/$base_branch" || { git rebase --abort; exit 1; }
+
+if ! git push origin "$branch"; then
+  echo "Failed to push branch $branch" >&2
+  exit 1
+fi
+
+# Create pull request
+pr_resp=$(curl -sSL -X POST \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "$api_url/repos/$GITHUB_REPOSITORY/pulls" \
+  -d "$(jq -n \
+    --arg title "$title" \
+    --arg body "$body" \
+    --arg head "$branch" \
+    --arg base "$base_branch" \
+    '{title: $title, body: $body, head: $head, base: $base, maintainer_can_modify: false}')")
+
+pr_number=$(echo "$pr_resp" | jq -r '.number // empty')
+if [ -z "$pr_number" ]; then
+  echo "Failed to create pull request: $(echo "$pr_resp" | jq -r '.message // . // empty')" >&2
+  exit 1
+fi
+
+echo "Created pull request #$pr_number"
+
+# Merge the pull request, retrying if the branch is out of date.
+for attempt in 1 2 3 4 5; do
+  merge_resp=$(curl -sSL -X PUT \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$api_url/repos/$GITHUB_REPOSITORY/pulls/$pr_number/merge" \
+    -d "$(jq -n \
+      --arg title "$title" \
+      '{commit_title: $title, merge_method: "rebase"}')")
+
+  if [ "$(echo "$merge_resp" | jq -r '.merged // false')" = "true" ]; then
+    echo "Merged pull request #$pr_number"
+    exit 0
+  fi
+
+  msg=$(echo "$merge_resp" | jq -r '.message // empty')
+  echo "Merge attempt $attempt failed: $msg" >&2
+
+  # If the PR is behind the base, rebase and force-push the branch.
+  if echo "$msg" | grep -qiE "not mergeable|merge conflict|head was modified|required status check|update branch|ahead|behind"; then
+    git fetch origin "$base_branch"
+    if git rebase "origin/$base_branch"; then
+      if git push origin "$branch" --force-with-lease; then
+        echo "Rebased and force-pushed; retrying merge"
+        sleep 5
+        continue
+      fi
+    else
+      git rebase --abort || true
+    fi
+  fi
+
+  sleep 5
+done
+
+echo "Failed to merge pull request #$pr_number" >&2
+exit 1

--- a/benchmarks/scripts/commit-results.sh
+++ b/benchmarks/scripts/commit-results.sh
@@ -71,7 +71,7 @@ git commit -m "$title"
 # Fetch the latest base before pushing to minimize the chance the PR branch
 # is behind. This handles the common stale checkout case.
 git fetch origin "$base_branch"
-git rebase "origin/$base_branch" || { git rebase --abort; exit 1; }
+git rebase --autostash "origin/$base_branch" || { git rebase --abort; exit 1; }
 
 if ! git push origin "$branch"; then
   echo "Failed to push branch $branch" >&2
@@ -112,6 +112,7 @@ for attempt in 1 2 3 4 5; do
 
   if [ "$(echo "$merge_resp" | jq -r '.merged // false')" = "true" ]; then
     echo "Merged pull request #$pr_number"
+    git push origin --delete "$branch" || true
     exit 0
   fi
 
@@ -121,7 +122,7 @@ for attempt in 1 2 3 4 5; do
   # If the PR is behind the base, rebase and force-push the branch.
   if echo "$msg" | grep -qiE "not mergeable|merge conflict|head was modified|required status check|update branch|ahead|behind"; then
     git fetch origin "$base_branch"
-    if git rebase "origin/$base_branch"; then
+    if git rebase --autostash "origin/$base_branch"; then
       if git push origin "$branch" --force-with-lease; then
         echo "Rebased and force-pushed; retrying merge"
         sleep 5


### PR DESCRIPTION
## Summary

The `Collect Results` step in benchmark workflows was failing with `GH013: Changes must be made through a pull request` because the branch ruleset on `master` still requires a PR and `required_linear_history`. Direct `git push` no longer works.

This change introduces a shared helper, `benchmarks/scripts/commit-results.sh`, that the 19 result-committing workflows now call instead of an inline `git push`:

- Stages the supplied file patterns.
- Creates a temporary branch `bench-results/<workflow-slug>/<run-id>-<attempt>`.
- Opens a PR via the GitHub REST API.
- Merges it with `merge_method: rebase` to satisfy `required_linear_history`.
- Retries the rebase/merge loop if `master` advances while the PR is open.
- Deletes the temporary branch after a successful merge to avoid branch clutter.
- Uses `git rebase --autostash` so unstaged working-tree edits (e.g. from `pnpm update`) do not block the rebase.

Each calling workflow step passes `GITHUB_TOKEN` to the helper via an `env:` block, and the `pricing-svg.yml` workflow was also given `pull-requests: write` permission. No benchmark logic is changed; this only affects how generated result files land in the repo.

After this PR is merged, the next scheduled/dispatched benchmark run should successfully commit `results/`, SVGs, and lockfile updates.

Link to Devin session: https://app.devin.ai/sessions/b2915c0a696248fd813f92ddccb9fbfc
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->