### PR TITLE
bench(daytona): switch TTI/DAX to prebuilt daytona-8cpu-16gb snapshot

### DIFF
--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -79,7 +79,6 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   },
   beam:         { cpu: 8, memory: 16384 },                   // cpu = cores, memory = MiB
   codesandbox:  { vmTier: VMTier.Small },                  // Small = 8 CPU, 16 GiB
-  daytona:      { resources: { cpu: 8, memory: 16 } },     // memory in GiB; requires image-based creation (see providers.ts)
   northflank:   { deploymentPlan: process.env.NORTHFLANK_DEPLOYMENT_PLAN || 'nf-compute-50', ephemeralStorageSize: 5120 },  // 5 GiB ephemeral storage
   declaw:       { templateId: 'node-large' },              // node-large template: 8 vCPU / 16 GiB RAM / 8 GiB disk
   superserve:   { templateId: 'node22-8cpu-16gb' },           // 8 vCPU / 16 GiB template built in the pre-step

--- a/benchmarks/sandbox/providers.ts
+++ b/benchmarks/sandbox/providers.ts
@@ -101,7 +101,7 @@ export const providers: ProviderConfig[] = [
     name: 'daytona',
     requiredEnvVars: ['DAYTONA_API_KEY'],
     createCompute: () => daytona({ apiKey: process.env.DAYTONA_API_KEY! }),
-    sandboxOptions: { autoStopInterval: 15, autoDeleteInterval: 0, image: 'node:22' },
+    sandboxOptions: { autoStopInterval: 15, autoDeleteInterval: 0, snapshotId: 'daytona-8cpu-16gb' },
   },
   {
     name: 'declaw',


### PR DESCRIPTION
## What

- Switch the Daytona provider to the prebuilt, generally available `daytona-8cpu-16gb` snapshot (8 vCPU / 16 GiB RAM / 20 GiB disk, Node preinstalled) instead of on-demand image creation from `node:22`.
- Drop the DAX resource override for Daytona, the snapshot carries the resource spec, so image-based creation is no longer required.

## Why

- Creating from a raw image reference triggers a per-runner on-demand image build/pull, which adds a long tail to sandbox creation times that isn't representative of Daytona's snapshot-based creation path.
- Several other sandbox providers in this suite are already benchmarked using prebuilt templates/snapshots (via `templateId`/`snapshotId`); this puts Daytona on the same mechanism for a like-for-like comparison.
- The snapshot is generally available to every Daytona account, so results stay reproducible by anyone, no custom account state needed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->