### PR TITLE
chore(deps): bump @computesdk/runloop to ^1.3.56

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@computesdk/quilt": "^1.0.3",
     "@computesdk/railway": "^2.0.2",
     "@computesdk/run-cloud": "^1.0.2",
-    "@computesdk/runloop": "^1.3.55",
+    "@computesdk/runloop": "^1.3.56",
     "@computesdk/sail": "^1.0.2",
     "@computesdk/sandbox0": "^1.0.3",
     "@computesdk/sprites": "^0.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@computesdk/runloop':
-        specifier: ^1.3.55
-        version: 1.3.55
+        specifier: ^1.3.56
+        version: 1.3.56
       '@computesdk/sail':
         specifier: ^1.0.2
         version: 1.0.2
@@ -730,8 +730,8 @@ packages:
     resolution: {integrity: sha512-MWnfZc8F4Fw5CgdEVRagKMgektHZ8f76O/7EbEs3v5tI9i38mjMxzs9BsLZFbpUkmkGtEtHwl7vofA02iNMsGw==}
     engines: {node: '>=20'}
 
-  '@computesdk/runloop@1.3.55':
-    resolution: {integrity: sha512-FcPuuwWKp3O6X4kB0+poV/LZ++xKaHiv8cpzVqLLQhlA4f5MzoW70KhA4rs8HDMesL9yxDdfbGMGwV3zC6fH7Q==}
+  '@computesdk/runloop@1.3.56':
+    resolution: {integrity: sha512-FPonGX7+xVqFC5WjAlmhE+URPPe7Qg6k9fO6b72COlFZUUHdwTGDlr8vNKAq3K5o2Gf82mi1M5l5iJ6p79x76A==}
 
   '@computesdk/sail@1.0.2':
     resolution: {integrity: sha512-mHGNRD4Qc6hB0XGn6zJpw7epvGQvbnwWVluJGcGe8KtK6VrysHlhNwEByjSaz/JMcPKc/rDqnzkiY7XRsy/afA==}
@@ -6397,7 +6397,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@computesdk/runloop@1.3.55':
+  '@computesdk/runloop@1.3.56':
     dependencies:
       '@computesdk/provider': 2.1.5
       '@runloop/api-client': 1.28.0


### PR DESCRIPTION
## Summary

Bumps `@computesdk/runloop` from `^1.3.55` to `^1.3.56` and refreshes `pnpm-lock.yaml` to the latest published version. `pnpm install` and `pnpm typecheck` both passed locally.

Link to Devin session: https://app.devin.ai/sessions/d7c6018d34e04bd5b7f0b5ccafe280e4
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->