### PR TITLE
fix: exclude failed/null TTI iterations from legacy and platform aggregates

### DIFF
--- a/benchmarks/sandbox/legacy-results.ts
+++ b/benchmarks/sandbox/legacy-results.ts
@@ -55,12 +55,12 @@ export function recordsToSandboxResults(
   return participants.map((participant) => {
     const records = byTaskIndex(participant.records);
     const iterations = records.map((r) => {
-      const ttiMs = typeof r.data?.ttiMs === 'number' ? r.data.ttiMs : 0;
+      const ttiMs = typeof r.data?.ttiMs === 'number' ? r.data.ttiMs : undefined;
       return r.status === 'error'
-        ? { ttiMs, error: r.errorCode ?? 'error' }
+        ? { error: r.errorCode ?? 'error' }
         : { ttiMs };
     });
-    const successful = iterations.filter((i) => !i.error);
+    const successful = iterations.filter((i): i is { ttiMs: number } => !i.error && i.ttiMs != null);
     const summary = {
       ttiMs:
         successful.length > 0

--- a/benchmarks/sandbox/table.ts
+++ b/benchmarks/sandbox/table.ts
@@ -139,7 +139,7 @@ export async function writeResultsJson(results: BenchmarkResult[], outPath: stri
       })),
     } : {}),
     iterations: r.iterations.map(i => ({
-      ttiMs: round(i.ttiMs),
+      ...(i.ttiMs != null ? { ttiMs: round(i.ttiMs) } : {}),
       ...(i.error ? { error: i.error } : {}),
     })),
     summary: {

--- a/benchmarks/sandbox/types.ts
+++ b/benchmarks/sandbox/types.ts
@@ -17,7 +17,7 @@ export interface ProviderConfig {
 
 export interface TimingResult {
   /** Total time from start to first successful code execution */
-  ttiMs: number;
+  ttiMs?: number;
   /** Error message if this iteration failed */
   error?: string;
 }

--- a/benchmarks/scripts/backfill.ts
+++ b/benchmarks/scripts/backfill.ts
@@ -88,8 +88,12 @@ function percentile(sortedValues: number[], p: number): number {
 function ttiPercentiles(r: any): { median: number; p95: number; p99: number } {
   const { median, p95, p99 } = r.summary.ttiMs;
   if (p95 != null && p99 != null) return { median, p95, p99 };
-  // Old format: compute from raw iterations
-  const values = (r.iterations as any[]).map((it: any) => it.ttiMs as number).sort((a, b) => a - b);
+  // Old format: compute from raw iterations; skip failed iterations that
+  // were previously emitted as `ttiMs: 0`.
+  const values = (r.iterations as any[])
+    .filter((it: any) => !it.error && typeof it.ttiMs === 'number')
+    .map((it: any) => it.ttiMs as number)
+    .sort((a, b) => a - b);
   return {
     median,
     p95: percentile(values, 95),


### PR DESCRIPTION
## Summary
Failed sandbox TTI iterations were still being treated as `0 ms` in legacy result files and backfill calculations, which could pull down (or, in some cases, inflate) median TTI rankings.

- `TimingResult.ttiMs` is now optional so error iterations can omit it entirely.
- `legacy-results.ts` no longer emits `ttiMs: 0` for failed iterations and only includes numeric `ttiMs` values when computing the summary stats.
- `table.ts` serializes `ttiMs` only when it exists, preventing `0`/`NaN` from being written for errors.
- `backfill.ts` filters out failed/non-numeric `ttiMs` before computing percentile fallbacks from old-format `latest.json` files.

This keeps the legacy `latest.json` output aligned with the platform-side `status = 'success'` filtering so failures do not count as `0 ms`.

Link to Devin session: https://app.devin.ai/sessions/e8b73f58be604fd7a1bac9916dd7d19a
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->