### PR TITLE
fix(benchsdk): auto-capture participant-mode step logs

### DIFF
--- a/packages/benchsdk/src/__tests__/client.test.ts
+++ b/packages/benchsdk/src/__tests__/client.test.ts
@@ -225,8 +225,9 @@ describe('createBenchmarkClient', () => {
     expect((eventCalls[1].body as any).records).toHaveLength(1);
     expect(eventCalls.map((entry) => (entry.body as any).sequenceNumber)).toEqual([0, 1]);
     expect(eventCalls.map((entry) => (entry.body as any).isFinal)).toEqual([false, true]);
-    expect(seen.at(-1)).toMatchObject({ method: 'POST' });
-    expect(seen.at(-1)?.url).toContain('/complete');
+    const completeCall = seen.find((entry) => entry.url.includes('/complete'));
+    expect(completeCall).toBeDefined();
+    expect(completeCall).toMatchObject({ method: 'POST' });
   });
 
   it('uses 1000 task results as the default worker batch size', async () => {
@@ -370,8 +371,9 @@ describe('createBenchmarkClient', () => {
       errorMessage: 'boom',
     });
     expect(result.records[0].steps).toMatchObject([{ name: 'create', status: 'error', errorCode: 'TypeError' }]);
-    expect(seen.at(-1)?.url).toContain('/fail');
-    expect(seen.at(-1)?.body).toMatchObject({ errorMessage: 'One or more tasks failed' });
+    const failCall = seen.find((entry) => entry.url.includes('/fail'));
+    expect(failCall?.url).toContain('/fail');
+    expect(failCall?.body).toMatchObject({ errorMessage: 'One or more tasks failed' });
   });
 
   it('runs a worker task with ordered steps', async () => {
@@ -508,6 +510,39 @@ describe('createBenchmarkClient', () => {
     const upload = seen.find((entry) => entry.url === 'https://upload.test');
     expect(upload?.method).toBe('PUT');
     expect(String((upload as any)?.body)).toContain('uploading {"n":1}');
+  });
+
+  it('uploads a worker log artifact with step entries even when the task never calls ctx.log', async () => {
+    const seen: Array<{ url: string; body: unknown; method?: string }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const body = init?.body && url.startsWith('https://platform.test/') ? JSON.parse(String(init.body)) : init?.body;
+      seen.push({ url, body, method: init?.method });
+      if (url.endsWith('/participants/e2b/workers/claim')) return jsonResponse({ assignment: assignment({ taskRange: { start: 0, end: 0, count: 1 } }) });
+      if (url.endsWith('/events')) return jsonResponse({ eventBatch: { id: 'batch_1' } }, 202);
+      if (url.endsWith('/workers/00000000-0000-4000-8000-000000000002/artifacts')) return jsonResponse({ artifactId: 'artifact_1', uploadUrl: 'https://upload.test' });
+      if (url === 'https://upload.test') return new Response(null, { status: 200 });
+      if (url.endsWith('/complete')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const client = createBenchmarkClient({ baseUrl: 'https://platform.test/api/v1', fetch: fetchMock as typeof fetch });
+    await client.runWorker({
+      benchmarkSlug: 'scale',
+      runId: '00000000-0000-4000-8000-000000000001',
+      participantSlug: 'e2b',
+      task: async ({ step }) => {
+        await step('create', () => undefined, { readiness: 'internal' });
+      },
+    });
+
+    const artifactPost = seen.find((entry) => entry.url.endsWith('/artifacts'));
+    expect(artifactPost?.body).toMatchObject({ kind: 'coordinator.log', name: 'worker.log', contentType: 'text/plain' });
+    const upload = seen.find((entry) => entry.url === 'https://upload.test');
+    expect(upload?.method).toBe('PUT');
+    const logBody = String((upload as any)?.body);
+    expect(logBody.length).toBeGreaterThan(0);
+    expect(logBody).toContain('[task 0] create');
   });
 
   it('waits for platform step readiness before running a step body', async () => {

--- a/packages/benchsdk/src/__tests__/public-api.contract.test.ts
+++ b/packages/benchsdk/src/__tests__/public-api.contract.test.ts
@@ -964,7 +964,7 @@ describe('runWorker lifecycle and task execution', () => {
     for (let i = 1; i < samples.length; i++) {
       expect(samples[i - 1].active).toBeGreaterThanOrEqual(samples[i].active);
     }
-    expect(calls.at(-1)!.url).toContain('/complete');
+    expect(calls.some((c) => c.url.includes('/complete'))).toBe(true);
   });
 
   it('VAL-SDK-055: fails the worker when any task fails', async () => {
@@ -975,8 +975,10 @@ describe('runWorker lifecycle and task execution', () => {
       task: async ({ step }) => { await step('create', () => { throw new TypeError('boom'); }, { readiness: 'internal' }); },
     });
     expect(result.records[0]).toMatchObject({ status: 'error', errorCode: 'TypeError' });
-    expect(calls.at(-1)!.url).toContain('/fail');
-    expect(calls.at(-1)!.body).toMatchObject({ errorMessage: 'One or more tasks failed' });
+    const failCall = calls.find((c) => c.url.includes('/fail'));
+    expect(failCall).toBeDefined();
+    expect(failCall!.url).toContain('/fail');
+    expect(failCall!.body).toMatchObject({ errorMessage: 'One or more tasks failed' });
   });
 
   it('VAL-SDK-056: completes the worker when all tasks succeed', async () => {

--- a/packages/benchsdk/src/client.ts
+++ b/packages/benchsdk/src/client.ts
@@ -623,8 +623,8 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
       }, options.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS);
       resultFlush.unref?.();
 
-      // Accumulated across the worker's tasks via `ctx.log`, uploaded once as a
-      // worker log artifact when the worker finishes.
+      // Accumulated across the worker's tasks via `ctx.step` and `ctx.log`,
+      // uploaded once as a worker log artifact when the worker finishes.
       const workerLogLines: string[] = [];
 
       async function runFinishHook(status: 'success' | 'error'): Promise<void> {
@@ -713,10 +713,14 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
               if (stepOptions.readiness === 'poll') {
                 await waitForStepReady(name, stepOptions);
               }
-              return await fn();
+              const value = await fn();
+              workerLogLines.push(`${new Date().toISOString()} [task ${taskIndex}] ${name}`);
+              return value;
             } catch (error) {
               stepRecord.status = 'error';
               stepRecord.errorCode = getErrorCode(error);
+              workerLogLines.push(`${new Date().toISOString()} [task ${taskIndex}] ${name}`);
+              workerLogLines.push(`  error: ${error instanceof Error ? error.message : String(error)}`);
               throw error;
             } finally {
               activeStep = previousStep;

--- a/packages/benchsdk/src/client.ts
+++ b/packages/benchsdk/src/client.ts
@@ -49,6 +49,7 @@ const DEFAULT_READY_POLL_INTERVAL_MS = 1000;
 const MAX_TASK_RESULT_RECORDS = 5000;
 const MAX_TASK_RECORD_STEPS = 100;
 const MAX_HEARTBEAT_CONCURRENCY_SAMPLES = 20;
+const MAX_WORKER_LOG_LINES = 100_000;
 
 export class BenchmarkApiError extends Error {
   constructor(
@@ -626,6 +627,17 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
       // Accumulated across the worker's tasks via `ctx.step` and `ctx.log`,
       // uploaded once as a worker log artifact when the worker finishes.
       const workerLogLines: string[] = [];
+      let workerLogTruncated = false;
+      function appendWorkerLog(line: string): void {
+        if (workerLogLines.length >= MAX_WORKER_LOG_LINES) {
+          if (!workerLogTruncated) {
+            workerLogTruncated = true;
+            workerLogLines.push('... (worker log truncated)');
+          }
+          return;
+        }
+        workerLogLines.push(line);
+      }
 
       async function runFinishHook(status: 'success' | 'error'): Promise<void> {
         await options.onFinish?.({
@@ -685,7 +697,7 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
 
           function log(message: string, meta?: JsonObject): void {
             const suffix = meta && Object.keys(meta).length > 0 ? ` ${JSON.stringify(meta)}` : '';
-            workerLogLines.push(`${new Date().toISOString()} [task ${taskIndex}] ${message}${suffix}`);
+            appendWorkerLog(`${new Date().toISOString()} [task ${taskIndex}] ${message}${suffix}`);
           }
 
           async function step<T>(name: string, fn: () => Promise<T> | T, stepOptions: DefineStepOptions = {}): Promise<T> {
@@ -714,13 +726,13 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
                 await waitForStepReady(name, stepOptions);
               }
               const value = await fn();
-              workerLogLines.push(`${new Date().toISOString()} [task ${taskIndex}] ${name}`);
+              appendWorkerLog(`${new Date().toISOString()} [task ${taskIndex}] ${name}`);
               return value;
             } catch (error) {
               stepRecord.status = 'error';
               stepRecord.errorCode = getErrorCode(error);
-              workerLogLines.push(`${new Date().toISOString()} [task ${taskIndex}] ${name}`);
-              workerLogLines.push(`  error: ${error instanceof Error ? error.message : String(error)}`);
+              appendWorkerLog(`${new Date().toISOString()} [task ${taskIndex}] ${name}`);
+              appendWorkerLog(`  error: ${error instanceof Error ? error.message : String(error)}`);
               throw error;
             } finally {
               activeStep = previousStep;


### PR DESCRIPTION
## Summary

Participant mode in `client.runWorker` now records a log line for every `ctx.step()` call, so benchmark tasks no longer need to explicitly call `ctx.log()` to produce a `coordinator.log` artifact. This matches the behavior of round mode, which uses `LogBuffer.step()` in `@benchsdk/runner`.

### What changed

- In `packages/benchsdk/src/client.ts`, `step()` now appends into `workerLogLines`:
  - On success: `2026-08-11T...Z [task {taskIndex}] {stepName}`
  - On failure: the same header plus `  error: {message}`
- The explicit `ctx.log()` path is unchanged.
- `uploadWorkerLogArtifact()` still wraps upload errors and never fails the run.
- To prevent unbounded memory growth on high-volume workers, `workerLogLines` is capped at `MAX_WORKER_LOG_LINES` (100,000). Once the cap is reached, a single `... (worker log truncated)` marker is appended and further lines are dropped.

### Test updates

- Added `client.test.ts` coverage that runs a participant-mode task with `step()` and no `log()` calls, then asserts the uploaded `coordinator.log` body is non-empty and contains `[task 0] create`.
- Updated two `client.test.ts` and two `public-api.contract.test.ts` assertions that previously assumed `/complete` or `/fail` was the final HTTP call. Those tests now locate the lifecycle call explicitly, since the best-effort log upload can follow it.

### Not changed

- Round mode / `LogBuffer` is untouched.
- Artifact `kind` (`coordinator.log`) and `contentType` (`text/plain`) are unchanged.
- No new config flags; this is the default participant-mode behavior.

Link to Devin session: https://app.devin.ai/sessions/857327fbf92b4694b9024a9649359fcd
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/computesdk/codesmith/benchmarks/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788999334&installation_model_id=431880&pr_number=296&repository=computesdk%2Fbenchmarks&return_to=https%3A%2F%2Fgithub.com%2Fcomputesdk%2Fbenchmarks%2Fpull%2F296&signature=4c695f0092376c8dba2cb21a3bf0d2e5550d6d1667156048ff9ea83555a20229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->