### PR TITLE
feat(runner): per-step timeoutMs and concurrency options

### DIFF
--- a/packages/benchsdk-runner/src/__tests__/runner.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/runner.test.ts
@@ -707,4 +707,124 @@ describe('runBenchmark', () => {
     expect(recorded.e2b[0].errorCode).toBe('probe_failed');
     expect(recorded.e2b[0].data).toEqual({ mode: 'cold' });
   });
+
+  describe('ctx.step options', () => {
+    const setupRoundReporter = (recorded: TaskResultRecord[]) =>
+      reporterClaim.mockImplementation(async () => ({
+        taskIndexStart: 0,
+        recordResult: (r: TaskResultRecord) => recorded.push(r),
+        uploadArtifact: async () => ({}),
+        setProgress: () => {},
+        heartbeat: async () => {},
+        finish: async () => {},
+      }));
+
+    it('runs a step with timeoutMs that completes normally', async () => {
+      const recorded: TaskResultRecord[] = [];
+      setupRoundReporter(recorded);
+
+      const task = vi.fn(async (ctx: any) => {
+        const value = await ctx.step('fast', () => 'ok', { timeoutMs: 1000 });
+        expect(value).toBe('ok');
+        return {};
+      });
+
+      await runBenchmark(
+        { benchmarkSlug: 's', benchmarkName: 'n', iterations: 1, groupBy: 'round', participants: [participants[0]] },
+        defineTask(task),
+        [],
+      );
+
+      const step = recorded[0].steps?.find((s) => s.name === 'fast');
+      expect(step?.status).toBe('success');
+      expect(step?.timeoutMs).toBe(1000);
+      expect(step?.errorCode).toBeUndefined();
+    });
+
+    it('times out a step with timeoutMs and records step_timeout', async () => {
+      const recorded: TaskResultRecord[] = [];
+      setupRoundReporter(recorded);
+
+      let caught: unknown;
+      const task = vi.fn(async (ctx: any) => {
+        try {
+          await ctx.step('slow', () => new Promise((resolve) => setTimeout(resolve, 5000)), { timeoutMs: 10 });
+        } catch (error) {
+          caught = error;
+        }
+        return {};
+      });
+
+      await runBenchmark(
+        { benchmarkSlug: 's', benchmarkName: 'n', iterations: 1, groupBy: 'round', participants: [participants[0]] },
+        defineTask(task),
+        [],
+      );
+
+      expect(caught).toBeInstanceOf(TaskError);
+      expect((caught as TaskError).code).toBe('step_timeout');
+      const step = recorded[0].steps?.find((s) => s.name === 'slow');
+      expect(step?.status).toBe('error');
+      expect(step?.errorCode).toBe('step_timeout');
+      expect(step?.timeoutMs).toBe(10);
+    });
+
+    it('runs a step with concurrency > 1 and returns an array of results', async () => {
+      const recorded: TaskResultRecord[] = [];
+      setupRoundReporter(recorded);
+
+      const task = vi.fn(async (ctx: any) => {
+        const results = await ctx.step('parallel', () => 42, { concurrency: 3 });
+        expect(results).toEqual([42, 42, 42]);
+        return {};
+      });
+
+      await runBenchmark(
+        { benchmarkSlug: 's', benchmarkName: 'n', iterations: 1, groupBy: 'round', participants: [participants[0]] },
+        defineTask(task),
+        [],
+      );
+
+      const step = recorded[0].steps?.find((s) => s.name === 'parallel');
+      expect(step?.status).toBe('success');
+      expect(step?.concurrency).toBe(3);
+    });
+
+    it('fails a step with concurrency > 1 when one invocation fails', async () => {
+      const recorded: TaskResultRecord[] = [];
+      setupRoundReporter(recorded);
+
+      let calls = 0;
+      let caught: unknown;
+      const task = vi.fn(async (ctx: any) => {
+        try {
+          await ctx.step(
+            'parallel',
+            () => {
+              const index = calls++;
+              if (index === 1) throw new TaskError('boom', { code: 'invocation_failed' });
+              return index;
+            },
+            { concurrency: 3 },
+          );
+        } catch (error) {
+          caught = error;
+        }
+        return {};
+      });
+
+      await runBenchmark(
+        { benchmarkSlug: 's', benchmarkName: 'n', iterations: 1, groupBy: 'round', participants: [participants[0]] },
+        defineTask(task),
+        [],
+      );
+
+      expect(caught).toBeInstanceOf(TaskError);
+      expect((caught as TaskError).code).toBe('invocation_failed');
+      const step = recorded[0].steps?.find((s) => s.name === 'parallel');
+      expect(step?.status).toBe('error');
+      expect(step?.concurrency).toBe(3);
+      expect(step?.errorCode).toBe('invocation_failed');
+    });
+  });
 });

