### PR TITLE
fix(ai-gateway): measure tokens/sec over full request wall-clock time

### DIFF
--- a/AI_GATEWAYS.md
+++ b/AI_GATEWAYS.md
@@ -19,7 +19,7 @@ For each gateway, every probe request is one of two kinds:
 
 Every probe (cold or warm) also records:
 
-- **Output tokens generated** and **tokens/sec** (generation throughput after the first token)
+- **Output tokens generated** and **tokens/sec** (output tokens divided by the full wall-clock time from request start to stream end, so buffering/batching cannot inflate the rate)
 - **Success/error** — any non-2xx response, a timeout, or a completed stream with zero content tokens observed counts as a failure for that iteration
 - **Receipt headers** (`x-vercel-id`, `cf-ray`, `x-request-id`, `anthropic-request-id`, etc.) captured from the response, for tracing a specific measured request back to the provider's own logs if a number is disputed
 

--- a/benchmarks/ai-gateway/phase-probe.ts
+++ b/benchmarks/ai-gateway/phase-probe.ts
@@ -161,8 +161,13 @@ function sendAndMeasure(
 
 function tokensPerSecond(outcome: RawProbeOutcome): number | undefined {
   if (!outcome.outputTokens || outcome.outputTokens <= 0) return undefined;
-  const generationMs = Math.max(outcome.totalMs - outcome.ttftMs, 1);
-  return outcome.outputTokens / (generationMs / 1000);
+  // Measure throughput over the full wall-clock time from request start to
+  // stream end, including TTFT. Using only the window from the first token to
+  // the last token would let a gateway buffer the whole response and emit it
+  // in a single burst, inflating this number while the user still waits the
+  // full generation time.
+  const elapsedMs = Math.max(outcome.totalMs, 1);
+  return outcome.outputTokens / (elapsedMs / 1000);
 }
 
 /**

--- a/benchmarks/ai-gateway/types.ts
+++ b/benchmarks/ai-gateway/types.ts
@@ -63,6 +63,7 @@ export interface PhaseProbeResult {
   /** dns + tcp + tls + ttft: what a short-lived process pays end to end. Cold only. */
   coldE2eMs?: number;
   outputTokens?: number;
+  /** Output tokens per second over the full request wall-clock time (request start -> stream end). */
   outputTokensPerSec?: number;
   /**
    * Upstream provider that actually served this request, when the gateway's


### PR DESCRIPTION
## Summary

The AI gateway benchmark was computing `outputTokensPerSec` as:

```ts
outputTokens / ((streamEndMs - firstTokenMs) / 1000)
```

That window excludes the time spent waiting for the first token, so a gateway can game it by buffering the entire upstream response and emitting all SSE events in one burst. The resulting `tokens/sec` looks fast even though the caller waited the full generation time.

This change measures throughput over the full wall-clock time from request start to stream end:

```ts
outputTokens / (totalMs / 1000)
```

Now `TTFT` is included in the throughput denominator, so batching/buffering no longer inflates the score. This matches the intent of the 10% throughput weight in `computeAIGatewayScore`.

Updated `AI_GATEWAYS.md` and the `outputTokensPerSec` type comment to reflect the new definition.

`pnpm typecheck` and the `@benchsdk/client` / `@benchsdk/runner` test suites pass.

Link to Devin session: https://app.devin.ai/sessions/b30adcaa7bbb49c1bff70eaff6fa6bbd
Requested by: @dtice25

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/computesdk/codesmith/benchmarks/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789054942&installation_model_id=431880&pr_number=299&repository=computesdk%2Fbenchmarks&return_to=https%3A%2F%2Fgithub.com%2Fcomputesdk%2Fbenchmarks%2Fpull%2F299&signature=0e496cf0848d93ba8ecfee494ae1e1d000302acd591b3e73a76dff060022936e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->