### PR TITLE
ci: restore Namespace runners for storage workflow

### DIFF
--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -44,14 +44,11 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   bench:
     name: Bench ${{ matrix.provider }} ${{ matrix.file_size }}
-    runs-on: ubuntu-latest
-    # Namespace runner with vault permissions:
-    # runs-on: namespace-profile-default;permissions.additional_grant=vault/object:*:list;permissions.additional_grant=vault/object:*:describe
+    runs-on: namespace-profile-default;permissions.additional_grant=vault/object:*:list;permissions.additional_grant=vault/object:*:describe
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -74,7 +71,6 @@ jobs:
         with:
           node-version: 24
           cache: 'pnpm'
-      - uses: namespacelabs/nscloud-setup@v0
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
@@ -110,9 +106,7 @@ jobs:
 
   collect:
     name: Collect Results
-    runs-on: ubuntu-latest
-    # Namespace runner with vault permissions:
-    # runs-on: namespace-profile-default;permissions.additional_grant=vault/object:*:list;permissions.additional_grant=vault/object:*:describe
+    runs-on: namespace-profile-default;permissions.additional_grant=vault/object:*:list;permissions.additional_grant=vault/object:*:describe
     needs: [bench]
     if: always()
     steps:
@@ -127,7 +121,6 @@ jobs:
         with:
           node-version: 24
           cache: 'pnpm'
-      - uses: namespacelabs/nscloud-setup@v0
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then


### PR DESCRIPTION
## Summary\n- restore the storage benchmark and collection jobs to Namespace runners\n- remove the temporary GitHub OIDC setup used for testing\n\nThis restores the workflow configuration used before the OIDC test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/computesdk/codesmith/benchmarks/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788971198&installation_model_id=431880&pr_number=293&repository=computesdk%2Fbenchmarks&return_to=https%3A%2F%2Fgithub.com%2Fcomputesdk%2Fbenchmarks%2Fpull%2F293&signature=57d30e7bf32fbe963ac6d49ff394afd9e48cae0079bda55239b9614538006b97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->