### PR TITLE
chore(deps): bump @computesdk/miosa to ^1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "@computesdk/lelantos": "^0.2.3",
     "@computesdk/lightning": "^1.0.3",
     "@computesdk/microsandbox": "^0.1.1",
-    "@computesdk/miosa": "^1.0.1",
+    "@computesdk/miosa": "^1.0.2",
     "@computesdk/modal": "^1.9.5",
     "@computesdk/mosaic": "^0.1.4",
     "@computesdk/namespace": "^1.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1
       '@computesdk/miosa':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.0.2
+        version: 1.0.2
       '@computesdk/modal':
         specifier: ^1.9.5
         version: 1.9.5
@@ -704,8 +704,8 @@ packages:
     resolution: {integrity: sha512-WgD9YUjCFTOONHQr+IR8X8vumO4EX69wckT5c3PM4bRfWrFXtPk88lP9ZjWr6sGvH6K1U6hFX4c69x3my/G0Yw==}
     engines: {node: '>=22'}
 
-  '@computesdk/miosa@1.0.1':
-    resolution: {integrity: sha512-9yr0zWbbiOQ2Ln/64UD8W+YiStWgwN25g0F/BJkBIgCS8kNVMoH7HuNnIKNIaLy2yqiMO34KOBd2JKfslIooJQ==}
+  '@computesdk/miosa@1.0.2':
+    resolution: {integrity: sha512-IHbQwtX2+sCDHqHIYvE1ZPDiGJU2FCCq7Fl1VtJqmebRLOIgGy1DC8NPK7gFdBF2wv7Of+hukF5h+L+UxEUyDg==}
 
   '@computesdk/modal@1.9.5':
     resolution: {integrity: sha512-WTZZwN73htUFrkRTkCEtNofxS4tmYQwzPPYvdQ4MysjLwq2nZP8gYZk6awloV051o/dG1miZDPBnRHfz9gw/vA==}
@@ -6380,7 +6380,7 @@ snapshots:
       computesdk: 4.1.4
       microsandbox: 0.6.10
 
-  '@computesdk/miosa@1.0.1':
+  '@computesdk/miosa@1.0.2':
     dependencies:
       '@computesdk/provider': 2.1.5
       computesdk: 4.1.4


### PR DESCRIPTION
## Summary

Bumps `@computesdk/miosa` from `^1.0.1` to `^1.0.2` in `package.json` and updates `pnpm-lock.yaml` accordingly.

```
package.json
- "@computesdk/miosa": "^1.0.1",
+ "@computesdk/miosa": "^1.0.2",
```

Ran `pnpm install` to regenerate the lockfile entry for the new version.

Link to Devin session: https://app.devin.ai/sessions/c25a9facc51344909dae145d6accbd0a
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->