### PR TITLE
feat(dax): request an 8 vCPU / 16 GiB MIOSA box for the Dax build

### DIFF
--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -86,6 +86,7 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   opencomputer: { cpuCount: 4, memoryMB: 16384, timeout: 600_000 },
   microsandbox: { cpus: 8, memoryMib: 16384 },
   mosaic:       { vcpus: 8, memoryMb: 16384 },
+  miosa:        { vcpus: 8, memory: 16384 },               // maps to MIOSA size contract "large" (8 vCPU / 16 GiB)
   // Sandbox0 exposes only memory. Override the 128 MiB TTI size;
   // getSandboxOptionsWithResources preserves hardTtl from providers.ts.
   miosa:        { vcpus: 8, memory: 16384 },

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -89,7 +89,6 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   miosa:        { vcpus: 8, memory: 16384 },               // maps to MIOSA size contract "large" (8 vCPU / 16 GiB)
   // Sandbox0 exposes only memory. Override the 128 MiB TTI size;
   // getSandboxOptionsWithResources preserves hardTtl from providers.ts.
-  miosa:        { vcpus: 8, memory: 16384 },
   sandbox0:     { memory: 16384 },
   sail:         { size: 'l' },
 };

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -88,6 +88,7 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
   mosaic:       { vcpus: 8, memoryMb: 16384 },
   // Sandbox0 exposes only memory. Override the 128 MiB TTI size;
   // getSandboxOptionsWithResources preserves hardTtl from providers.ts.
+  miosa:        { vcpus: 8, memory: 16384 },
   sandbox0:     { memory: 16384 },
   sail:         { size: 'l' },
 };


### PR DESCRIPTION
The Dax typecheck runs nine concurrent `tsgo` workers and peaks past 4.5 GiB; MIOSA's default shape is 2 vCPU / 4 GiB, so the run OOMs. This adds miosa to `DAX_RESOURCE_OPTIONS` requesting 8 vCPU / 16 GiB via the standard resource hints — the same class E2B and Superserve use for these runs via their purpose-built templates.

Depends on computesdk/computesdk#718, which teaches the miosa provider to map `vcpus`/`memory` onto MIOSA size contracts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->