--- a/packages/benchsdk-runner/src/__tests__/runner.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/runner.test.ts
@@ -192,19 +192,25 @@ describe('runBenchmark', () => {
         const records: any[] = [];
         for (let ti = start; ti < start + total; ti++) {
           // Mirror the real client worker: `measure` merges into the record's
-          // data alongside whatever the task returns.
+          // data alongside whatever the task returns. `step` records options
+          // so participant-mode option forwarding can be asserted.
           const measures: Record<string, unknown> = {};
+          const steps: any[] = [];
           const ctx = {
             taskIndex: ti,
             assignment,
-            step: async (_n: string, fn: any) => fn(),
+            step: async (_n: string, fn: any, options: any) => {
+              const value = await fn();
+              steps.push({ name: _n, options });
+              return value;
+            },
             measure: (d: Record<string, unknown>) => Object.assign(measures, d),
             log: () => {},
           };
           const returned = await opts.task(ctx);
           calls.taskData.push(returned);
           const data = { ...measures, ...(returned ?? {}) };
-          const rec = { taskIndex: ti, status: 'success', data };
+          const rec = { taskIndex: ti, status: 'success', data, steps };
           opts.onResult?.(rec);
           records.push(rec);
         }
@@ -825,6 +831,64 @@ describe('runBenchmark', () => {
       expect(step?.status).toBe('error');
       expect(step?.concurrency).toBe(3);
       expect(step?.errorCode).toBe('invocation_failed');
+    });
+
+    it('handles a parallel step where a later invocation rejects while an earlier one is still pending', async () => {
+      const recorded: TaskResultRecord[] = [];
+      setupRoundReporter(recorded);
+
+      let calls = 0;
+      let caught: unknown;
+      const task = vi.fn(async (ctx: any) => {
+        try {
+          await ctx.step(
+            'parallel',
+            () => {
+              const index = calls++;
+              if (index === 1) {
+                return new Promise((_, reject) =>
+                  setTimeout(() => reject(new TaskError('boom', { code: 'invocation_failed' })), 5),
+                );
+              }
+              return new Promise((resolve) => setTimeout(() => resolve(index), 50));
+            },
+            { concurrency: 3 },
+          );
+        } catch (error) {
+          caught = error;
+        }
+        return {};
+      });
+
+      await runBenchmark(
+        { benchmarkSlug: 's', benchmarkName: 'n', iterations: 1, groupBy: 'round', participants: [participants[0]] },
+        defineTask(task),
+        [],
+      );
+
+      expect(caught).toBeInstanceOf(TaskError);
+      expect((caught as TaskError).code).toBe('invocation_failed');
+      const step = recorded[0].steps?.find((s) => s.name === 'parallel');
+      expect(step?.status).toBe('error');
+      expect(step?.concurrency).toBe(3);
+      expect(step?.errorCode).toBe('invocation_failed');
+    });
+
+    it('forwards timeoutMs and concurrency to the platform worker step in participant mode', async () => {
+      const task = vi.fn(async (ctx: any) => {
+        await ctx.step('par', () => 'ok', { concurrency: 3, timeoutMs: 1000 });
+        return {};
+      });
+
+      const outcome = await runBenchmark(
+        { benchmarkSlug: 's', benchmarkName: 'n', iterations: 1, groupBy: 'participant', participants: [participants[0]] },
+        defineTask(task),
+        [],
+      );
+
+      expect(task).toHaveBeenCalled();
+      const stepOptions = (outcome.participants[0].records[0] as any).steps?.[0]?.options;
+      expect(stepOptions).toMatchObject({ timeoutMs: 1000, stepConcurrency: 3 });
     });
   });
 });

--- a/packages/benchsdk-runner/src/bench-config.ts
+++ b/packages/benchsdk-runner/src/bench-config.ts
@@ -78,7 +78,7 @@ export interface TaskResult {
 }
 
 /** Options for a single `ctx.step` invocation. */
