### PR TITLE
fix(ai-gateway): use record.data.mode for phase filtering in onScore

### DIFF
--- a/benchmarks/ai-gateway/ai-gateway.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway.bench.ts
@@ -147,13 +147,13 @@ export const config = defineBenchmarkConfig({
       lowerIsBetter('coldE2eMs', {
         unit: 'ms',
         ceiling: 20000,
-        value: (record) => ((record.data?.phase as string | undefined) === 'cold' && typeof record.latencyMs === 'number' ? record.latencyMs : undefined),
+        value: (record) => ((record.data?.mode as string | undefined) === 'cold' && typeof record.latencyMs === 'number' ? record.latencyMs : undefined),
         weights: { median: 0.30, p95: 0.15, p99: 0 },
       }),
       lowerIsBetter('warmTtftMs', {
         unit: 'ms',
         ceiling: 20000,
-        value: (record) => ((record.data?.phase as string | undefined) === 'warm' && typeof record.latencyMs === 'number' ? record.latencyMs : undefined),
+        value: (record) => ((record.data?.mode as string | undefined) === 'warm' && typeof record.latencyMs === 'number' ? record.latencyMs : undefined),
         weights: { median: 0.30, p95: 0.15, p99: 0 },
       }),
       higherIsBetter('outputTokensPerSec', {


### PR DESCRIPTION
## Summary

The `ai-gateway` scoring metrics `coldE2eMs` and `warmTtftMs` were checking `record.data?.phase`, but the task result only stores the phase in `data.mode`. This caused those metrics to find no samples and get skipped, so the composite score was being computed from only `outputTokensPerSec`.

Update the `value` callbacks to read `record.data?.mode` instead.

Link to Devin session: https://app.devin.ai/sessions/c891f330f5784bbd8499cf2cc21e4e41
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->