### PR TITLE
ci(ai-gateway-benchmarks): remove Ramp from dispatch options and vault filter

### DIFF
--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -42,7 +42,6 @@ on:
           - pydantic-ai-gateway
           - concentrate-ai-gateway
           - novita
-          - ramp
           - neon
           - ngrok
           - anthropic-direct
@@ -141,7 +140,7 @@ jobs:
           INPUT_ITERATIONS: ${{ github.event.inputs.iterations }}
           FAMILY_ITERATIONS: ${{ matrix.family.iterations }}
         run: |
-          . benchmarks/scripts/load-vault-secrets.sh '^(ANTHROPIC_API_KEY|OPENAI_API_KEY|GEMINI_API_KEY|KIMI_API_KEY|NOVITA_API_KEY|RAMP_ROUTER_API_KEY|NEON_AI_GATEWAY_BASE_URL|NEON_AI_GATEWAY_TOKEN|NGROK_AI_GATEWAY_API_KEY|CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID|CLOUDFLARE_AI_GATEWAY_GATEWAY_ID|CLOUDFLARE_AI_GATEWAY_TOKEN|LLM_GATEWAY_API_KEY|OPENROUTER_API_KEY|PYDANTIC_AI_GATEWAY_API_KEY|VERCEL_AI_GATEWAY_API_KEY|CONCENTRATE_AI_GATEWAY_API_KEY|COMPUTESDK_ADMIN_API_KEY|BENCHMARKS_PLATFORM_API_KEY)'
+          . benchmarks/scripts/load-vault-secrets.sh '^(ANTHROPIC_API_KEY|OPENAI_API_KEY|GEMINI_API_KEY|KIMI_API_KEY|NOVITA_API_KEY|NEON_AI_GATEWAY_BASE_URL|NEON_AI_GATEWAY_TOKEN|NGROK_AI_GATEWAY_API_KEY|CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID|CLOUDFLARE_AI_GATEWAY_GATEWAY_ID|CLOUDFLARE_AI_GATEWAY_TOKEN|LLM_GATEWAY_API_KEY|OPENROUTER_API_KEY|PYDANTIC_AI_GATEWAY_API_KEY|VERCEL_AI_GATEWAY_API_KEY|CONCENTRATE_AI_GATEWAY_API_KEY|COMPUTESDK_ADMIN_API_KEY|BENCHMARKS_PLATFORM_API_KEY)'
 
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "schedule" ]; then
             ITERATIONS="10"
@@ -200,7 +199,6 @@ jobs:
               'gemini-direct': 'Gemini (direct)',
               'kimi-direct': 'Kimi (direct)',
               'novita': 'Novita',
-              'ramp': 'Ramp Router',
               'neon': 'Neon AI Gateway',
               'ngrok': 'ngrok AI Gateway',
             };


### PR DESCRIPTION
## Summary

Temporarily removes **Ramp Router** from the AI Gateway benchmark workflow so it is not run in CI:

- Drops `ramp` from the `provider` `workflow_dispatch` choice list.
- Removes `RAMP_ROUTER_API_KEY` from the `load-vault-secrets.sh` regex so the credential is not loaded, causing the benchmark runner to skip Ramp participants at runtime.
- Removes the `'ramp': 'Ramp Router'` label from the results-posting `nameFor` map.

The Ramp provider configs in `benchmarks/ai-gateway/providers*.ts` are left untouched so it can be re-enabled by reverting this workflow change once you are ready to run it live.

Link to Devin session: https://app.devin.ai/sessions/3e3d5aaa6cbf4e129777af1f7bb2c24e
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->