### PR TITLE
fix(ci): scope browser concurrency run key to concurrency level

### DIFF
--- a/.github/workflows/browser-concurrent-benchmarks.yml
+++ b/.github/workflows/browser-concurrent-benchmarks.yml
@@ -117,7 +117,11 @@ jobs:
         run: |
           . benchmarks/scripts/load-vault-secrets.sh '^(BROWSERBASE_API_KEY|BROWSERBASE_PROJECT_ID|BROWSER_USE_API_KEY|HYPERBROWSER_API_KEY|KERNEL_API_KEY|NOTTE_API_KEY|STEEL_API_KEY|TILION_API_KEY|TILION_BASE_URL|COMPUTESDK_ADMIN_API_KEY|BENCHMARKS_PLATFORM_API_KEY)'
 
-          RUN_KEY="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          # Matrix jobs at the same concurrency level share one platform run.
+          # The benchmark slug is level-independent, so the level is part of
+          # the key; otherwise a provider would register once per level in the
+          # same run and the platform rejects the duplicate with 409 Conflict.
+          RUN_KEY="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-c${{ matrix.concurrency_level }}"
           # On push (smoke test) use 3 iterations regardless of concurrency
           # level; on schedule/workflow_dispatch use the full matrix value.
           ITERS=${{ github.event_name == 'push' && '3' || matrix.iterations }}


### PR DESCRIPTION
## Problem

The Browser Concurrency Benchmark fails immediately with `409 Conflict` from the benchmarks platform:

```
Participant: browseruse
Benchmark failed: Benchmark API request failed: 409 Conflict
```

All 35 matrix jobs (7 providers x 5 concurrency levels) share one run key:

```
RUN_KEY="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
```

The benchmark slug (`browser-concurrent-local`) is level-independent, so every job joins the same platform run. Within that run each provider appears five times, once per concurrency level, and the second registration of a given provider is rejected as a duplicate participant.

## Fix

Put the concurrency level in the run key:

```
RUN_KEY="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-c${{ matrix.concurrency_level }}"
```

This produces five platform runs of seven participants each instead of one run with 35 conflicting registrations, which also groups the leaderboard per level the way the SVG generator reads results.

This is the same rule `storage-benchmarks.yml` already applies for its second dimension, where the run key includes the file size for exactly this reason.

## Notes

The identical change is also present on `add-browser-concurrency-bench` (the benchmark code branch), so the two will not conflict. This PR lands the fix on master ahead of that branch so scheduled and push-triggered runs stop failing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/computesdk/codesmith/benchmarks/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789068922&installation_model_id=431880&pr_number=301&repository=computesdk%2Fbenchmarks&return_to=https%3A%2F%2Fgithub.com%2Fcomputesdk%2Fbenchmarks%2Fpull%2F301&signature=f116ab36572bbad5e6a805bf0b3995fafeebdf9afb6f7c41b58b69b17324c9a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->