### PR TITLE
ci: run browser concurrency levels sequentially per provider

### DIFF
--- a/.github/workflows/browser-concurrent-benchmarks.yml
+++ b/.github/workflows/browser-concurrent-benchmarks.yml
@@ -68,16 +68,18 @@ jobs:
           echo "Resolved ${#urls[@]} shared article URLs for all providers"
 
   bench:
-    name: Bench ${{ matrix.provider }} at c${{ matrix.concurrency_level }}
+    name: Bench ${{ matrix.provider }}
     runs-on: namespace-profile-default;permissions.additional_grant=vault/object:*:list;permissions.additional_grant=vault/object:*:describe
     permissions:
       contents: read
       id-token: write
     needs: setup
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
+        # Only the provider is a matrix dimension. Concurrency levels run
+        # sequentially inside the job, see the benchmark step for why.
         provider:
           - browserbase
           - browseruse
@@ -86,19 +88,6 @@ jobs:
           - notte
           - steel
           - tilion
-        concurrency_level: [1, 5, 10, 25, 50]
-        include:
-          # Scale iterations inversely with concurrency so total sessions ≈ 50 per level
-          - concurrency_level: 1
-            iterations: 50
-          - concurrency_level: 5
-            iterations: 10
-          - concurrency_level: 10
-            iterations: 5
-          - concurrency_level: 25
-            iterations: 2
-          - concurrency_level: 50
-            iterations: 1
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -117,24 +106,66 @@ jobs:
         run: |
           . benchmarks/scripts/load-vault-secrets.sh '^(BROWSERBASE_API_KEY|BROWSERBASE_PROJECT_ID|BROWSER_USE_API_KEY|HYPERBROWSER_API_KEY|KERNEL_API_KEY|NOTTE_API_KEY|STEEL_API_KEY|TILION_API_KEY|TILION_BASE_URL|COMPUTESDK_ADMIN_API_KEY|BENCHMARKS_PLATFORM_API_KEY)'
 
-          # Matrix jobs at the same concurrency level share one platform run.
-          # The benchmark slug is level-independent, so the level is part of
-          # the key; otherwise a provider would register once per level in the
-          # same run and the platform rejects the duplicate with 409 Conflict.
-          RUN_KEY="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-c${{ matrix.concurrency_level }}"
-          # On push (smoke test) use 3 iterations regardless of concurrency
-          # level; on schedule/workflow_dispatch use the full matrix value.
-          ITERS=${{ github.event_name == 'push' && '3' || matrix.iterations }}
-          npx tsx packages/benchsdk-runner/dist/bin.js run benchmarks/browser/browser-concurrent.bench.ts \
-            --provider ${{ matrix.provider }} \
-            --concurrency-level ${{ matrix.concurrency_level }} \
-            --iterations "$ITERS" \
-            --run-key "$RUN_KEY"
+          # Concurrency levels run one after another inside this job, never as
+          # parallel matrix jobs. Parallel level jobs all target the same
+          # provider account at once, so the c1 job would measure its baseline
+          # while 5 + 10 + 25 + 50 sibling sessions were live on that account
+          # and every level's numbers would depend on scheduling overlap.
+          #
+          # A cooldown between levels lets sessions released at the end of one
+          # level clear the provider's quota before the next level starts.
+          if [ "${{ github.event_name }}" = "push" ]; then
+            LEVELS="1 5"   # smoke test only
+            COOLDOWN=10
+          else
+            LEVELS="1 5 10 25 50"
+            COOLDOWN=60
+          fi
+
+          # Rounds per level. Session-level metrics pool every session at a
+          # level, so a handful of rounds at high concurrency already yields a
+          # large sample; the round count only needs to give the barrier
+          # wall-clock a few observations.
+          iterations_for() {
+            case "$1" in
+              1)  echo 10 ;;
+              5)  echo 10 ;;
+              10) echo 5 ;;
+              25) echo 3 ;;
+              50) echo 3 ;;
+              *)  echo 3 ;;
+            esac
+          }
+
+          status=0
+          for level in $LEVELS; do
+            if [ "${{ github.event_name }}" = "push" ]; then
+              iters=1
+            else
+              iters=$(iterations_for "$level")
+            fi
+
+            echo "::group::c${level} (${iters} rounds)"
+            # One platform run per level: the benchmark slug is
+            # level-independent, so without the level in the key a provider
+            # would register as the same participant five times and the
+            # platform rejects the duplicate with 409 Conflict.
+            RUN_KEY="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-c${level}"
+            npx tsx packages/benchsdk-runner/dist/bin.js run benchmarks/browser/browser-concurrent.bench.ts \
+              --provider ${{ matrix.provider }} \
+              --concurrency-level "$level" \
+              --iterations "$iters" \
+              --run-key "$RUN_KEY" || status=$?
+            echo "::endgroup::"
+
+            sleep "$COOLDOWN"
+          done
+          exit $status
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: browser-concurrent-results-${{ matrix.provider }}-c${{ matrix.concurrency_level }}
+          name: browser-concurrent-results-${{ matrix.provider }}
           path: results/browser-concurrent/
           if-no-files-found: ignore
           retention-days: 7


### PR DESCRIPTION
## Problem

The five concurrency levels ran as parallel matrix jobs. All 35 started within two seconds of each other against the same provider account, so the level under test was never the load the provider actually saw: during a `c1` round, that account could also be serving the `c5`, `c10`, `c25` and `c50` jobs, up to 91 concurrent sessions.

The failure pattern in run `31528686026` shows it directly:

```
steel   c1  failedRoundIndices: 0,1,2,3,4,5,6
tilion  c1  failedRoundIndices: 2,3,5
kernel  c1  failedRoundIndices: 1,3
```

Steel's sibling jobs all finished by ~91s; at ~9.4s per round that is rounds 0-6 exactly, after which it ran 43 consecutive clean rounds. Its reported 84% baseline is really 100% once its own load test stopped competing with it. Notte's c1 job ran entirely inside its siblings' window and scored 0%.

Every degradation curve was therefore measured against a contaminated baseline, and the contamination varied with scheduling luck.

## Change

- Matrix is provider-only; levels run sequentially inside each job.
- Cooldown between levels (60s scheduled, 10s on push) so sessions released by one level clear the provider's quota before the next starts.
- Rounds rebalanced to 10/10/5/3/3. The old 50/10/5/2/1 gave the c1 baseline 50 samples and the c50 headline exactly one, where median and p95 were the same observation despite carrying 45% of the composite weight. It also put c1 on the critical path at 997s versus 171s for c50.
- One artifact per provider instead of per provider/level. `merge-results` groups by the `c{N}` directory name, so the layout still resolves.
- `timeout-minutes` raised to 120 since levels are now sequential. The seven provider jobs still run in parallel.

The shell loop was dry-run offline to confirm the level/iteration pairs and that a failing level propagates its exit code.

## Note

This file is byte-identical to the copy on `add-browser-concurrency-bench`, so the two branches cannot conflict.

Worth flagging separately: master has this workflow but none of the benchmark code it invokes, so `benchmarks/browser/browser-concurrent.bench.ts` does not resolve on master and the Monday 04:00 UTC cron will fail there. Merging the benchmark branch is what makes master self-consistent; this PR only fixes the scheduling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->