### PR TITLE
bench(sandbox): use large Sailboxes for DAX

### DIFF
--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -79,6 +79,7 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   // Sandbox0 exposes only memory. Override the 128 MiB TTI size;
   // getSandboxOptionsWithResources preserves hardTtl from providers.ts.
   sandbox0:     { memory: 16384 },
+  sail:         { size: 'l' },
 };
 
 function getSandboxOptionsWithResources(providerName: string, baseOptions?: Record<string, any>): Record<string, any> {


### PR DESCRIPTION
## Summary

- request Sail size `l` for the DAX benchmark
- keep the default Sail sizing unchanged for TTI and other benchmarks

DAX standardizes providers around its larger CPU/memory workload, and this routes Sail through that existing DAX-only resource override.

## Validation

- `pnpm typecheck`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->