### PR TITLE
feat(benchmarks): support DAILY_BENCH_SLUG/NAME suffixes

### DIFF
--- a/benchmarks/ai-gateway/ai-gateway.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway.bench.ts
@@ -137,8 +137,8 @@ if (phases.length === 0) {
 }
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: `ai-gateway-latency${process.env.DAILY_BENCH_SLUG ?? ''}`,
-  benchmarkName: `AI Gateway Latency${process.env.DAILY_BENCH_NAME ?? ''}`,
+  benchmarkSlug: `ai-gateway-latency${process.env.DAILY_BENCH_SLUG ? `-${process.env.DAILY_BENCH_SLUG}` : ''}`,
+  benchmarkName: `AI Gateway Latency${process.env.DAILY_BENCH_NAME ? ` - ${process.env.DAILY_BENCH_NAME}` : ''}`,
   phases,
   groupBy: 'round',
   participants: providers,

--- a/benchmarks/ai-gateway/ai-gateway.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway.bench.ts
@@ -137,8 +137,8 @@ if (phases.length === 0) {
 }
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: 'ai-gateway-latency',
-  benchmarkName: 'AI Gateway Latency',
+  benchmarkSlug: `ai-gateway-latency${process.env.DAILY_BENCH_SLUG ?? ''}`,
+  benchmarkName: `AI Gateway Latency${process.env.DAILY_BENCH_NAME ?? ''}`,
   phases,
   groupBy: 'round',
   participants: providers,

--- a/benchmarks/browser/browser-throughput.bench.ts
+++ b/benchmarks/browser/browser-throughput.bench.ts
@@ -30,8 +30,8 @@ const throughputTimeoutMs =
   throughputProviders.reduce((max, p) => Math.max(max, p.timeout ?? 120_000), 0) || 120_000;
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: 'browser-throughput',
-  benchmarkName: 'Browser Throughput',
+  benchmarkSlug: `browser-throughput${process.env.DAILY_BENCH_SLUG ?? ''}`,
+  benchmarkName: `Browser Throughput${process.env.DAILY_BENCH_NAME ?? ''}`,
   iterations: 2,
   groupBy: 'round',
   participants: throughputProviders,

--- a/benchmarks/browser/browser-throughput.bench.ts
+++ b/benchmarks/browser/browser-throughput.bench.ts
@@ -30,8 +30,8 @@ const throughputTimeoutMs =
   throughputProviders.reduce((max, p) => Math.max(max, p.timeout ?? 120_000), 0) || 120_000;
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: `browser-throughput${process.env.DAILY_BENCH_SLUG ?? ''}`,
-  benchmarkName: `Browser Throughput${process.env.DAILY_BENCH_NAME ?? ''}`,
+  benchmarkSlug: `browser-throughput${process.env.DAILY_BENCH_SLUG ? `-${process.env.DAILY_BENCH_SLUG}` : ''}`,
+  benchmarkName: `Browser Throughput${process.env.DAILY_BENCH_NAME ? ` - ${process.env.DAILY_BENCH_NAME}` : ''}`,
   iterations: 2,
   groupBy: 'round',
   participants: throughputProviders,

--- a/benchmarks/browser/browser.bench.ts
+++ b/benchmarks/browser/browser.bench.ts
@@ -21,8 +21,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const browserTimeoutMs = browserProviders.reduce((max, p) => Math.max(max, p.timeout ?? 120_000), 0) || 120_000;
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: `browser-lifecycle${process.env.DAILY_BENCH_SLUG ?? ''}`,
-  benchmarkName: `Browser Lifecycle${process.env.DAILY_BENCH_NAME ?? ''}`,
+  benchmarkSlug: `browser-lifecycle${process.env.DAILY_BENCH_SLUG ? `-${process.env.DAILY_BENCH_SLUG}` : ''}`,
+  benchmarkName: `Browser Lifecycle${process.env.DAILY_BENCH_NAME ? ` - ${process.env.DAILY_BENCH_NAME}` : ''}`,
   iterations: 2,
   concurrency: 1,
   participants: browserProviders,

