### PR TITLE
fix(ai-gateway): make CLOUDFLARE_AI_GATEWAY_TOKEN required

### DIFF
--- a/AI_GATEWAYS.md
+++ b/AI_GATEWAYS.md
@@ -127,7 +127,7 @@ pnpm run bench:ai-gateway -- --iterations 20
 npx tsx benchmarks/ai-gateway/ai-gateway.bench.ts --ai-gateway-iterations-cold 20 --ai-gateway-iterations-warm 0
 ```
 
-Required environment variables (`benchmarks/.env.example`): `OPENROUTER_API_KEY`, `VERCEL_AI_GATEWAY_API_KEY`, `LLM_GATEWAY_API_KEY`, `PYDANTIC_AI_GATEWAY_API_KEY`, `CONCENTRATE_AI_GATEWAY_API_KEY`, `CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID` + `CLOUDFLARE_AI_GATEWAY_GATEWAY_ID` (+ optional `CLOUDFLARE_AI_GATEWAY_TOKEN` if the gateway has Authenticated Gateway enabled), `ANTHROPIC_API_KEY` (shared by Cloudflare's passthrough and the direct baseline). Missing credentials cause that gateway to be reported as `SKIPPED` rather than failing the run.
+Required environment variables (`benchmarks/.env.example`): `OPENROUTER_API_KEY`, `VERCEL_AI_GATEWAY_API_KEY`, `LLM_GATEWAY_API_KEY`, `PYDANTIC_AI_GATEWAY_API_KEY`, `CONCENTRATE_AI_GATEWAY_API_KEY`, `CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID`, `CLOUDFLARE_AI_GATEWAY_GATEWAY_ID`, `CLOUDFLARE_AI_GATEWAY_TOKEN`, and `ANTHROPIC_API_KEY` (shared by Cloudflare's passthrough and the direct baseline). Missing credentials cause that gateway to be reported as `SKIPPED` rather than failing the run.
 
 ## Output
 

--- a/benchmarks/ai-gateway/providers.ts
+++ b/benchmarks/ai-gateway/providers.ts
@@ -73,8 +73,12 @@ export const providers: AIGatewayProviderConfig[] = [
     // Direct Anthropic passthrough (not routed through another gateway), so
     // this measures Cloudflare's own overhead in isolation.
     name: 'cloudflare-ai-gateway',
-    requiredEnvVars: ['CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID', 'CLOUDFLARE_AI_GATEWAY_GATEWAY_ID', 'ANTHROPIC_API_KEY'],
-    optionalEnvVars: ['CLOUDFLARE_AI_GATEWAY_TOKEN'],
+    requiredEnvVars: [
+      'CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID',
+      'CLOUDFLARE_AI_GATEWAY_GATEWAY_ID',
+      'CLOUDFLARE_AI_GATEWAY_TOKEN',
+      'ANTHROPIC_API_KEY',
+    ],
     wireFormat: 'anthropic',
     model: 'claude-haiku-4-5-20251001',
     host: 'gateway.ai.cloudflare.com',

--- a/benchmarks/ai-gateway/providers.ts
+++ b/benchmarks/ai-gateway/providers.ts
@@ -74,6 +74,7 @@ export const providers: AIGatewayProviderConfig[] = [
     // this measures Cloudflare's own overhead in isolation.
     name: 'cloudflare-ai-gateway',
     requiredEnvVars: ['CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID', 'CLOUDFLARE_AI_GATEWAY_GATEWAY_ID', 'ANTHROPIC_API_KEY'],
+    optionalEnvVars: ['CLOUDFLARE_AI_GATEWAY_TOKEN'],
     wireFormat: 'anthropic',
     model: 'claude-haiku-4-5-20251001',
     host: 'gateway.ai.cloudflare.com',

--- a/benchmarks/ai-gateway/types.ts
+++ b/benchmarks/ai-gateway/types.ts
@@ -5,6 +5,11 @@ export interface AIGatewayProviderConfig {
   name: string;
   /** Environment variables that must all be set to run this benchmark */
   requiredEnvVars: string[];
+  /**
+   * Optional environment variables that the provider will use when present
+   * (e.g. an authenticated gateway token). Loaded into CI but not required.
+   */
+  optionalEnvVars?: string[];
   /** Request/response wire format this gateway speaks */
   wireFormat: AIGatewayWireFormat;
   /** Model id to request, in this gateway's own catalog naming convention */

--- a/benchmarks/ai-gateway/types.ts
+++ b/benchmarks/ai-gateway/types.ts
@@ -5,11 +5,6 @@ export interface AIGatewayProviderConfig {
   name: string;
   /** Environment variables that must all be set to run this benchmark */
   requiredEnvVars: string[];
-  /**
-   * Optional environment variables that the provider will use when present
-   * (e.g. an authenticated gateway token). Loaded into CI but not required.
-   */
-  optionalEnvVars?: string[];
   /** Request/response wire format this gateway speaks */
   wireFormat: AIGatewayWireFormat;
   /** Model id to request, in this gateway's own catalog naming convention */

--- a/benchmarks/scripts/gen-provider-vars.ts
+++ b/benchmarks/scripts/gen-provider-vars.ts
@@ -1,8 +1,8 @@
 /**
  * Generate benchmarks/scripts/provider-vars.json: the authoritative map of
  * which env vars each provider benchmark needs, read straight from the
- * `requiredEnvVars` and `optionalEnvVars` fields on every provider config
- * (the single source of truth in benchmarks/{mode}/providers.ts).
+ * `requiredEnvVars` field on every provider config (the single source of truth
+ * in benchmarks/{mode}/providers.ts).
  *
  * Each workflow's Load+Run step grep's this manifest by env-var name to keep
  * the per-job envdef (and thus the secrets the runner requests) scoped to
@@ -22,12 +22,7 @@ import { storageProviders } from '../storage/providers.js';
 import { providers as scaleProviders } from '../scale/providers.js';
 import { providers as aiGatewayProviders } from '../ai-gateway/providers.js';
 
-type Cfg = {
-  name: string;
-  requiredEnvVars?: string[];
-  optionalEnvVars?: string[];
-  snapshotFork?: { requiredEnvVars?: string[] };
-};
+type Cfg = { name: string; requiredEnvVars?: string[]; snapshotFork?: { requiredEnvVars?: string[] } };
 
 const modes: Record<string, Cfg[]> = {
   sandbox: sandboxProviders as Cfg[],
@@ -42,10 +37,8 @@ const manifest: Record<string, Record<string, string[]>> = {};
 for (const [mode, configs] of Object.entries(modes)) {
   manifest[mode] = {};
   for (const c of configs) {
-    // De-dupe and keep declared order (required vars first, then optional).
-    manifest[mode][c.name] = [
-      ...new Set([...(c.requiredEnvVars ?? []), ...(c.optionalEnvVars ?? [])]),
-    ];
+    // De-dupe and keep declared order.
+    manifest[mode][c.name] = [...new Set(c.requiredEnvVars ?? [])];
   }
 }
 

--- a/benchmarks/scripts/gen-provider-vars.ts
+++ b/benchmarks/scripts/gen-provider-vars.ts
@@ -1,8 +1,8 @@
 /**
  * Generate benchmarks/scripts/provider-vars.json: the authoritative map of
  * which env vars each provider benchmark needs, read straight from the
- * `requiredEnvVars` field on every provider config (the single source of
- * truth in benchmarks/{mode}/providers.ts).
+ * `requiredEnvVars` and `optionalEnvVars` fields on every provider config
+ * (the single source of truth in benchmarks/{mode}/providers.ts).
  *
  * Each workflow's Load+Run step grep's this manifest by env-var name to keep
  * the per-job envdef (and thus the secrets the runner requests) scoped to
@@ -22,7 +22,12 @@ import { storageProviders } from '../storage/providers.js';
 import { providers as scaleProviders } from '../scale/providers.js';
 import { providers as aiGatewayProviders } from '../ai-gateway/providers.js';
 
-type Cfg = { name: string; requiredEnvVars?: string[]; snapshotFork?: { requiredEnvVars?: string[] } };
+type Cfg = {
+  name: string;
+  requiredEnvVars?: string[];
+  optionalEnvVars?: string[];
+  snapshotFork?: { requiredEnvVars?: string[] };
+};
 
 const modes: Record<string, Cfg[]> = {
   sandbox: sandboxProviders as Cfg[],
@@ -37,8 +42,10 @@ const manifest: Record<string, Record<string, string[]>> = {};
 for (const [mode, configs] of Object.entries(modes)) {
   manifest[mode] = {};
   for (const c of configs) {
-    // De-dupe and keep declared order.
-    manifest[mode][c.name] = [...new Set(c.requiredEnvVars ?? [])];
+    // De-dupe and keep declared order (required vars first, then optional).
+    manifest[mode][c.name] = [
+      ...new Set([...(c.requiredEnvVars ?? []), ...(c.optionalEnvVars ?? [])]),
+    ];
   }
 }
 

--- a/benchmarks/scripts/provider-vars.json
+++ b/benchmarks/scripts/provider-vars.json
@@ -67,11 +67,11 @@
       "OPENCOMPUTER_API_KEY",
       "OPENCOMPUTER_API_URL"
     ],
-    "run-cloud": [
-      "RUN_CLOUD_API_KEY"
-    ],
     "runloop": [
       "RUNLOOP_API_KEY"
+    ],
+    "run-cloud": [
+      "RUN_CLOUD_API_KEY"
     ],
     "sandbox0": [
       "SANDBOX0_TOKEN"
@@ -240,7 +240,8 @@
     "cloudflare-ai-gateway": [
       "CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID",
       "CLOUDFLARE_AI_GATEWAY_GATEWAY_ID",
-      "ANTHROPIC_API_KEY"
+      "ANTHROPIC_API_KEY",
+      "CLOUDFLARE_AI_GATEWAY_TOKEN"
     ],
     "llmgateway": [
       "LLM_GATEWAY_API_KEY"

--- a/benchmarks/scripts/provider-vars.json
+++ b/benchmarks/scripts/provider-vars.json
@@ -240,8 +240,8 @@
     "cloudflare-ai-gateway": [
       "CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID",
       "CLOUDFLARE_AI_GATEWAY_GATEWAY_ID",
-      "ANTHROPIC_API_KEY",
-      "CLOUDFLARE_AI_GATEWAY_TOKEN"
+      "CLOUDFLARE_AI_GATEWAY_TOKEN",
+      "ANTHROPIC_API_KEY"
     ],
     "llmgateway": [
       "LLM_GATEWAY_API_KEY"


### PR DESCRIPTION
## Summary

The `benchmarks-daily` run was failing every Cloudflare AI Gateway probe with `HTTP 401: ... code 2009 Unauthorized` (e.g. [run 32014160077](https://github.com/computesdk/benchmarks-daily/actions/runs/32014160077/job/95340194582)). The probe was sending the Anthropic API key but not `cf-aig-authorization`, because `CLOUDFLARE_AI_GATEWAY_TOKEN` was not in the provider's `requiredEnvVars` and therefore wasn't loaded from the Namespace vault.

Cloudflare AI Gateway in the `benchmarks-daily` environment requires authenticated gateway access, so the token should be required rather than optional.

## Changes

- Moved `CLOUDFLARE_AI_GATEWAY_TOKEN` into `requiredEnvVars` for `cloudflare-ai-gateway` in `benchmarks/ai-gateway/providers.ts`.
- Regenerated `benchmarks/scripts/provider-vars.json` so the daily workflow now loads:
  ```json
  [
    "CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID",
    "CLOUDFLARE_AI_GATEWAY_GATEWAY_ID",
    "CLOUDFLARE_AI_GATEWAY_TOKEN",
    "ANTHROPIC_API_KEY"
  ]
  ```
- Updated `AI_GATEWAYS.md` to list `CLOUDFLARE_AI_GATEWAY_TOKEN` as required.

With this change, if `CLOUDFLARE_AI_GATEWAY_TOKEN` is present in the Namespace vault, Cloudflare AI Gateway will be sent the `cf-aig-authorization` header and the 401 will stop. If the token is missing, the runner will now skip the provider with a clear "missing env var" message instead of failing each probe.

Link to Devin session: https://app.devin.ai/sessions/37e60accc4ca49bda1bfba4e473f3a8d
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->