### PR TITLE
ci(browser-concurrency): require usable article pages in the setup job

### DIFF
--- a/.github/workflows/browser-concurrent-benchmarks.yml
+++ b/.github/workflows/browser-concurrent-benchmarks.yml
@@ -56,13 +56,24 @@ jobs:
           MIN_LINKS=5
           urls=()
           for i in $(seq 1 "$count"); do
+            # Reset per slot. Both are read after the attempt loop, and a slot
+            # that never reached the counting step would otherwise be judged on
+            # the previous slot's numbers.
+            url=''
+            links=0
             for attempt in 1 2 3 4 5; do
-              url=$(curl -sL -A 'ComputeSDK-Benchmark' -o /dev/null -w '%{url_effective}' \
+              resolved=$(curl -sL -A 'ComputeSDK-Benchmark' -o /dev/null -w '%{url_effective}' \
                 'https://en.wikipedia.org/wiki/Special:Random')
-              if [ -z "$url" ] || [[ "$url" == *"Special:Random"* ]]; then
-                url='https://en.wikipedia.org/wiki/Special:Random'
-                break
+              # Retry rather than give up: this is a transient redirect failure,
+              # which is what the attempt loop is for. Never put Special:Random
+              # itself in the list — each provider's browser would resolve it to
+              # a different article, so the slot would be neither validated nor
+              # shared, and a shared page set is the point of resolving up front.
+              if [ -z "$resolved" ] || [[ "$resolved" == *"Special:Random"* ]]; then
+                echo "Slot $i attempt $attempt: could not resolve a concrete article"
+                continue
               fi
+              url="$resolved"
               html=$(curl -sL -A 'ComputeSDK-Benchmark' "$url")
               # Content area only, and namespaced links (Help:, File:, wikt:)
               # dropped the same way isArticleLink drops them. All three href
@@ -70,17 +81,23 @@ jobs:
               # absolute and ./-relative links while the page chrome uses
               # /wiki/ — matching only the last form counts zero links on even
               # a large article.
+              # || true keeps a zero-match page from failing the step if this
+              # ever runs under pipefail, where the empty grep would abort it.
               links=$(printf '%s' "$html" \
                 | sed -n '/id="mw-content-text"/,$p' \
                 | grep -oP 'href="(\./|/wiki/|https://en\.wikipedia\.org/wiki/)[^"#:]+"' \
-                | sort -u | wc -l)
+                | sort -u | wc -l || true)
               if [ "$links" -ge "$MIN_LINKS" ]; then
                 break
               fi
               echo "Rejected $url: $links in-content article links, need $MIN_LINKS"
             done
+            if [ -z "$url" ]; then
+              echo "::error::Slot $i: could not resolve an article in 5 attempts"
+              exit 1
+            fi
             if [ "$links" -lt "$MIN_LINKS" ]; then
-              echo "::warning::Using $url after $attempt attempts: only $links in-content article links"
+              echo "::warning::Slot $i using $url: only $links in-content article links"
             fi
             urls+=("$url")
           done

--- a/.github/workflows/browser-concurrent-benchmarks.yml
+++ b/.github/workflows/browser-concurrent-benchmarks.yml
@@ -38,10 +38,22 @@ jobs:
         id: pick
         run: |
           # Resolve concrete articles up front so every provider benchmarks
-          # against the same pages. Sessions index into this list, so 50 covers
-          # a full c50 round; longer levels wrap, which keeps the page mix
-          # identical across providers.
+          # against the same pages. One session takes one URL, so 50 covers a
+          # full c50 round and every provider sees the same page mix.
           count=${{ github.event_name == 'push' && '5' || '50' }}
+
+          # Accept a page only if it offers what the action loop needs: several
+          # distinct article links inside #mw-content-text, which is where the
+          # loop's selector looks and where it clicks.
+          #
+          # The old check grepped the whole document for any /wiki/ link, so a
+          # page whose only qualifying links sat in the chrome (navigation,
+          # sidebar, footer) passed and then stalled in the browser. In run
+          # 31626532250 two of the fifty articles did exactly that, timing out
+          # waitForSelector or click at 30s for every provider alike, capping
+          # success at 96% and setting a 63s task p95 that had nothing to do
+          # with concurrency.
+          MIN_LINKS=5
           urls=()
           for i in $(seq 1 "$count"); do
             for attempt in 1 2 3 4 5; do
@@ -52,12 +64,24 @@ jobs:
                 break
               fi
               html=$(curl -sL -A 'ComputeSDK-Benchmark' "$url")
