### PR TITLE
fix(sandbox): make DAX disk metrics portable

### DIFF
--- a/benchmarks/scripts/dax-benchmark.sh
+++ b/benchmarks/scripts/dax-benchmark.sh
@@ -215,7 +215,7 @@ typecheck() {
 }
 
 disk() {
-  du -sx --block-size=1 "$ROOT" | awk '{print $1}'
+  du -skx "$ROOT" | awk '{print $1 * 1024}'
 }
 
 clear_caches() {


### PR DESCRIPTION
## Summary

- replace GNU-only `du --block-size=1` with `du -skx`
- convert KiB to bytes so the DAX result format stays unchanged

## Why

BusyBox `du` rejects `--block-size=1`. The benchmark continues, but its disk fields are missing.

## Verification

- `pnpm typecheck`
- `pnpm -r --if-present test` (184 passed, 1 skipped)
- `actionlint -ignore 'string should not be empty' -shellcheck=`
- `bash -n benchmarks/scripts/dax-benchmark.sh`
- ShellCheck on the changed script, excluding the two unchanged warnings already on `master`
- real Blaxel DAX run with this fix and #272: 7/7 phases, three populated disk values, zero cleanup residue