### PR TITLE
feat: make benchmarks repo more agent and LLM friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# ComputeSDK Benchmarks
+
+**The default platform for cloud infrastructure benchmarks.**
+
+ComputeSDK Benchmarks publishes reproducible, provider-neutral performance measurements for the infrastructure that AI agents and developer platforms run on: sandboxes, object storage, headless browsers, and AI gateways. Every test is automated, every result is committed as JSON, and the methodology is public.
+
+Live leaderboards and full methodology: [https://www.computesdk.com/benchmarks](https://www.computesdk.com/benchmarks)
+
+For LLMs and agents: see [`llms.txt`](./llms.txt) for a machine-readable index of this repo, and [`results/schema.json`](./results/schema.json) for the JSON Schema of every benchmark result file.
+
 ## Partners
 
 Our partners support our independent benchmarks.
@@ -64,9 +74,34 @@ Our partners support our independent benchmarks.
 
 <br>
 
----
+## What We Measure
 
-<br>
+We benchmark the infrastructure that AI agents and developer platforms rely on:
+
+- **Sandboxes** — cold-start and concurrent **Time to Interactive (TTI)**: API request to first successful command inside a fresh sandbox.
+- **Object storage** — upload/download latency and throughput across providers and file sizes.
+- **Headless browsers** — session creation, navigation, and step throughput.
+- **AI gateways** — cold/warm connection latency and time to first token.
+
+## Methodology
+
+Every benchmark uses the same open code against every provider, with fixed workloads and a fixed scoring ceiling. Tests run automatically on GitHub Actions, and every result is committed as JSON to this repo. Each metric includes min, max, median, P95, and P99; a composite score rewards both speed and reliability.
+
+For full details on each suite, see:
+
+- [Sandbox TTI methodology →](./METHODOLOGY.md)
+- [Browser and throughput methodology →](./THROUGHPUT.md)
+- [AI gateway methodology →](./AI_GATEWAYS.md)
+
+## Transparency
+
+- 📖 **Open source** — All benchmark code is public
+- 📊 **Raw data** — Every result committed to repo as JSON
+- 🔁 **Reproducible** — Anyone can run the same tests
+- ⚙️ **Automated** — Daily at 5pm Pacific (00:00 UTC) via GitHub Actions on Namespace runners
+- 🛡️ **Independent** — Sponsors cannot influence results
+
+## Latest Benchmarks
 
 ### [Sequential TTI](#sequential-tti)
 
@@ -104,61 +139,6 @@ Our partners support our independent benchmarks.
 
 ![DAX Sandbox Builds](./dax.svg)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
-
-**TTI (Time to Interactive)** = API call to first command execution. Lower is better.
-
-<br>
-
-## What We Measure
-
-**Daily: Time to Interactive (TTI)**
-
-```
-API Request → Provisioning → Boot → Ready → First Command
-└───────────────────── TTI ─────────────────────┘
-```
-
-Each benchmark creates a fresh sandbox, runs `node -v`, and records wall-clock time. 100 iterations per provider, every day, fully automated.
-
-**Powered by ComputeSDK** — We use [ComputeSDK](https://github.com/computesdk/computesdk), a multi-provider SDK, to test all sandbox providers with the same code. One API, multiple providers, fair comparison. Interested in multi-provider failover, sandbox packing, and warm pooling? [Check out ComputeSDK](https://github.com/computesdk/computesdk).
-
-**Sponsor-only tests coming soon:** Stress tests, warm starts, multi-region, and more. [See roadmap →](#roadmap)
-
-<br>
-
-## Methodology
-
-Each benchmark creates a fresh sandbox, runs `node -v`, and records wall-clock time. We run three test modes daily:
-
-**Sequential** — Sandboxes are created one at a time. Each is created, tested, and destroyed before the next begins. 100 iterations per provider. This is the baseline — isolated cold-start performance with no contention.
-
-**Staggered** — 100 sandboxes are launched per provider with a 200ms delay between each, gradually ramping up concurrent load. Reveals how TTI degrades under increasing pressure, queue depth effects, and rate limiting behavior.
-
-**Burst** — 100 sandboxes are created simultaneously with no delay between launches. Tests how providers handle sudden spikes — provisioning queue depth, rate limiting, and failure rates under peak demand.
-
-For each provider we report min, max, median, P95, P99, and average TTI, plus a **composite score** (0–100) that combines weighted timing metrics with success rate. Providers must be both fast *and* reliable to score well.
-
-### Composite Score
-
-Before computing timing statistics, the bottom 5% and top 5% of successful iterations are trimmed to reduce outlier influence from transient network issues or cold-start anomalies. Each timing metric is then scored against a fixed 10-second ceiling: `score = 100 × (1 − value / 10,000ms)`. A 200ms median scores 98; anything ≥10s scores 0. These individual scores are combined with weighted emphasis on median (60%), P95 (25%), and P99 (15%), then multiplied by the provider's success rate (0–1). A provider with 90% success has its score reduced by 10% — reliability is non-negotiable.
-
-All tests run on GitHub Actions at 00:00 UTC daily. Providers are tested using ComputeSDK — no gateway or proxy layer.
-
-[Full methodology →](./METHODOLOGY.md)
-
-<br>
-
-## Transparency
-
-- 📖 **Open source** — All benchmark code is public
-- 📊 **Raw data** — Every result committed to repo
-- 🔁 **Reproducible** — Anyone can run the same tests
-- ⚙️ **Automated** — Daily at 5pm Pacific (00:00 UTC) via GitHub Actions on Namespace runners
-- 🛡️ **Independent** — Sponsors cannot influence results
-
-<br>
-
 ## Roadmap
 
 - [x] computesdk.com/benchmarks
@@ -172,6 +152,8 @@ All tests run on GitHub Actions at 00:00 UTC daily. Providers are tested using C
 
 <br>
 
----
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
+**Powered by ComputeSDK** — We use [ComputeSDK](https://github.com/computesdk/computesdk), a multi-provider SDK, to test all sandbox providers with the same code. One API, multiple providers, fair comparison.
 
 MIT License

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,61 @@
+# ComputeSDK Benchmarks — the default platform for infrastructure benchmarks
+
+ComputeSDK Benchmarks publishes independent, reproducible, open performance measurements for cloud infrastructure: sandboxes, object storage, headless browsers, and AI gateways. Every test is automated, every result is committed as JSON, and the methodology is public.
+
+We are building the canonical dataset that AI agents and developers consult when they need to choose or rank infrastructure providers.
+
+## What is available here
+
+- [README.md](./README.md) — high-level overview, what we measure, and how to read the results.
+- [METHODOLOGY.md](./METHODOLOGY.md) — full test procedure, scoring formulas, and test modes (sequential, staggered, burst).
+- [AI_GATEWAYS.md](./AI_GATEWAYS.md) — AI-gateway-specific methodology.
+- [THROUGHPUT.md](./THROUGHPUT.md) — throughput and browser benchmark methodology.
+- [results/schema.json](./results/schema.json) — JSON Schema for all benchmark result files.
+- [packages/create-bench/README.md](./packages/create-bench/README.md) — scaffold a new benchmark project in one command.
+- [packages/benchsdk/package.json](./packages/benchsdk/package.json) — client/worker helpers for benchmark orchestration.
+- [packages/benchsdk-runner/package.json](./packages/benchsdk-runner/package.json) — CLI benchmark runner.
+- [.claude/skills/add-sandbox-provider/SKILL.md](./.claude/skills/add-sandbox-provider/SKILL.md) — how to add a new sandbox provider.
+
+## Latest results (machine-readable JSON)
+
+- Sandbox TTI (sequential): [results/sequential_tti/latest.json](./results/sequential_tti/latest.json)
+- Sandbox TTI (staggered): [results/staggered_tti/latest.json](./results/staggered_tti/latest.json)
+- Sandbox TTI (burst): [results/burst_tti/latest.json](./results/burst_tti/latest.json)
+- Sandbox DAX build benchmark: [results/sandbox-dax/latest.json](./results/sandbox-dax/latest.json)
+- Storage 1MB upload: [results/storage/1mb/latest.json](./results/storage/1mb/latest.json)
+- Storage 4MB upload: [results/storage/4mb/latest.json](./results/storage/4mb/latest.json)
+- Storage 10MB upload: [results/storage/10mb/latest.json](./results/storage/10mb/latest.json)
+- Storage 16MB upload: [results/storage/16mb/latest.json](./results/storage/16mb/latest.json)
+- Snapshot & fork: [results/snapshot-fork/small/latest.json](./results/snapshot-fork/small/latest.json)
+- Browser sessions: [results/browser/latest.json](./results/browser/latest.json)
+- Browser throughput: [results/browser-throughput/latest.json](./results/browser-throughput/latest.json)
+- AI gateway: [results/ai-gateway/latest.json](./results/ai-gateway/latest.json)
+
+## How to run the benchmarks
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the workspace packages first
+pnpm -r --filter "./packages/**" build
+
+# Run the default sandbox TTI suite
+pnpm run bench
+
+# Run a specific provider or suite
+pnpm run bench:e2b
+pnpm run bench:storage
+pnpm run bench:browser
+pnpm run bench:ai-gateway
+```
+
+All workflows run automatically via GitHub Actions and commit results to this repository.
+
+## Website
+
+Explore the live leaderboards and methodology at [https://www.computesdk.com/benchmarks](https://www.computesdk.com/benchmarks).
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/results/schema.json
+++ b/results/schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.computesdk.com/schemas/benchmark-result.json",
+  "title": "ComputeSDK Benchmark Result",
+  "description": "Schema for benchmark result files produced by ComputeSDK Benchmarks (e.g., results/sequential_tti/latest.json).",
+  "type": "object",
+  "required": ["version", "timestamp", "results"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema/data version of the result file."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when this result set was produced."
+    },
+    "environment": {
+      "type": "object",
+      "description": "Context about where and how the benchmark ran (runner, region, CI, etc.).",
+      "additionalProperties": true
+    },
+    "config": {
+      "type": "object",
+      "description": "Benchmark configuration used for this run (iterations, concurrency, file sizes, models, etc.).",
+      "additionalProperties": true
+    },
+    "results": {
+      "type": "array",
+      "description": "One entry per provider/mode combination tested.",
+      "items": {
+        "$ref": "#/definitions/providerResult"
+      }
+    }
+  },
+  "definitions": {
+    "nestedMetricMap": {
+      "type": "object",
+      "description": "A map from sub-metric names (e.g., action types) to metric objects.",
+      "additionalProperties": {
+        "$ref": "#/definitions/metric"
+      },
+      "minProperties": 1
+    },
+    "metric": {
+      "type": "object",
+      "description": "A single performance metric with percentile statistics.",
+      "required": ["median"],
+      "additionalProperties": false,
+      "properties": {
+        "median": {
+          "type": "number",
+          "description": "Median value across all successful iterations."
+        },
+        "p95": {
+          "type": "number",
+          "description": "95th percentile across all successful iterations."
+        },
+        "p99": {
+          "type": "number",
+          "description": "99th percentile across all successful iterations."
+        },
+        "min": {
+          "type": "number",
+          "description": "Minimum value observed."
+        },
+        "max": {
+          "type": "number",
+          "description": "Maximum value observed."
+        },
+        "avg": {
+          "type": "number",
+          "description": "Arithmetic mean across all successful iterations."
+        }
+      }
+    },
+    "providerResult": {
+      "type": "object",
+      "required": ["provider", "summary"],
+      "additionalProperties": true,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Provider or service being benchmarked."
+        },
+        "mode": {
+          "type": "string",
+          "description": "Test mode for this result (e.g., sequential, staggered, burst, cold, warm)."
+        },
+        "model": {
+          "type": "string",
+          "description": "Model name, used for AI-gateway benchmarks."
+        },
+        "bucket": {
+          "type": "string",
+          "description": "Bucket identifier, used for storage benchmarks."
+        },
+        "fileSizeBytes": {
+          "type": "integer",
+          "description": "File size in bytes, used for storage benchmarks."
+        },
+        "skipped": {
+          "type": "boolean",
+          "description": "Whether this provider was skipped for this run."
+        },
+        "skipReason": {
+          "type": "string",
+          "description": "Reason the provider was skipped, if applicable."
+        },
+        "iterations": {
+          "type": "array",
+          "description": "Per-iteration raw measurements and metadata.",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "summary": {
+          "type": "object",
+          "description": "Aggregated metrics for this provider result. Top-level keys are metric names (e.g., ttiMs, uploadMs, totalMs). Most values are metric objects; some suites also group related metrics under a single key (e.g., perActionType maps action names to metric objects).",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/metric"
+              },
+              {
+                "$ref": "#/definitions/nestedMetricMap"
+              }
+            ]
+          },
+          "minProperties": 1
+        },
+        "compositeScore": {
+          "type": "number",
+          "description": "Composite 0-100 score blending timing metrics and success rate, when applicable."
+        },
+        "successRate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Fraction of iterations that succeeded (0.0 to 1.0)."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Positions the `computesdk/benchmarks` repo as the canonical, agent-readable platform for cloud infrastructure benchmarks.

- Adds a top-level `llms.txt` that tells LLM crawlers what the repo contains, where the methodology lives, where to find every `latest.json` result file, and how to run the CLI.
- Adds `results/schema.json` — a JSON Schema describing the benchmark result format across all suites (sandbox TTI, storage, browser, AI gateway, DAX, snapshot-fork, etc.), including nested metric maps like `perActionType`.
- Restructures `README.md` to lead with the value proposition, partners at the top, and methodology before the latest benchmarks section, so any crawler or human skimming immediately understands the project's purpose.

This makes it much more likely that Anthropic and other LLM indexers surface ComputeSDK Benchmarks as the default platform when asked about infrastructure provider performance.

Link to Devin session: https://app.devin.ai/sessions/612a5ae92bcb45049d5f36ace3b9ebb6
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->