### PR TITLE
fix(benchmarks/scripts): log missing vault keys and fail when they resolve empty

### DIFF
--- a/benchmarks/scripts/load-vault-secrets.sh
+++ b/benchmarks/scripts/load-vault-secrets.sh
@@ -104,13 +104,20 @@ eval "$vault_exported"
 # call; GH Actions splits the value internally so each line gets masked.
 resolved_count=0
 missing_count=0
-while IFS= read -r key; do
+missing_keys=""
+while IFS= read -r line; do
+  key="${line%%=*}"
+  object_id="${line#*=}"
   v="${!key-}"
   if [ -n "$v" ]; then
     echo "::add-mask::$v"
     resolved_count=$((resolved_count + 1))
   else
     missing_count=$((missing_count + 1))
+    missing_keys="${missing_keys:+, }${key} (object_id=${object_id})"
   fi
-done < <(awk -F= '{print $1}' /tmp/vault.envdef)
+done < /tmp/vault.envdef
+if [ -n "$missing_keys" ]; then
+  echo "::warning::load-vault-secrets.sh: missing ${missing_count} key(s): ${missing_keys}"
+fi
 echo "::notice::load-vault-secrets.sh: resolved=${resolved_count} missing=${missing_count}"

--- a/benchmarks/scripts/load-vault-secrets.sh
+++ b/benchmarks/scripts/load-vault-secrets.sh
@@ -114,7 +114,7 @@ while IFS= read -r line; do
     resolved_count=$((resolved_count + 1))
   else
     missing_count=$((missing_count + 1))
-    missing_keys="${missing_keys:+, }${key} (object_id=${object_id})"
+    missing_keys="${missing_keys}${missing_keys:+, }${key} (object_id=${object_id})"
   fi
 done < /tmp/vault.envdef
 if [ -n "$missing_keys" ]; then

--- a/benchmarks/scripts/load-vault-secrets.sh
+++ b/benchmarks/scripts/load-vault-secrets.sh
@@ -118,6 +118,7 @@ while IFS= read -r line; do
   fi
 done < /tmp/vault.envdef
 if [ -n "$missing_keys" ]; then
-  echo "::warning::load-vault-secrets.sh: missing ${missing_count} key(s): ${missing_keys}"
+  echo "::error::load-vault-secrets.sh: missing ${missing_count} key(s): ${missing_keys}" >&2
+  return 1 2>/dev/null || exit 1
 fi
 echo "::notice::load-vault-secrets.sh: resolved=${resolved_count} missing=${missing_count}"

--- a/benchmarks/scripts/load-vault-secrets.sh
+++ b/benchmarks/scripts/load-vault-secrets.sh
@@ -119,6 +119,8 @@ while IFS= read -r line; do
 done < /tmp/vault.envdef
 if [ -n "$missing_keys" ]; then
   echo "::error::load-vault-secrets.sh: missing ${missing_count} key(s): ${missing_keys}" >&2
-  return 1 2>/dev/null || exit 1
 fi
 echo "::notice::load-vault-secrets.sh: resolved=${resolved_count} missing=${missing_count}"
+if [ -n "$missing_keys" ]; then
+  return 1 2>/dev/null || exit 1
+fi


### PR DESCRIPTION
## Summary

`nsc vault list` is returning 45 active objects, but `nsc vault export` only resolves 40 of them, so keys like `DECLAW_API_KEY` are silently empty. We need to (1) log exactly which keys and vault object IDs are empty, and (2) make the step fail so the vault problem surfaces instead of the benchmark silently skipping providers.

### Changed

- The post-export loop reads the full `KEY=object_id` line and emits an `::error::` listing every missing key name and its vault `object_id` (no secret values).
- It then prints the `resolved`/`missing` notice and returns `1`, failing the workflow step before `npx tsx` runs.
- This restores the "exit 1 on missing secret" behavior from before #348, but does it deterministically and with diagnostics.

The expected log now looks like:

```
::error::load-vault-secrets.sh: missing 5 key(s): DECLAW_API_KEY (object_id=...), E2B_API_KEY (object_id=...), ...
::notice::load-vault-secrets.sh: resolved=40 missing=5
```

The prior `deleted_at` filter, deduplication, and count diagnostics (`active_raw`, `active_unique`, `duplicates`, `deleted`) remain in place.

### Note

This intentionally turns a previously tolerated condition (some secrets resolving empty) into a step failure. That matches the request to revert #348 so the missing-vault-key issue stops being silently swallowed.

Link to Devin session: https://app.devin.ai/sessions/16e95ed879554249be307c173dfc759d
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->