### PR TITLE
chore(deps): bump @computesdk/isorun to ^0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@computesdk/e2b": "^1.7.52",
     "@computesdk/hopx": "^0.2.27",
     "@computesdk/hyperbrowser": "^0.2.7",
-    "@computesdk/isorun": "^0.1.1",
+    "@computesdk/isorun": "^0.1.2",
     "@computesdk/just-bash": "^0.4.15",
     "@computesdk/kernel": "^0.2.10",
     "@computesdk/lelantos": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^0.2.7
         version: 0.2.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@computesdk/isorun':
-        specifier: ^0.1.1
-        version: 0.1.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        specifier: ^0.1.2
+        version: 0.1.2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@computesdk/just-bash':
         specifier: ^0.4.15
         version: 0.4.15(just-bash@3.1.0)
@@ -676,8 +676,8 @@ packages:
   '@computesdk/hyperbrowser@0.2.7':
     resolution: {integrity: sha512-RXG/SQQPZ2Wpfk9dR0hZJ/GTmNeFNP2LMMy8+DNT4m2lUTtiIYrBCEXYdiNXkNfV8nxiKTXRCfkSxr4CxGkbJw==}
 
-  '@computesdk/isorun@0.1.1':
-    resolution: {integrity: sha512-4HiMxoySc43dd6RovnoAGef2wXMnqW7bfmo3N7E1xdiTICk6MVraRdchtXrpbJd+sOoqIhxaeakXo8xXSCST0A==}
+  '@computesdk/isorun@0.1.2':
+    resolution: {integrity: sha512-jkZazDqoWY1S751fL/7tfnd+RP3Ic+lkj6N2vJEPbcoivv3gD7houYBrRPMJ8U6adfpOLkxrFRx3JF7A64uJpQ==}
     engines: {node: '>=22.19.0'}
 
   '@computesdk/just-bash@0.4.15':
@@ -6274,9 +6274,9 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@computesdk/isorun@0.1.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+  '@computesdk/isorun@0.1.2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@computesdk/provider': 2.1.4
+      '@computesdk/provider': 2.1.5
       computesdk: 4.1.4
       isorun: 1.0.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Bumps `@computesdk/isorun` from `^0.1.1` to `^0.1.2` and updates the lockfile. The new version pulls in `@computesdk/provider@2.1.5` and adds typed `Runtime` handling for `options.runtime`.

### What changed

- `package.json`: update `@computesdk/isorun` specifier to `^0.1.2`
- `pnpm-lock.yaml`: refresh resolution and snapshot for `@computesdk/isorun@0.1.2` plus updated peer dependency `@computesdk/provider@2.1.5`

Link to Devin session: https://app.devin.ai/sessions/986f506c17874babada84aec5581167c
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->