### PR TITLE
chore: add changesets for onScore and submitRunSummary

### DIFF
--- a/.changeset/benchsdk-client-submitRunSummary.md
+++ b/.changeset/benchsdk-client-submitRunSummary.md
@@ -1,0 +1,5 @@
+---
+"@benchsdk/client": minor
+---
+
+Adds `submitRunSummary(benchmarkSlug, runId, input)` to `BenchmarkClient`, plus `BenchmarkRunSummaryInput`, `BenchmarkRunSummaryRunMetadata`, `BenchmarkRunSummaryResult`, `BenchmarkRunSummaryMetric`, and `BenchmarkRunSummaryScalar` types. Posts to `POST /benchmarks/{slug}/runs/{runId}/summary`.

--- a/.changeset/benchsdk-runner-onscore.md
+++ b/.changeset/benchsdk-runner-onscore.md
@@ -1,0 +1,5 @@
+---
+"@benchsdk/runner": minor
+---
+
+Adds `onScore` to `BenchmarkConfig`. The runner invokes `onScore(lowerIsBetter, higherIsBetter)` after a run, computes per-participant composite scores with `score(outcome, spec)`, and posts the scored summary to the platform via `BenchmarkClient.submitRunSummary`. Includes `lowerIsBetter`, `higherIsBetter`, `score`, `MetricScoring`, `ScoringSpec`, and `BenchmarkScoreResult` exports. Existing `onComplete` / legacy `latest.json` flows remain unchanged.


### PR DESCRIPTION
## Summary

Adds the missing changesets for the `onScore` scoring hook, `score()` / `lowerIsBetter()` / `higherIsBetter()` primitives, and the `submitRunSummary` client method that were shipped in #316.

- `@benchsdk/runner`: `onScore`, `score()`, `lowerIsBetter`, `higherIsBetter`, `ScoringSpec`, `MetricScoring`, and `BenchmarkScoreResult`.
- `@benchsdk/client`: `submitRunSummary` plus `BenchmarkRunSummary*` types.

These changesets capture the minor-version bumps that should have been included with that PR.


Link to Devin session: https://app.devin.ai/sessions/c891f330f5784bbd8499cf2cc21e4e41
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->