--- a/benchmarks/browser/browser.bench.ts
+++ b/benchmarks/browser/browser.bench.ts
@@ -21,8 +21,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const browserTimeoutMs = browserProviders.reduce((max, p) => Math.max(max, p.timeout ?? 120_000), 0) || 120_000;
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: 'browser-lifecycle',
-  benchmarkName: 'Browser Lifecycle',
+  benchmarkSlug: `browser-lifecycle${process.env.DAILY_BENCH_SLUG ?? ''}`,
+  benchmarkName: `Browser Lifecycle${process.env.DAILY_BENCH_NAME ?? ''}`,
   iterations: 2,
   concurrency: 1,
   participants: browserProviders,

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -36,8 +36,8 @@ const timeout = 600_000;
 const destroyTimeoutMs = 15_000;
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: 'sandbox-dax',
-  benchmarkName: 'Sandbox Dax',
+  benchmarkSlug: `sandbox-dax${process.env.DAILY_BENCH_SLUG ?? ''}`,
+  benchmarkName: `Sandbox Dax${process.env.DAILY_BENCH_NAME ?? ''}`,
   iterations: 3,
   concurrency: 1,
   groupBy: 'round',

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -36,8 +36,8 @@ const timeout = 600_000;
 const destroyTimeoutMs = 15_000;
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: `sandbox-dax${process.env.DAILY_BENCH_SLUG ?? ''}`,
-  benchmarkName: `Sandbox Dax${process.env.DAILY_BENCH_NAME ?? ''}`,
+  benchmarkSlug: `sandbox-dax${process.env.DAILY_BENCH_SLUG ? `-${process.env.DAILY_BENCH_SLUG}` : ''}`,
+  benchmarkName: `Sandbox Dax${process.env.DAILY_BENCH_NAME ? ` - ${process.env.DAILY_BENCH_NAME}` : ''}`,
   iterations: 3,
   concurrency: 1,
   groupBy: 'round',

--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -34,8 +34,8 @@ const COMMAND_TIMEOUT_MS = 30_000;
 const DESTROY_TIMEOUT_MS = 15_000;
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: 'sandbox-tti',
-  benchmarkName: 'Sandbox TTI (Burst)',
+  benchmarkSlug: `sandbox-tti${process.env.DAILY_BENCH_SLUG ?? ''}`,
+  benchmarkName: `Sandbox TTI (Burst)${process.env.DAILY_BENCH_NAME ?? ''}`,
   iterations: 2,
   concurrency: 1,
   participants: providers,

--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -34,8 +34,8 @@ const COMMAND_TIMEOUT_MS = 30_000;
 const DESTROY_TIMEOUT_MS = 15_000;
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: `sandbox-tti${process.env.DAILY_BENCH_SLUG ?? ''}`,
-  benchmarkName: `Sandbox TTI (Burst)${process.env.DAILY_BENCH_NAME ?? ''}`,
+  benchmarkSlug: `sandbox-tti${process.env.DAILY_BENCH_SLUG ? `-${process.env.DAILY_BENCH_SLUG}` : ''}`,
+  benchmarkName: `Sandbox TTI (Burst)${process.env.DAILY_BENCH_NAME ? ` - ${process.env.DAILY_BENCH_NAME}` : ''}`,
   iterations: 2,
   concurrency: 1,
   participants: providers,

--- a/benchmarks/storage/snapshot-fork.bench.ts
+++ b/benchmarks/storage/snapshot-fork.bench.ts
@@ -48,8 +48,8 @@ const participants: StorageProviderConfig[] = storageProviders.map((p) => {
 });
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: `snapshot-fork${process.env.DAILY_BENCH_SLUG ?? ''}`,
-  benchmarkName: `Storage Snapshot/Fork${process.env.DAILY_BENCH_NAME ?? ''}`,
+  benchmarkSlug: `snapshot-fork${process.env.DAILY_BENCH_SLUG ? `-${process.env.DAILY_BENCH_SLUG}` : ''}`,
+  benchmarkName: `Storage Snapshot/Fork${process.env.DAILY_BENCH_NAME ? ` - ${process.env.DAILY_BENCH_NAME}` : ''}`,
   iterations: 2,
   concurrency: 1,
   participants,