-export interface TaskStepOptions extends Omit<DefineStepOptions, 'concurrency'> {
+export interface TaskStepOptions extends Omit<DefineStepOptions, 'concurrency' | 'stepConcurrency'> {
   /** Per-iteration timeout in milliseconds. If an invocation exceeds this, it is aborted and a `step_timeout` TaskError is thrown. */
   timeoutMs?: number;
   /** Number of times to invoke `fn` in parallel. Defaults to 1. When greater than 1, the step returns an array of results. */

--- a/packages/benchsdk-runner/src/bench-config.ts
+++ b/packages/benchsdk-runner/src/bench-config.ts
@@ -77,6 +77,14 @@ export interface TaskResult {
   latencyMs?: number;
 }
 
+/** Options for a single `ctx.step` invocation. */
+export interface TaskStepOptions extends Omit<DefineStepOptions, 'concurrency'> {
+  /** Per-iteration timeout in milliseconds. If an invocation exceeds this, it is aborted and a `step_timeout` TaskError is thrown. */
+  timeoutMs?: number;
+  /** Number of times to invoke `fn` in parallel. Defaults to 1. When greater than 1, the step returns an array of results. */
+  concurrency?: number;
+}
+
 /**
  * Throw this from a task to record a failure while preserving domain data and
  * any pre-measured steps (a plain thrown Error loses them).
@@ -104,9 +112,15 @@ export interface TaskContext<T extends BaseParticipant = BaseParticipant> {
   phase?: string;
   /**
    * Runs `fn` as a named platform step. Mirrors `@benchsdk/client`'s
-   * `RunWorkerContext.step`; supports closures and try/finally.
+   * `RunWorkerContext.step`; supports closures and try/finally. A `concurrency`
+   * greater than 1 invokes `fn` that many times in parallel and returns an array.
+   * `timeoutMs` aborts any invocation that exceeds it with a `step_timeout` TaskError.
    */
-  step<R>(name: string, fn: () => Promise<R> | R, options?: DefineStepOptions): Promise<R>;
+  step<R, C extends number = 1>(
+    name: string,
+    fn: () => Promise<R> | R,
+    options?: TaskStepOptions & { concurrency?: C },
+  ): Promise<C extends 1 ? R : R[]>;
   /**
    * Attaches a JSON measurement to the platform. Inside a `step` it lands on
    * that step's data; at task top-level it lands on the task record's data.

--- a/packages/benchsdk-runner/src/index.ts
+++ b/packages/benchsdk-runner/src/index.ts
@@ -4,6 +4,7 @@ export type {
   BenchmarkTask,
   TaskContext,
   TaskResult,
+  TaskStepOptions,
   Phase,
   GroupBy,
   ParticipantRecords,

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -24,6 +24,7 @@ import { NoAvailableParticipantsError } from './no-available-participants.js';
 import type {
   BaseParticipant,
   BenchmarkClient,
+  DefineStepOptions,
   JsonObject,
   RunWorkerContext,
   TaskResultRecord,
@@ -40,6 +41,7 @@ import type {
   ResolvedRunConfig,
   TaskContext,
   TaskResult,
+  TaskStepOptions,
 } from './bench-config.js';
 import { LogBuffer } from './log-buffer.js';
 
@@ -72,6 +74,74 @@ function sleep(ms: number): Promise<void> {
 
 function getErrorCode(error: unknown): string {
   return error instanceof Error && error.name ? error.name : 'ERROR';
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, name: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new TaskError(`Step "${name}" timed out after ${ms}ms`, { code: 'step_timeout' })),
+      ms,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function runStepInvocations<R>(
+  name: string,
+  fn: () => Promise<R> | R,
+  options: TaskStepOptions | undefined,
+): Promise<R | R[]> {
+  const requestedConcurrency = options?.concurrency;
+  if (requestedConcurrency !== undefined && (!Number.isInteger(requestedConcurrency) || requestedConcurrency < 1)) {
+    throw new Error(`step "${name}" concurrency must be an integer >= 1 (got ${requestedConcurrency})`);
+  }
+  const timeoutMs = options?.timeoutMs;
+  if (timeoutMs !== undefined && (!Number.isFinite(timeoutMs) || timeoutMs < 0)) {
+    throw new Error(`step "${name}" timeoutMs must be a number >= 0 (got ${timeoutMs})`);
+  }
+
+  const count = requestedConcurrency ?? 1;
+  const invocations = Array.from({ length: count }, () => {
+    const promise = Promise.resolve().then(() => fn());
+    if (timeoutMs === undefined) return promise;
+    return withTimeout(promise, timeoutMs, name);
+  });
+
+  if (count === 1) {
+    return invocations[0];
+  }
+
+  const results: R[] = [];
+  let firstError: unknown;
+  for (const promise of invocations) {
+    try {
+      results.push(await promise);
+    } catch (error) {
+      if (firstError === undefined) firstError = error;
+    }
+  }
+  if (firstError !== undefined) throw firstError;
+  return results;
+}
+
+async function runStepWithClient<R, C extends number = 1>(
+  clientStep: RunWorkerContext['step'],
+  name: string,
+  fn: () => Promise<R> | R,
+  options?: TaskStepOptions & { concurrency?: C },
+): Promise<C extends 1 ? R : R[]> {
+  const { concurrency: _runnerConcurrency, timeoutMs: _runnerTimeout, ...clientOptions } = options ?? {};
+  const result = await clientStep(name, () => runStepInvocations(name, fn, options), clientOptions as DefineStepOptions);
+  return result as C extends 1 ? R : R[];
 }
 
 /**
@@ -465,12 +535,14 @@ async function runGroupedByParticipant<T extends BaseParticipant>(
         }
         const slot = schedule[scheduleIndex];
         // The client owns step timing, `measure` attribution, and worker-log
-        // upload; the runner just threads them onto the task context.
+        // upload; the runner just threads them onto the task context. The runner
+        // wraps `ctx.step` so per-step `timeoutMs` and `concurrency` work in
+        // participant mode as well.
         const taskResult = await slot.task({
           participant,
           taskIndex: scheduleIndex,
           phase: slot.phase,
-          step: ctx.step,
+          step: (name, fn, options) => runStepWithClient(ctx.step, name, fn, options),
           measure: ctx.measure,
           log: ctx.log,
         });
@@ -639,7 +711,11 @@ async function runTaskRecord<T extends BaseParticipant>(
     participant,
     taskIndex: scheduleIndex,
     phase,
-    async step(name, fn) {
+    async step<R, C extends number = 1>(
+      name: string,
+      fn: () => Promise<R> | R,
+      options?: TaskStepOptions & { concurrency?: C },
+    ): Promise<C extends 1 ? R : R[]> {
       const stepStartedAtMs = Date.now();
       const stepRecord: TaskStepRecord = {
         name,
@@ -648,15 +724,17 @@ async function runTaskRecord<T extends BaseParticipant>(
         completedAt: new Date(stepStartedAtMs).toISOString(),
         latencyMs: 0,
       };
+      if (options?.concurrency !== undefined) stepRecord.concurrency = options.concurrency;
+      if (options?.timeoutMs !== undefined) stepRecord.timeoutMs = options.timeoutMs;
       const previousStep = activeStep;
       activeStep = stepRecord;
       try {
-        const result = await fn();
+        const result = await runStepInvocations<R>(name, fn, options);
         logBuffer.step(taskIndex, name, {});
-        return result;
+        return result as C extends 1 ? R : R[];
       } catch (error) {
         stepRecord.status = 'error';
-        stepRecord.errorCode = getErrorCode(error);
+        stepRecord.errorCode = error instanceof TaskError ? error.code ?? error.name : getErrorCode(error);
         logBuffer.step(taskIndex, name, { error: error instanceof Error ? error.message : String(error) });
         throw error;
       } finally {

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -120,13 +120,14 @@ async function runStepInvocations<R>(
     return invocations[0];
   }
 
+  const outcomes = await Promise.allSettled(invocations);
   const results: R[] = [];
   let firstError: unknown;
-  for (const promise of invocations) {
-    try {
-      results.push(await promise);
-    } catch (error) {
-      if (firstError === undefined) firstError = error;
+  for (const outcome of outcomes) {
+    if (outcome.status === 'fulfilled') {
+      results.push(outcome.value);
+    } else if (firstError === undefined) {
+      firstError = outcome.reason;
     }
   }
   if (firstError !== undefined) throw firstError;
@@ -139,8 +140,13 @@ async function runStepWithClient<R, C extends number = 1>(
   fn: () => Promise<R> | R,
   options?: TaskStepOptions & { concurrency?: C },
 ): Promise<C extends 1 ? R : R[]> {
-  const { concurrency: _runnerConcurrency, timeoutMs: _runnerTimeout, ...clientOptions } = options ?? {};
-  const result = await clientStep(name, () => runStepInvocations(name, fn, options), clientOptions as DefineStepOptions);
+  const { concurrency: runnerConcurrency, timeoutMs, ...clientOptions } = options ?? {};
+  const clientStepOptions: DefineStepOptions = {
+    ...clientOptions,
+    timeoutMs,
+    stepConcurrency: runnerConcurrency,
+  };
+  const result = await clientStep(name, () => runStepInvocations(name, fn, options), clientStepOptions);
   return result as C extends 1 ? R : R[];
 }
 

--- a/packages/benchsdk/src/client.ts
+++ b/packages/benchsdk/src/client.ts
@@ -84,6 +84,9 @@ function getApiKey(input?: string): string | undefined {
 }
 
 function getErrorCode(error: unknown): string {
+  if (error instanceof Error && 'code' in error && typeof (error as { code: unknown }).code === 'string' && (error as { code: string }).code) {
+    return (error as { code: string }).code;
+  }
   if (error instanceof Error && error.name) return error.name;
   return 'ERROR';
 }
@@ -709,6 +712,8 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
               completedAt: new Date().toISOString(),
               latencyMs: 0,
             };
+            if (stepOptions.timeoutMs !== undefined) stepRecord.timeoutMs = stepOptions.timeoutMs;
+            if (stepOptions.stepConcurrency !== undefined) stepRecord.concurrency = stepOptions.stepConcurrency;
 
             const shouldReportConcurrency = stepOptions.reportConcurrency ?? true;
             if (shouldReportConcurrency) {

--- a/packages/benchsdk/src/types.ts
+++ b/packages/benchsdk/src/types.ts
@@ -183,6 +183,10 @@ export interface TaskStepRecord {
   latencyMs?: number;
   errorCode?: string | null;
   data?: JsonObject;
+  /** Number of parallel invocations requested for this step. */
+  concurrency?: number;
+  /** Per-iteration timeout in milliseconds applied to this step. */
+  timeoutMs?: number;
 }
 
 export interface SendTaskResultsInput {

--- a/packages/benchsdk/src/types.ts
+++ b/packages/benchsdk/src/types.ts
@@ -555,6 +555,10 @@ export interface DefineStepOptions {
   reportConcurrency?: boolean;
   /** Per-worker target for this step. Defaults to worker concurrency/assignment target. */
   concurrency?: number;
+  /** Number of parallel invocations the step function should run internally. Used by the runner to record step-level concurrency. */
+  stepConcurrency?: number;
+  /** Per-invocation timeout in milliseconds for this step. Used by the runner to record step-level timeout metadata. */
+  timeoutMs?: number;
   /** Readiness coordination mode. Defaults to internal. */
   readiness?: 'poll' | 'internal';
   /** Poll interval while waiting for readiness. Defaults to 1000ms. */


### PR DESCRIPTION
## Summary

Adds an optional third `options` argument to `ctx.step` in `@benchsdk/runner`:

```ts
ctx.step('name', async () => { ... }, { timeoutMs: 5000, concurrency: 3 });
```

- `timeoutMs?: number` — aborts any invocation that exceeds the limit and throws a `TaskError` with code `step_timeout`.
- `concurrency?: number` — invokes `fn` that many times in parallel; the step resolves to an array of results when `> 1`.
- `TaskStepRecord` now records `timeoutMs` and `concurrency`.

## Details

- Introduced `TaskStepOptions` in `packages/benchsdk-runner/src/bench-config.ts`. It intentionally `Omit`s the client `DefineStepOptions.concurrency` (heartbeat target) and redefines `concurrency` as a repeat count.
- Round-mode execution (`runTaskRecord`) uses `runStepInvocations` to schedule parallel calls and `withTimeout` for per-iteration timeouts.
- Participant-mode execution wraps the client `ctx.step` with `runStepWithClient` / `runStepInvocations` so the same `timeoutMs`/`concurrency` behavior applies without leaking runner-specific options into the client heartbeat configuration.
- Added four tests in `packages/benchsdk-runner/src/__tests__/runner.test.ts` covering: a `timeoutMs` step that completes, a `timeoutMs` step that times out, a `concurrency > 1` step that succeeds, and a `concurrency > 1` step where one invocation fails.

This is intended as the bottom PR of a stack; follow-up PRs may build on this API.


Link to Devin session: https://app.devin.ai/sessions/d59e8ecffd2040d9b09060056b977b37
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->