### PR TITLE
docs(readme): add AI Gateway benchmark SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,22 @@ For full details on each suite, see:
 
 ![DAX Sandbox Builds](./dax.svg)
 
+### [AI Gateway - Anthropic](#ai-gateway-anthropic)
+
+![AI Gateway - Anthropic](./ai-gateway.svg)
+
+### [AI Gateway - OpenAI](#ai-gateway-openai)
+
+![AI Gateway - OpenAI](./ai-gateway-openai.svg)
+
+### [AI Gateway - Gemini](#ai-gateway-gemini)
+
+![AI Gateway - Gemini](./ai-gateway-gemini.svg)
+
+### [AI Gateway - Kimi](#ai-gateway-kimi)
+
+![AI Gateway - Kimi](./ai-gateway-kimi.svg)
+
 ## Roadmap
 
 - [x] computesdk.com/benchmarks

--- a/README.md
+++ b/README.md
@@ -133,19 +133,19 @@ For full details on each suite, see:
 
 ![DAX Sandbox Builds](./dax.svg)
 
-### [AI Gateway - Anthropic](#ai-gateway-anthropic)
+### [AI Gateway - Anthropic](#ai-gateway---anthropic)
 
 ![AI Gateway - Anthropic](./ai-gateway.svg)
 
-### [AI Gateway - OpenAI](#ai-gateway-openai)
+### [AI Gateway - OpenAI](#ai-gateway---openai)
 
 ![AI Gateway - OpenAI](./ai-gateway-openai.svg)
 
-### [AI Gateway - Gemini](#ai-gateway-gemini)
+### [AI Gateway - Gemini](#ai-gateway---gemini)
 
 ![AI Gateway - Gemini](./ai-gateway-gemini.svg)
 
-### [AI Gateway - Kimi](#ai-gateway-kimi)
+### [AI Gateway - Kimi](#ai-gateway---kimi)
 
 ![AI Gateway - Kimi](./ai-gateway-kimi.svg)
 


### PR DESCRIPTION
## Summary

The `Latest Benchmarks` section in `README.md` lists charts for every benchmark except AI gateway. The workflow already generates and commits `ai-gateway.svg` (Anthropic), `ai-gateway-openai.svg`, `ai-gateway-gemini.svg`, and `ai-gateway-kimi.svg`, but they were never referenced in the README.

This adds an `AI Gateway` section under `Latest Benchmarks` with all four family SVGs so the published results render the same way as the other benchmark charts.

Link to Devin session: https://app.devin.ai/sessions/0d04702d60b24616a72c3e38eab9b31a
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->