--- a/benchmarks/storage/snapshot-fork.bench.ts
+++ b/benchmarks/storage/snapshot-fork.bench.ts
@@ -48,8 +48,8 @@ const participants: StorageProviderConfig[] = storageProviders.map((p) => {
 });
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: 'snapshot-fork',
-  benchmarkName: 'Storage Snapshot/Fork',
+  benchmarkSlug: `snapshot-fork${process.env.DAILY_BENCH_SLUG ?? ''}`,
+  benchmarkName: `Storage Snapshot/Fork${process.env.DAILY_BENCH_NAME ?? ''}`,
   iterations: 2,
   concurrency: 1,
   participants,

--- a/benchmarks/storage/storage.bench.ts
+++ b/benchmarks/storage/storage.bench.ts
@@ -41,8 +41,8 @@ const fileSizeBytes = FILE_SIZE_BYTES[fileSizeLabel];
 const testData = crypto.randomBytes(fileSizeBytes);
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: 'storage-lifecycle',
-  benchmarkName: 'Storage Lifecycle',
+  benchmarkSlug: `storage-lifecycle${process.env.DAILY_BENCH_SLUG ?? ''}`,
+  benchmarkName: `Storage Lifecycle${process.env.DAILY_BENCH_NAME ?? ''}`,
   iterations: 2,
   concurrency: 1,
   participants: storageProviders,

--- a/benchmarks/storage/storage.bench.ts
+++ b/benchmarks/storage/storage.bench.ts
@@ -41,8 +41,8 @@ const fileSizeBytes = FILE_SIZE_BYTES[fileSizeLabel];
 const testData = crypto.randomBytes(fileSizeBytes);
 
 export const config = defineBenchmarkConfig({
-  benchmarkSlug: `storage-lifecycle${process.env.DAILY_BENCH_SLUG ?? ''}`,
-  benchmarkName: `Storage Lifecycle${process.env.DAILY_BENCH_NAME ?? ''}`,
+  benchmarkSlug: `storage-lifecycle${process.env.DAILY_BENCH_SLUG ? `-${process.env.DAILY_BENCH_SLUG}` : ''}`,
+  benchmarkName: `Storage Lifecycle${process.env.DAILY_BENCH_NAME ? ` - ${process.env.DAILY_BENCH_NAME}` : ''}`,
   iterations: 2,
   concurrency: 1,
   participants: storageProviders,


### PR DESCRIPTION
## Summary
Allow benchmark slugs/names to be suffixed at runtime by two optional environment variables, `DAILY_BENCH_SLUG` and `DAILY_BENCH_NAME`. When unset the values are unchanged; when set the config inserts the separator so the env values can be plain (`daily` / `Daily`) rather than carrying punctuation.

Changed the `benchmarkSlug` and `benchmarkName` fields in the seven top-level benchmark configs:

```ts
benchmarkSlug: `browser-lifecycle${process.env.DAILY_BENCH_SLUG ? `-${process.env.DAILY_BENCH_SLUG}` : ''}`,
benchmarkName: `Browser Lifecycle${process.env.DAILY_BENCH_NAME ? ` - ${process.env.DAILY_BENCH_NAME}` : ''}`,
```

So `DAILY_BENCH_SLUG=daily` produces `browser-lifecycle-daily` and `DAILY_BENCH_NAME=Daily` produces `Browser Lifecycle - Daily`.

Files updated:
- `benchmarks/sandbox/dax.bench.ts`
- `benchmarks/sandbox/tti.bench.ts`
- `benchmarks/browser/browser.bench.ts`
- `benchmarks/browser/browser-throughput.bench.ts`
- `benchmarks/ai-gateway/ai-gateway.bench.ts`
- `benchmarks/storage/snapshot-fork.bench.ts`
- `benchmarks/storage/storage.bench.ts`

`pnpm typecheck` passes.

Link to Devin session: https://app.devin.ai/sessions/0e67378960a34308b7dc0726fc620f9d
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->