### PR TITLE
chore(benchmarks): update remaining @benchsdk/client imports to @benchsdk/api

### DIFF
--- a/benchmarks/ai-gateway/legacy-results.ts
+++ b/benchmarks/ai-gateway/legacy-results.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, copyFileSync } from 'node:fs';
 import path from 'node:path';
 import type { ParticipantRecords } from '@benchsdk/runner';
-import type { JsonObject, TaskResultRecord, TaskStepRecord } from '@benchsdk/client';
+import type { JsonObject, TaskResultRecord, TaskStepRecord } from '@benchsdk/api';
 import { byTaskIndex } from '../src/util/records.js';
 import { computeStats } from '../src/util/stats.js';
 import { writeAIGatewayResultsJson } from './benchmark.js';

--- a/benchmarks/ai-gateway/shared-task.ts
+++ b/benchmarks/ai-gateway/shared-task.ts
@@ -19,7 +19,7 @@
  */
 import { TaskError } from '@benchsdk/runner';
 import type { TaskContext, TaskResult } from '@benchsdk/runner';
-import type { JsonObject, TaskStepRecord } from '@benchsdk/client';
+import type { JsonObject, TaskStepRecord } from '@benchsdk/api';
 import { runColdProbe, runWarmProbe } from './phase-probe.js';
 import type { AIGatewayProviderConfig, PhaseProbeResult } from './types.js';
 

--- a/benchmarks/browser/browser-throughput-legacy-results.ts
+++ b/benchmarks/browser/browser-throughput-legacy-results.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, copyFileSync } from 'node:fs';
 import path from 'node:path';
 import type { ParticipantRecords } from '@benchsdk/runner';
-import type { JsonObject } from '@benchsdk/client';
+import type { JsonObject } from '@benchsdk/api';
 import { byTaskIndex } from '../src/util/records.js';
 import { summarizeIterations, writeThroughputResultsJson } from './throughput-benchmark.js';
 import { computeThroughputCompositeScores } from './throughput-scoring.js';

--- a/benchmarks/browser/browser-throughput.bench.ts
+++ b/benchmarks/browser/browser-throughput.bench.ts
@@ -17,7 +17,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { chromium, type Browser, type Page } from 'playwright-core';
 import { defineBenchmarkConfig, defineTask, TaskError } from '@benchsdk/runner';
-import type { JsonValue } from '@benchsdk/client';
+import type { JsonValue } from '@benchsdk/api';
 import { withTimeout } from '../src/util/timeout.js';
 import { throughputProviders } from './throughput-providers.js';
 import { writeThroughputLegacyResults } from './browser-throughput-legacy-results.js';

--- a/benchmarks/browser/legacy-results.ts
+++ b/benchmarks/browser/legacy-results.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, copyFileSync } from 'node:fs';
 import path from 'node:path';
 import type { ParticipantRecords } from '@benchsdk/runner';
-import type { JsonObject } from '@benchsdk/client';
+import type { JsonObject } from '@benchsdk/api';
 import { byTaskIndex } from '../src/util/records.js';
 import { computeStats } from '../src/util/stats.js';
 import { computeBrowserCompositeScores } from './scoring.js';

--- a/benchmarks/sandbox/dax-legacy-results.ts
+++ b/benchmarks/sandbox/dax-legacy-results.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, copyFileSync } from 'node:fs';
 import path from 'node:path';
 import type { ParticipantRecords } from '@benchsdk/runner';
-import type { JsonObject, TaskResultRecord } from '@benchsdk/client';
+import type { JsonObject, TaskResultRecord } from '@benchsdk/api';
 import { byTaskIndex } from '../src/util/records.js';
 import { summarize, emptySummary, writeDaxResultsJson } from './dax.js';
 import type { DaxBenchmarkResult, DaxTimingResult } from './dax.js';

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -20,7 +20,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineBenchmarkConfig, defineTask, TaskError } from '@benchsdk/runner';
-import type { JsonObject, TaskStepRecord } from '@benchsdk/client';
+import type { JsonObject, TaskStepRecord } from '@benchsdk/api';
 import { VMTier } from '@codesandbox/sdk';
 import { withTimeout } from '../src/util/timeout.js';
 import { formatError } from '../src/util/error.js';

--- a/benchmarks/sandbox/legacy-results.ts
+++ b/benchmarks/sandbox/legacy-results.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, copyFileSync } from 'node:fs';
 import path from 'node:path';
 import type { ParticipantRecords } from '@benchsdk/runner';
-import type { TaskResultRecord } from '@benchsdk/client';
+import type { TaskResultRecord } from '@benchsdk/api';
 import { byTaskIndex } from '../src/util/records.js';
 import { computeStats } from '../src/util/stats.js';
 import { computeCompositeScores } from './scoring.js';

--- a/benchmarks/src/util/records.ts
+++ b/benchmarks/src/util/records.ts
@@ -1,4 +1,4 @@
-import type { TaskResultRecord } from '@benchsdk/client';
+import type { TaskResultRecord } from '@benchsdk/api';
 
 /**
  * Platform records arrive in completion order, while the legacy result files

--- a/benchmarks/storage/legacy-results.ts
+++ b/benchmarks/storage/legacy-results.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, copyFileSync } from 'node:fs';
 import path from 'node:path';
 import type { ParticipantRecords } from '@benchsdk/runner';
-import type { JsonObject } from '@benchsdk/client';
+import type { JsonObject } from '@benchsdk/api';
 import { byTaskIndex } from '../src/util/records.js';
 import { computeStats } from './stats.js';
 import { computeStorageCompositeScores } from './scoring.js';

--- a/benchmarks/storage/snapshot-fork-legacy-results.ts
+++ b/benchmarks/storage/snapshot-fork-legacy-results.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, copyFileSync } from 'node:fs';
 import path from 'node:path';
 import type { ParticipantRecords } from '@benchsdk/runner';
-import type { JsonObject } from '@benchsdk/client';
+import type { JsonObject } from '@benchsdk/api';
 import { byTaskIndex } from '../src/util/records.js';
 import { computeStats } from './stats.js';
 import { computeSnapshotForkCompositeScores, writeSnapshotForkResultsJson } from './snapshot-fork-benchmark.js';

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@aws-sdk/s3-presigned-post": "^3.1115.0",
     "@aws-sdk/s3-request-presigner": "^3.1115.0",
     "@azure/storage-blob": "^12.33.0",
+    "@benchsdk/api": "workspace:*",
     "@benchsdk/client": "workspace:*",
     "@benchsdk/runner": "workspace:*",
     "@codesandbox/sdk": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@azure/storage-blob':
         specifier: ^12.33.0
         version: 12.33.0
+      '@benchsdk/api':
+        specifier: workspace:*
+        version: link:packages/benchsdk-api
       '@benchsdk/client':
         specifier: workspace:*
         version: link:packages/benchsdk


### PR DESCRIPTION
## Summary

After the SDK split into `@benchsdk/api`/`@benchsdk/worker`/`@benchsdk/client`, a number of benchmark files still imported platform types from the umbrella `@benchsdk/client` package. This PR points those imports at `@benchsdk/api` so the benchmark code matches the package boundaries used by the runner.

- Replaced `@benchsdk/client` type imports with `@benchsdk/api` in `benchmarks/{ai-gateway,browser,sandbox,storage,src/util}`.
- Added `@benchsdk/api` to the root `package.json` so top-level benchmark files can resolve it directly.
- Left the archived `benchmarks/scale/` scripts on `@benchsdk/client`.

Link to Devin session: https://app.devin.ai/sessions/e5c1507360b24f6f89327ccc975ae961
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->