### PR TITLE
fix(benchmarks/scripts): prevent load-vault-secrets.sh from aborting when last secret value is empty

### DIFF
--- a/benchmarks/scripts/load-vault-secrets.sh
+++ b/benchmarks/scripts/load-vault-secrets.sh
@@ -61,5 +61,7 @@ eval "$(nsc vault export --envdef /tmp/vault.envdef --shell=bash)"
 # call; GH Actions splits the value internally so each line gets masked.
 awk -F= '{print $1}' /tmp/vault.envdef | while IFS= read -r key; do
   v="${!key-}"
-  [ -n "$v" ] && echo "::add-mask::$v"
+  if [ -n "$v" ]; then
+    echo "::add-mask::$v"
+  fi
 done


### PR DESCRIPTION
The `::add-mask::` loop at the end of `benchmarks/scripts/load-vault-secrets.sh` used `[ -n "$v" ] && echo ...`, so the final iteration of the `while` loop returned `1` whenever the last exported secret value was empty. Because the workflow step runs with `bash -e`, that non-zero status aborted the step before `npx tsx` was invoked, producing the `envdef line count` line followed by `Process completed with exit code 1` and no benchmark output. Since `nsc vault list` ordering varies by runner, this looked like random providers failing.

Change the conditional to `if [ -n "$v" ]; then echo "::add-mask::$v"; fi` so the loop always exits `0` and the benchmark command runs.

Link to Devin session: https://app.devin.ai/sessions/16e95ed879554249be307c173dfc759d
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->