-              if echo "$html" | grep -qP 'href="(//en\.wikipedia\.org)?/wiki/[^"]*" *' \
-                 && echo "$html" | grep -oP 'href="[^"]*"' \
-                    | grep -qP '/wiki/[^:]*$'; then
+              # Content area only, and namespaced links (Help:, File:, wikt:)
+              # dropped the same way isArticleLink drops them. All three href
+              # forms are accepted because the content area is served with
+              # absolute and ./-relative links while the page chrome uses
+              # /wiki/ — matching only the last form counts zero links on even
+              # a large article.
+              links=$(printf '%s' "$html" \
+                | sed -n '/id="mw-content-text"/,$p' \
+                | grep -oP 'href="(\./|/wiki/|https://en\.wikipedia\.org/wiki/)[^"#:]+"' \
+                | sort -u | wc -l)
+              if [ "$links" -ge "$MIN_LINKS" ]; then
                 break
               fi
+              echo "Rejected $url: $links in-content article links, need $MIN_LINKS"
             done
+            if [ "$links" -lt "$MIN_LINKS" ]; then
+              echo "::warning::Using $url after $attempt attempts: only $links in-content article links"
+            fi
             urls+=("$url")
           done
           {
@@ -116,7 +140,6 @@ jobs:
           # numbers would depend on overlap.
           if [ "${{ github.event_name }}" = "push" ]; then
             LEVELS="1,5"             # smoke test: cheapest two levels
-            export CONCURRENT_ROUNDS_PER_LEVEL=1
             export CONCURRENT_LEVEL_COOLDOWN_MS=10000
           else
             LEVELS="1,5,10,25,50"


### PR DESCRIPTION
Follow-up to #307, workflow-only. Master currently validates the shared Wikipedia articles with a check that is weaker than what the benchmark actually needs, and it produced a measurable distortion.

## The problem

Run [31626532250](https://github.com/computesdk/benchmarks/actions/runs/31626532250) reported the same 96% success rate and the same ~63s task p95 for six independent providers. That uniformity was the tell: it came from the page set, not from the providers.

Mapping every action failure in the run to its article index (`roundIndex * level + sessionIndex`) puts all of them on index 6 or 44, modulo the 50-URL list, across all five concurrency levels and all seven providers:

```
c1:  r6s0  -> url#6
c5:  r1s1  -> url#6     r8s4  -> url#44
c10: r0s6  -> url#6     r4s4  -> url#44
c25: r0s6  -> url#6     r1s19 -> url#44   r2s6 -> url#56 (=6)
c50: r0s6, r0s44, r1s6, r1s44, r2s6, r2s44
```

Article 6 timed out `waitForSelector` and then `textContent`, leaving 8/10 actions. Article 44 timed out `click`, cascading into five skipped actions and leaving 4/10.

Because a round ends when its slowest session ends, one stalled session set the whole round's wall clock:

```
round 1: taskMs= 62.63s  <-- contains a 30s action timeout
round 8: taskMs= 31.33s  <-- contains a 30s action timeout
other rounds: 2.72s - 7.09s
```

With `taskP95` carrying 20% of the composite score, two unlucky articles were moving the ranking.

## The cause

The check grepped the whole document for any `/wiki/` link, while the action loop needs a clickable, non-namespaced link inside `#mw-content-text`. A page whose only qualifying links sat in the navigation, sidebar or footer passed and then stalled in the browser.

## The change

Require five distinct non-namespaced article links inside `#mw-content-text`, where the loop looks and clicks. All three href forms are matched, because the content area is served with absolute and `./`-relative links while the chrome uses `/wiki/` — matching only the last form counts **zero** links on even a 1,100-link article. Rejections are logged, and exhausting all five attempts now emits a `::warning::` instead of silently using an unvalidated page.

Verified against live pages:

| page | in-content links | old check | new check |
|---|---|---|---|
| Albert_Einstein | 1106 | pass | pass |
| Cheese | 414 | pass | pass |
| Kazimierz_Nowak | 24 | pass | pass |
| Linda_Gardner (random draw) | 9 | pass | pass |
| File:Example.jpg | 1 | pass | **fail** |
| Special:BlankPage | 0 | pass | **fail** |
| Wikipedia:Sandbox | 0 | pass | **fail** |

Eight fresh random draws all passed, 9 to 349 links.

Also drops `CONCURRENT_ROUNDS_PER_LEVEL=1` from the smoke path, since one round per level is now the default in the benchmark itself.

## Notes

- Workflow-only, and byte-identical to `.github/workflows/browser-concurrent-benchmarks.yml` on `add-browser-concurrency-bench`, so the branch can keep smoke-testing from `workflow_dispatch`.
- Validation alone cannot be the whole answer, since a bad page will eventually slip through. The companion change on the benchmark branch censors actions cut off at the timeout out of the latency stats while still counting them as failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->