### PR TITLE
fix(benchmarks/scripts): filter deleted vault entries and add diagnostic counts

### DIFF
--- a/benchmarks/scripts/load-vault-secrets.sh
+++ b/benchmarks/scripts/load-vault-secrets.sh
@@ -35,12 +35,17 @@ nsc version ensure --at_least 0.0.550 >/dev/null
 # project to KEY=<object_id>. Object_ids are random handles; secret VALUES only
 # materialise via the subsequent `nsc vault export`.
 nsc vault list --output json | jq -r '
-  .[]
-  | select((.deleted_at // null) == null)
-  | (.labels // []) as $l
-  | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
-  | select($name | test("^[A-Z][A-Z0-9_]*$"))
-  | "\($name)=\(.object_id)"
+  [ .[]
+    | select((.deleted_at // null) == null)
+    | (.labels // []) as $l
+    | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
+    | select($name | test("^[A-Z][A-Z0-9_]*$"))
+    | {name: $name, object_id: .object_id}
+  ]
+  | group_by(.name)
+  | map(last)
+  | .[]
+  | "\(.name)=\(.object_id)"
 ' | grep -E "$KEYS" > /tmp/vault.envdef
 
 # Diagnostic — surface "did the filter match anything" without leaking the
@@ -52,7 +57,11 @@ if [ ! -s /tmp/vault.envdef ]; then
 fi
 
 # Eval exports each resolved secret into the current shell.
-eval "$(nsc vault export --envdef /tmp/vault.envdef --shell=bash)"
+if ! vault_exported=$(nsc vault export --envdef /tmp/vault.envdef --shell=bash); then
+  echo "::error::nsc vault export failed to resolve secrets" >&2
+  return 1 2>/dev/null || exit 1
+fi
+eval "$vault_exported"
 
 # Re-mask each loaded value with GH Actions workflow-command masking. Bare
 # `export KEY=value` (from the eval'd `cat /tmp/X` heredoc) is NOT auto-redacted
@@ -60,9 +69,15 @@ eval "$(nsc vault export --envdef /tmp/vault.envdef --shell=bash)"
 # happens to include the value (e.g. a stack trace printing GCS_PRIVATE_KEY) is
 # masked here. Multi-line values like PEM keys register as one `::add-mask::`
 # call; GH Actions splits the value internally so each line gets masked.
-awk -F= '{print $1}' /tmp/vault.envdef | while IFS= read -r key; do
+resolved_count=0
+missing_count=0
+while IFS= read -r key; do
   v="${!key-}"
   if [ -n "$v" ]; then
     echo "::add-mask::$v"
+    resolved_count=$((resolved_count + 1))
+  else
+    missing_count=$((missing_count + 1))
   fi
-done
+done < <(awk -F= '{print $1}' /tmp/vault.envdef)
+echo "::notice::load-vault-secrets.sh: resolved ${resolved_count} keys, ${missing_count} missing/empty"

--- a/benchmarks/scripts/load-vault-secrets.sh
+++ b/benchmarks/scripts/load-vault-secrets.sh
@@ -46,7 +46,7 @@ deleted_count=$(jq --arg KEYS "$KEYS_REGEX" '
     | (.labels // []) as $l
     | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
     | select($name | test("^[A-Z][A-Z0-9_]*$"))
-    | select($name | test($KEYS))
+    | select(($name + "=") | test($KEYS))
   ]
   | length
 ' <<< "$vault_json")
@@ -58,7 +58,7 @@ active_raw_count=$(jq --arg KEYS "$KEYS_REGEX" '
     | (.labels // []) as $l
     | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
     | select($name | test("^[A-Z][A-Z0-9_]*$"))
-    | select($name | test($KEYS))
+    | select(($name + "=") | test($KEYS))
   ]
   | length
 ' <<< "$vault_json")
@@ -70,7 +70,7 @@ jq -r --arg KEYS "$KEYS_REGEX" '
     | (.labels // []) as $l
     | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
     | select($name | test("^[A-Z][A-Z0-9_]*$"))
-    | select($name | test($KEYS))
+    | select(($name + "=") | test($KEYS))
     | {name: $name, object_id: .object_id}
   ]
   | group_by(.name)

--- a/benchmarks/scripts/load-vault-secrets.sh
+++ b/benchmarks/scripts/load-vault-secrets.sh
@@ -35,17 +35,12 @@ nsc version ensure --at_least 0.0.550 >/dev/null
 # project to KEY=<object_id>. Object_ids are random handles; secret VALUES only
 # materialise via the subsequent `nsc vault export`.
 nsc vault list --output json | jq -r '
-  [ .[]
-    | select((.deleted_at // null) == null)
-    | (.labels // []) as $l
-    | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
-    | select($name | test("^[A-Z][A-Z0-9_]*$"))
-    | {name: $name, object_id: .object_id}
-  ]
-  | group_by(.name)
-  | map(last)
-  | .[]
-  | "\(.name)=\(.object_id)"
+  .[]
+  | select((.deleted_at // null) == null)
+  | (.labels // []) as $l
+  | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
+  | select($name | test("^[A-Z][A-Z0-9_]*$"))
+  | "\($name)=\(.object_id)"
 ' | grep -E "$KEYS" > /tmp/vault.envdef
 
 # Diagnostic — surface "did the filter match anything" without leaking the
@@ -57,11 +52,7 @@ if [ ! -s /tmp/vault.envdef ]; then
 fi
 
 # Eval exports each resolved secret into the current shell.
-if ! vault_exported=$(nsc vault export --envdef /tmp/vault.envdef --shell=bash); then
-  echo "::error::nsc vault export failed to resolve secrets" >&2
-  return 1 2>/dev/null || exit 1
-fi
-eval "$vault_exported"
+eval "$(nsc vault export --envdef /tmp/vault.envdef --shell=bash)"
 
 # Re-mask each loaded value with GH Actions workflow-command masking. Bare
 # `export KEY=value` (from the eval'd `cat /tmp/X` heredoc) is NOT auto-redacted
@@ -69,15 +60,9 @@ eval "$vault_exported"
 # happens to include the value (e.g. a stack trace printing GCS_PRIVATE_KEY) is
 # masked here. Multi-line values like PEM keys register as one `::add-mask::`
 # call; GH Actions splits the value internally so each line gets masked.
-resolved_count=0
-missing_count=0
-while IFS= read -r key; do
+awk -F= '{print $1}' /tmp/vault.envdef | while IFS= read -r key; do
   v="${!key-}"
   if [ -n "$v" ]; then
     echo "::add-mask::$v"
-    resolved_count=$((resolved_count + 1))
-  else
-    missing_count=$((missing_count + 1))
   fi
-done < <(awk -F= '{print $1}' /tmp/vault.envdef)
-echo "::notice::load-vault-secrets.sh: resolved ${resolved_count} keys, ${missing_count} missing/empty"
+done

--- a/benchmarks/scripts/load-vault-secrets.sh
+++ b/benchmarks/scripts/load-vault-secrets.sh
@@ -35,11 +35,17 @@ nsc version ensure --at_least 0.0.550 >/dev/null
 # project to KEY=<object_id>. Object_ids are random handles; secret VALUES only
 # materialise via the subsequent `nsc vault export`.
 nsc vault list --output json | jq -r '
-  .[]
-  | (.labels // []) as $l
-  | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
-  | select($name | test("^[A-Z][A-Z0-9_]*$"))
-  | "\($name)=\(.object_id)"
+  [ .[]
+    | select((.deleted_at // null) == null)
+    | (.labels // []) as $l
+    | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
+    | select($name | test("^[A-Z][A-Z0-9_]*$"))
+    | {name: $name, object_id: .object_id}
+  ]
+  | group_by(.name)
+  | map(last)
+  | .[]
+  | "\(.name)=\(.object_id)"
 ' | grep -E "$KEYS" > /tmp/vault.envdef
 
 # Diagnostic — surface "did the filter match anything" without leaking the
@@ -51,7 +57,11 @@ if [ ! -s /tmp/vault.envdef ]; then
 fi
 
 # Eval exports each resolved secret into the current shell.
-eval "$(nsc vault export --envdef /tmp/vault.envdef --shell=bash)"
+if ! vault_exported=$(nsc vault export --envdef /tmp/vault.envdef --shell=bash); then
+  echo "::error::nsc vault export failed to resolve secrets" >&2
+  return 1 2>/dev/null || exit 1
+fi
+eval "$vault_exported"
 
 # Re-mask each loaded value with GH Actions workflow-command masking. Bare
 # `export KEY=value` (from the eval'd `cat /tmp/X` heredoc) is NOT auto-redacted
@@ -59,9 +69,15 @@ eval "$(nsc vault export --envdef /tmp/vault.envdef --shell=bash)"
 # happens to include the value (e.g. a stack trace printing GCS_PRIVATE_KEY) is
 # masked here. Multi-line values like PEM keys register as one `::add-mask::`
 # call; GH Actions splits the value internally so each line gets masked.
-awk -F= '{print $1}' /tmp/vault.envdef | while IFS= read -r key; do
+resolved_count=0
+missing_count=0
+while IFS= read -r key; do
   v="${!key-}"
   if [ -n "$v" ]; then
     echo "::add-mask::$v"
+    resolved_count=$((resolved_count + 1))
+  else
+    missing_count=$((missing_count + 1))
   fi
-done
+done < <(awk -F= '{print $1}' /tmp/vault.envdef)
+echo "::notice::load-vault-secrets.sh: resolved ${resolved_count} keys, ${missing_count} missing/empty"

--- a/benchmarks/scripts/load-vault-secrets.sh
+++ b/benchmarks/scripts/load-vault-secrets.sh
@@ -34,25 +34,58 @@ nsc version ensure --at_least 0.0.550 >/dev/null
 # Pull env-var names from `name=` labels (or `description` as a fallback) and
 # project to KEY=<object_id>. Object_ids are random handles; secret VALUES only
 # materialise via the subsequent `nsc vault export`.
-nsc vault list --output json | jq -r '
+vault_json=$(nsc vault list --output json)
+KEYS_REGEX="$KEYS"
+
+# Diagnostic count of deleted vault objects that match the requested keys.
+# If this is >0, `nsc vault list` is returning deleted entries for active
+# env-vars and that should be reported to Namespace.
+deleted_count=$(jq --arg KEYS "$KEYS_REGEX" '
+  [ .[]
+    | select((.deleted_at // null) != null)
+    | (.labels // []) as $l
+    | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
+    | select($name | test("^[A-Z][A-Z0-9_]*$"))
+    | select($name | test($KEYS))
+  ]
+  | length
+' <<< "$vault_json")
+
+# Count active entries before deduplication so we can detect duplicates.
+active_raw_count=$(jq --arg KEYS "$KEYS_REGEX" '
   [ .[]
     | select((.deleted_at // null) == null)
     | (.labels // []) as $l
     | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
     | select($name | test("^[A-Z][A-Z0-9_]*$"))
+    | select($name | test($KEYS))
+  ]
+  | length
+' <<< "$vault_json")
+
+# Build the envdef from the newest active object per env-var name.
+jq -r --arg KEYS "$KEYS_REGEX" '
+  [ .[]
+    | select((.deleted_at // null) == null)
+    | (.labels // []) as $l
+    | (($l | map(select(.name=="name")) | .[0].value) // .description // "") as $name
+    | select($name | test("^[A-Z][A-Z0-9_]*$"))
+    | select($name | test($KEYS))
     | {name: $name, object_id: .object_id}
   ]
   | group_by(.name)
   | map(last)
   | .[]
   | "\(.name)=\(.object_id)"
-' | grep -E "$KEYS" > /tmp/vault.envdef
+' <<< "$vault_json" > /tmp/vault.envdef
 
-# Diagnostic — surface "did the filter match anything" without leaking the
-# actual KEY=<object_id> mappings into CI logs.
-echo "::notice::envdef line count: $(wc -l < /tmp/vault.envdef)"
+active_unique_count=$(wc -l < /tmp/vault.envdef)
+duplicate_count=$((active_raw_count - active_unique_count))
+
+# Diagnostic — surface counts without leaking KEY=<object_id> mappings.
+echo "::notice::load-vault-secrets.sh: active_raw=${active_raw_count} active_unique=${active_unique_count} duplicates=${duplicate_count} deleted=${deleted_count}"
 if [ ! -s /tmp/vault.envdef ]; then
-  echo "::error::envdef is empty after grep — no vault entries matched KEYS pattern" >&2
+  echo "::error::envdef is empty after filtering — no vault entries matched KEYS pattern" >&2
   return 1 2>/dev/null || exit 1
 fi
 
@@ -80,4 +113,4 @@ while IFS= read -r key; do
     missing_count=$((missing_count + 1))
   fi
 done < <(awk -F= '{print $1}' /tmp/vault.envdef)
-echo "::notice::load-vault-secrets.sh: resolved ${resolved_count} keys, ${missing_count} missing/empty"
+echo "::notice::load-vault-secrets.sh: resolved=${resolved_count} missing=${missing_count}"


### PR DESCRIPTION
## Summary

`nsc vault list` recently started returning deleted vault objects alongside active ones, so the envdef can reference a deleted/empty object for an env-var like `DECLAW_API_KEY`. The script now filters out objects with `deleted_at` set, deduplicates by env-var name, and emits diagnostic counts so we can confirm whether the root cause is on the Namespace vault side.

### Changed

- `jq` filter now `select((.deleted_at // null) == null)` before building the envdef.
- Deduplicates active vault objects per env-var name (`group_by(.name) | map(last)`), keeping the last active entry.
- `nsc vault export` exit status is no longer swallowed by `eval "$(...)"`; a non-zero export now fails the step explicitly.
- Post-export masking loop reports `resolved`/`missing` counts.
- Added pre-filter diagnostics: `active_raw`, `active_unique`, `duplicates`, `deleted` counts are logged without leaking object IDs or values.

This should make the Dax benchmark step actually load keys like `DECLAW_API_KEY` while surfacing whether `nsc vault list` is returning stale/deleted entries.

Link to Devin session: https://app.devin.ai/sessions/16e95ed879554249be307c173dfc759d
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->