### PR TITLE
benchsdk: improve worker logging with leveled output, step capture, incremental flush, compression, and artifact downloads

### DIFF
--- a/packages/benchsdk-api/src/client.ts
+++ b/packages/benchsdk-api/src/client.ts
@@ -1,6 +1,11 @@
+import { gunzip as gunzipCallback } from 'node:zlib';
+import { promisify } from 'node:util';
+
+const gunzip = promisify(gunzipCallback);
 import type {
-  BenchmarkAssignment,
   BenchmarkArtifact,
+  BenchmarkArtifactDownload,
+  BenchmarkAssignment,
   BenchmarkClient,
   BenchmarkClientConfig,
   BenchmarkParticipant,
@@ -123,6 +128,40 @@ function bodySizeBytes(body: UploadWorkerArtifactInput['body']): number | undefi
   if (ArrayBuffer.isView(body)) return body.byteLength;
   if (body instanceof URLSearchParams) return new TextEncoder().encode(body.toString()).byteLength;
   return undefined;
+}
+
+function isGzipContentType(contentType: string | null | undefined): boolean {
+  if (!contentType) return false;
+  const lowered = contentType.toLowerCase();
+  return lowered.includes('gzip') || lowered.includes('x-gzip') || lowered === 'application/gzip';
+}
+
+async function downloadArtifactBody(
+  doFetch: typeof fetch,
+  url: string,
+  options?: { contentType?: string; decompress?: boolean },
+): Promise<string> {
+  const response = await doFetch(url);
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => '');
+    throw new BenchmarkApiError(
+      `Artifact download failed with ${response.status}`,
+      response.status,
+      errorBody,
+    );
+  }
+  const buffer = await response.arrayBuffer();
+  const responseContentType = response.headers.get('content-type');
+  const contentType = options?.contentType ?? responseContentType ?? '';
+  if (isGzipContentType(contentType) || options?.decompress) {
+    try {
+      const decompressed = await gunzip(new Uint8Array(buffer));
+      return new TextDecoder().decode(decompressed);
+    } catch {
+      // Fall through and return the raw body if decompression fails.
+    }
+  }
+  return new TextDecoder().decode(buffer);
 }
 
 export function createBenchmarkClient(config: BenchmarkClientConfig = {}): BenchmarkClient {
@@ -401,6 +440,27 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
         `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/workers/${encodePath(workerId)}/artifacts`,
       );
       return normalizeArtifacts(data);
+    },
+
+    async getWorkerArtifact(benchmarkSlug, runId, workerId, artifactId) {
+      return request<BenchmarkArtifactDownload>(
+        'GET',
+        `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/workers/${encodePath(workerId)}/artifacts/${encodePath(artifactId)}`,
+      );
+    },
+
+    downloadArtifact(url, options) {
+      return downloadArtifactBody(doFetch, url, options);
+    },
+
+    async downloadWorkerArtifact(benchmarkSlug, runId, workerId, artifactId) {
+      const { artifact, downloadUrl } = await client.getWorkerArtifact(
+        benchmarkSlug,
+        runId,
+        workerId,
+        artifactId,
+      );
+      return downloadArtifactBody(doFetch, downloadUrl, { contentType: artifact.contentType ?? undefined });
     },
 
     async getBenchmarkResults(benchmarkSlug, input: BenchmarkResultsOverviewInput = {}) {

--- a/packages/benchsdk-api/src/index.ts
+++ b/packages/benchsdk-api/src/index.ts
@@ -1,10 +1,14 @@
 export { BenchmarkApiError, createBenchmarkClient } from './client';
 export type {
+  BenchmarkArtifactDownload,
   BenchmarkAssignment,
   BenchmarkArtifact,
   BenchmarkClient,
   BenchmarkClientConfig,
   BenchmarkConcurrencyPoint,
+  BenchmarkLogLevel,
+  BenchmarkLogOptions,
+  BenchmarkStepOutcome,
   BenchmarkAnalyticsReadiness,
   BenchmarkEventRateBucket,
   BenchmarkFailurePoint,

--- a/packages/benchsdk-api/src/types.ts
+++ b/packages/benchsdk-api/src/types.ts
@@ -235,8 +235,17 @@ export interface BenchmarkArtifact {
   objectKey?: string;
   uploadUrl?: string;
   uploadUrlExpiresAt?: string;
+  /** Presigned GET URL for reading an artifact, returned by single-artifact lookups. */
+  downloadUrl?: string;
+  downloadUrlExpiresAt?: string;
   metadata?: JsonObject;
   createdAt?: string;
+}
+
+export interface BenchmarkArtifactDownload {
+  artifact: BenchmarkArtifact;
+  downloadUrl: string;
+  downloadUrlExpiresAt?: string;
 }
 
 export interface CreateWorkerArtifactResponse {
@@ -245,6 +254,19 @@ export interface CreateWorkerArtifactResponse {
   uploadUrl?: string;
   uploadUrlExpiresAt?: string;
   objectKey?: string;
+}
+
+export type BenchmarkLogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface BenchmarkLogOptions {
+  level?: BenchmarkLogLevel;
+  meta?: JsonObject;
+}
+
+export interface BenchmarkStepOutcome {
+  stdout?: string;
+  stderr?: string;
+  error?: string;
 }
 
 export interface BenchmarkResultLatencySummary {
@@ -538,8 +560,12 @@ export interface RunWorkerContext {
    * the platform — step return values are control flow and are never recorded.
    */
   measure(data: JsonObject): void;
-  /** Appends a line to the worker log, uploaded as an artifact when the worker finishes. */
-  log(message: string, meta?: JsonObject): void;
+  /**
+   * Appends a structured line to the worker log. `metaOrOptions` can be a
+   * metadata JSON object, or `{ level, meta }` to set a log level. Levels are
+   * filtered by the worker's configured `logLevel` (defaults to `info`).
+   */
+  log(message: string, metaOrOptions?: JsonObject | BenchmarkLogOptions): void;
 }
 
 export interface WorkerFinishContext {
@@ -565,6 +591,11 @@ export interface DefineStepOptions {
   readyPollIntervalMs?: number;
   /** Maximum time to wait for readiness. Defaults to no timeout. */
   readyTimeoutMs?: number;
+  /**
+   * When true (default), a step that returns a `BenchmarkStepOutcome` with
+   * `stdout`, `stderr`, or `error` strings writes those to the worker log.
+   */
+  captureOutput?: boolean;
 }
 
 /**
@@ -594,6 +625,14 @@ export interface RunWorkerOptions {
   onResult?: (record: TaskResultRecord) => void;
   /** Runs once after final result flush and before worker completion/failure is reported. */
   onFinish?: (context: WorkerFinishContext) => Promise<void> | void;
+  /** Minimum log level to record. Defaults to `BENCHMARK_LOG_LEVEL` env or `info`. */
+  logLevel?: BenchmarkLogLevel;
+  /** Maximum worker log lines before truncation. Defaults to 100,000. */
+  maxLogLines?: number;
+  /** Interval in ms to upload accumulated logs as artifacts mid-run. `0` disables. Defaults to `BENCHMARK_LOG_FLUSH_INTERVAL_MS` env or `0`. */
+  logFlushIntervalMs?: number;
+  /** Compress worker log artifacts with `gzip`. Defaults to `BENCHMARK_LOG_COMPRESSION` env or `false`. */
+  logCompression?: 'gzip' | false;
   task: TaskFunction;
 }
 
@@ -729,6 +768,19 @@ export interface BenchmarkClient {
   ): Promise<CreateWorkerArtifactResponse>;
   listRunArtifacts(benchmarkSlug: string, runId: string): Promise<BenchmarkArtifact[]>;
   listWorkerArtifacts(benchmarkSlug: string, runId: string, workerId: string): Promise<BenchmarkArtifact[]>;
+  getWorkerArtifact(
+    benchmarkSlug: string,
+    runId: string,
+    workerId: string,
+    artifactId: string,
+  ): Promise<BenchmarkArtifactDownload>;
+  downloadArtifact(url: string, options?: { contentType?: string; decompress?: boolean }): Promise<string>;
+  downloadWorkerArtifact(
+    benchmarkSlug: string,
+    runId: string,
+    workerId: string,
+    artifactId: string,
+  ): Promise<string>;
   getBenchmarkResults(benchmarkSlug: string, input?: BenchmarkResultsOverviewInput): Promise<BenchmarkResultsOverview>;
   getRunResults(benchmarkSlug: string, runId: string): Promise<BenchmarkRunResults>;
   getRunTaskResults(

--- a/packages/benchsdk-runner/src/bench-config.ts
+++ b/packages/benchsdk-runner/src/bench-config.ts
@@ -31,6 +31,7 @@
  * recorded.
  */
 import type {
+  BenchmarkLogOptions,
   DefineStepOptions,
   JsonObject,
   TaskResultRecord,
@@ -127,8 +128,11 @@ export interface TaskContext<T extends BaseParticipant = BaseParticipant> {
    * that step's data; at task top-level it lands on the task record's data.
    */
   measure(data: JsonObject): void;
-  /** Appends a line to the worker log, uploaded as an artifact when the worker finishes. */
-  log(message: string, meta?: JsonObject): void;
+  /**
+   * Appends a line to the worker log, uploaded as an artifact when the worker finishes.
+   * `metaOrOptions` can be a metadata JSON object, or `{ level, meta }` to set a log level.
+   */
+  log(message: string, metaOrOptions?: JsonObject | BenchmarkLogOptions): void;
 }
 
 export type BenchmarkTask<T extends BaseParticipant = BaseParticipant> = (

--- a/packages/benchsdk-runner/src/log-buffer.ts
+++ b/packages/benchsdk-runner/src/log-buffer.ts
@@ -1,19 +1,24 @@
+import type { BenchmarkLogLevel, BenchmarkLogOptions, BenchmarkStepOutcome } from '@benchsdk/api';
+
 /**
  * Accumulates one text log per worker across a task's steps, uploaded once as a
  * `coordinator.log` artifact. Used by the runner's manual `round` mode, where
  * `client.runWorker` (which owns log upload in `participant` mode) is not in
  * play.
  */
-export interface StepOutcome {
-  stdout?: string;
-  stderr?: string;
-  error?: string;
+export type StepOutcome = BenchmarkStepOutcome;
+
+function isLogOptions(value: unknown): value is BenchmarkLogOptions {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const keys = Object.keys(value as Record<string, unknown>);
+  if (keys.length === 0) return false;
+  return keys.includes('level') || (keys.includes('meta') && keys.every((k) => k === 'level' || k === 'meta'));
 }
 
 export class LogBuffer {
   private readonly lines: string[] = [];
 
-  step(taskIndex: number, stepName: string, outcome: StepOutcome): void {
+  step(taskIndex: number, stepName: string, outcome: BenchmarkStepOutcome): void {
     const header = `[task ${taskIndex}] ${stepName}`;
     this.lines.push(`${new Date().toISOString()} ${header}`);
     if (outcome.stdout?.trim()) {
@@ -28,9 +33,12 @@ export class LogBuffer {
   }
 
   /** Appends a free-form narration line (backs the task context's `log`). */
-  line(message: string, meta?: Record<string, unknown>): void {
-    const suffix = meta && Object.keys(meta).length > 0 ? ` ${JSON.stringify(meta)}` : '';
-    this.lines.push(`${new Date().toISOString()} ${message}${suffix}`);
+  line(message: string, metaOrOptions?: Record<string, unknown> | BenchmarkLogOptions): void {
+    const opts: { level: BenchmarkLogLevel; meta?: Record<string, unknown> } = isLogOptions(metaOrOptions)
+      ? { level: metaOrOptions.level ?? 'info', meta: metaOrOptions.meta }
+      : { level: 'info', meta: metaOrOptions };
+    const suffix = opts.meta && Object.keys(opts.meta).length > 0 ? ` ${JSON.stringify(opts.meta)}` : '';
+    this.lines.push(`${new Date().toISOString()} ${message} [${opts.level}]${suffix}`);
   }
 
   isEmpty(): boolean {

--- a/packages/benchsdk-runner/src/log-buffer.ts
+++ b/packages/benchsdk-runner/src/log-buffer.ts
@@ -8,11 +8,18 @@ import type { BenchmarkLogLevel, BenchmarkLogOptions, BenchmarkStepOutcome } fro
  */
 export type StepOutcome = BenchmarkStepOutcome;
 
+const LOG_LEVEL_ORDER: BenchmarkLogLevel[] = ['debug', 'info', 'warn', 'error'];
+
 function isLogOptions(value: unknown): value is BenchmarkLogOptions {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-  const keys = Object.keys(value as Record<string, unknown>);
+  const o = value as Record<string, unknown>;
+  const keys = Object.keys(o);
   if (keys.length === 0) return false;
-  return keys.includes('level') || (keys.includes('meta') && keys.every((k) => k === 'level' || k === 'meta'));
+  if (!keys.every((k) => k === 'level' || k === 'meta')) return false;
+  if (o.level !== undefined && (typeof o.level !== 'string' || !LOG_LEVEL_ORDER.includes(o.level as BenchmarkLogLevel))) {
+    return false;
+  }
+  return true;
 }
 
 export class LogBuffer {

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -27,6 +27,8 @@ import { NoAvailableParticipantsError } from './no-available-participants.js';
 import { higherIsBetter, lowerIsBetter, score, ScoringSpecError, scoringConfigToSpec } from './scoring.js';
 import type {
   BenchmarkClient,
+  BenchmarkLogOptions,
+  BenchmarkStepOutcome,
   DefineStepOptions,
   JsonObject,
   RunWorkerContext,
@@ -85,6 +87,15 @@ function sleep(ms: number): Promise<void> {
 
 function getErrorCode(error: unknown): string {
   return error instanceof Error && error.name ? error.name : 'ERROR';
+}
+
+function isStepOutcome(value: unknown): value is BenchmarkStepOutcome {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const o = value as Record<string, unknown>;
+  return (
+    (typeof o.stdout === 'string' || typeof o.stderr === 'string' || typeof o.error === 'string') &&
+    typeof o.then !== 'function'
+  );
 }
 
 function withTimeout<T>(promise: Promise<T>, ms: number, name: string): Promise<T> {
@@ -952,7 +963,11 @@ async function runTaskRecord<T extends BaseParticipant>(
       activeStep = stepRecord;
       try {
         const result = await runStepInvocations<R>(name, fn, options);
-        logBuffer.step(taskIndex, name, {});
+        const outcome: BenchmarkStepOutcome =
+          options?.captureOutput !== false && !Array.isArray(result) && isStepOutcome(result)
+            ? (result as BenchmarkStepOutcome)
+            : {};
+        logBuffer.step(taskIndex, name, outcome);
         return result as C extends 1 ? R : R[];
       } catch (error) {
         stepRecord.status = 'error';
@@ -973,8 +988,8 @@ async function runTaskRecord<T extends BaseParticipant>(
         Object.assign(taskMeasures, data);
       }
     },
-    log(message, meta) {
-      logBuffer.line(`[task ${taskIndex}] ${message}`, meta);
+    log(message, metaOrOptions) {
+      logBuffer.line(`[task ${taskIndex}] ${message}`, metaOrOptions);
     },
   };
 

--- a/packages/benchsdk-worker/src/worker.ts
+++ b/packages/benchsdk-worker/src/worker.ts
@@ -321,32 +321,52 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
     });
   }
 
-  let logUploadInFlight = false;
+  let logUploadInFlight: Promise<void> | undefined;
 
-  async function uploadWorkerLogArtifact(isFinal: boolean): Promise<void> {
-    if (logUploadInFlight) return;
+  async function uploadWorkerLogArtifact(isFinal: boolean = false): Promise<void> {
+    if (logUploadInFlight) {
+      if (!isFinal) return;
+      // At finish, wait for the in-flight upload before flushing any remaining
+      // lines appended after its snapshot.
+      await logUploadInFlight.catch(() => {});
+    }
+
     const snapshot = workerLogLines.slice();
     if (snapshot.length === 0) return;
 
-    logUploadInFlight = true;
+    let uploaded = false;
+    const upload = (async () => {
+      try {
+        const bodyText = snapshot.join('\n') + '\n';
+        const body = logCompression === 'gzip' ? await gzip(bodyText) : bodyText;
+        const contentType = logCompression === 'gzip' ? 'application/gzip' : 'text/plain';
+        await client.uploadWorkerArtifact(options.benchmarkSlug, options.runId, claimed.workerId, {
+          attemptId: claimed.attemptId,
+          kind: 'coordinator.log',
+          contentType,
+          name: 'worker.log',
+          body,
+        });
+        uploaded = true;
+        // Only remove the lines that were uploaded; lines appended during the
+        // upload remain buffered for the next flush.
+        workerLogLines.splice(0, snapshot.length);
+      } catch {
+        // Log upload is best-effort; never fail the run over it.
+      }
+    })();
+
+    logUploadInFlight = upload;
     try {
-      const bodyText = snapshot.join('\n') + '\n';
-      const body = logCompression === 'gzip' ? await gzip(bodyText) : bodyText;
-      const contentType = logCompression === 'gzip' ? 'application/gzip' : 'text/plain';
-      await client.uploadWorkerArtifact(options.benchmarkSlug, options.runId, claimed.workerId, {
-        attemptId: claimed.attemptId,
-        kind: 'coordinator.log',
-        contentType,
-        name: 'worker.log',
-        body,
-      });
-      // Only remove the lines that were uploaded; lines appended during the
-      // upload remain buffered for the next flush.
-      workerLogLines.splice(0, snapshot.length);
-    } catch {
-      // Log upload is best-effort; never fail the run over it.
+      await upload;
     } finally {
-      logUploadInFlight = false;
+      if (logUploadInFlight === upload) {
+        logUploadInFlight = undefined;
+      }
+      if (isFinal && uploaded && workerLogLines.length > 0) {
+        // Flush any lines appended while this upload was in flight.
+        await uploadWorkerLogArtifact(true).catch(() => {});
+      }
     }
   }
 

--- a/packages/benchsdk-worker/src/worker.ts
+++ b/packages/benchsdk-worker/src/worker.ts
@@ -58,9 +58,14 @@ function parseEnvInt(name: string, fallback: number): number {
 
 function isLogOptions(value: unknown): value is BenchmarkLogOptions {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-  const keys = Object.keys(value as Record<string, unknown>);
+  const o = value as Record<string, unknown>;
+  const keys = Object.keys(o);
   if (keys.length === 0) return false;
-  return keys.includes('level') || (keys.includes('meta') && keys.every((k) => k === 'level' || k === 'meta'));
+  if (!keys.every((k) => k === 'level' || k === 'meta')) return false;
+  if (o.level !== undefined && (typeof o.level !== 'string' || !LOG_LEVEL_ORDER.includes(o.level as BenchmarkLogLevel))) {
+    return false;
+  }
+  return true;
 }
 
 function isStepOutcome(value: unknown): value is BenchmarkStepOutcome {

--- a/packages/benchsdk-worker/src/worker.ts
+++ b/packages/benchsdk-worker/src/worker.ts
@@ -1,6 +1,13 @@
+import { gzip as gzipCallback } from 'node:zlib';
+import { promisify } from 'node:util';
+
+const gzip = promisify(gzipCallback);
 import type {
   BenchmarkClient,
   BenchmarkAssignment,
+  BenchmarkLogLevel,
+  BenchmarkLogOptions,
+  BenchmarkStepOutcome,
   DefineStepOptions,
   JsonObject,
   RunWorkerContext,
@@ -16,10 +23,54 @@ const DEFAULT_BATCH_SIZE = 1000;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_FLUSH_INTERVAL_MS = 30_000;
 const DEFAULT_READY_POLL_INTERVAL_MS = 1000;
+const DEFAULT_LOG_LEVEL: BenchmarkLogLevel = 'info';
+const DEFAULT_LOG_FLUSH_INTERVAL_MS = 0;
+const DEFAULT_MAX_LOG_LINES = 100_000;
 const MAX_TASK_RESULT_RECORDS = 5000;
 const MAX_TASK_RECORD_STEPS = 100;
 const MAX_HEARTBEAT_CONCURRENCY_SAMPLES = 20;
-const MAX_WORKER_LOG_LINES = 100_000;
+
+const LOG_LEVEL_ORDER: BenchmarkLogLevel[] = ['debug', 'info', 'warn', 'error'];
+
+function logLevelIndex(level: BenchmarkLogLevel): number {
+  return LOG_LEVEL_ORDER.indexOf(level);
+}
+
+function shouldLog(level: BenchmarkLogLevel, threshold: BenchmarkLogLevel): boolean {
+  return logLevelIndex(level) >= logLevelIndex(threshold);
+}
+
+function parseLogLevel(value: string | undefined, fallback: BenchmarkLogLevel): BenchmarkLogLevel {
+  if (!value) return fallback;
+  const trimmed = value.trim().toLowerCase() as BenchmarkLogLevel;
+  if (LOG_LEVEL_ORDER.includes(trimmed)) return trimmed;
+  return fallback;
+}
+
+function parseEnvInt(name: string, fallback: number): number {
+  if (typeof process === 'undefined') return fallback;
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) return fallback;
+  return parsed;
+}
+
+function isLogOptions(value: unknown): value is BenchmarkLogOptions {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const keys = Object.keys(value as Record<string, unknown>);
+  if (keys.length === 0) return false;
+  return keys.includes('level') || (keys.includes('meta') && keys.every((k) => k === 'level' || k === 'meta'));
+}
+
+function isStepOutcome(value: unknown): value is BenchmarkStepOutcome {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const o = value as Record<string, unknown>;
+  return (
+    (typeof o.stdout === 'string' || typeof o.stderr === 'string' || typeof o.error === 'string') &&
+    typeof o.then !== 'function'
+  );
+}
 
 function getErrorCode(error: unknown): string {
   if (error instanceof Error && 'code' in error && typeof (error as { code: unknown }).code === 'string' && (error as { code: string }).code) {
@@ -84,6 +135,19 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
   if (options.concurrency !== undefined) validatePositiveInteger('concurrency', options.concurrency);
   if (options.batchSize !== undefined) validateBatchSize(options.batchSize);
   if (options.flushIntervalMs !== undefined) validatePositiveInteger('flushIntervalMs', options.flushIntervalMs);
+  if (options.logFlushIntervalMs !== undefined && options.logFlushIntervalMs < 0) {
+    throw new Error('Benchmark logFlushIntervalMs must be a non-negative integer.');
+  }
+
+  const logLevel: BenchmarkLogLevel = options.logLevel ?? parseLogLevel(
+    typeof process !== 'undefined' ? process.env.BENCHMARK_LOG_LEVEL : undefined,
+    DEFAULT_LOG_LEVEL,
+  );
+  const maxLogLines = options.maxLogLines ?? parseEnvInt('BENCHMARK_LOG_MAX_LINES', DEFAULT_MAX_LOG_LINES);
+  const logFlushIntervalMs = options.logFlushIntervalMs ?? parseEnvInt('BENCHMARK_LOG_FLUSH_INTERVAL_MS', DEFAULT_LOG_FLUSH_INTERVAL_MS);
+  const logCompression: 'gzip' | false =
+    options.logCompression ??
+    (typeof process !== 'undefined' && process.env.BENCHMARK_LOG_COMPRESSION === 'gzip' ? 'gzip' : false);
 
   const assignment = await client.claimWorker(options.benchmarkSlug, options.runId, options.participantSlug, {
     processKind: options.processKind,
@@ -211,11 +275,12 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
   resultFlush.unref?.();
 
   // Accumulated across the worker's tasks via `ctx.step` and `ctx.log`,
-  // uploaded once as a worker log artifact when the worker finishes.
+  // uploaded as a `coordinator.log` worker artifact. Flushed incrementally
+  // when `logFlushIntervalMs` is set and once when the worker finishes.
   const workerLogLines: string[] = [];
   let workerLogTruncated = false;
   function appendWorkerLog(line: string): void {
-    if (workerLogLines.length >= MAX_WORKER_LOG_LINES) {
+    if (workerLogLines.length >= maxLogLines) {
       if (!workerLogTruncated) {
         workerLogTruncated = true;
         workerLogLines.push('... (worker log truncated)');
@@ -223,6 +288,22 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
       return;
     }
     workerLogLines.push(line);
+  }
+
+  function appendPrefixedLines(prefix: string, channel: string, text: string): void {
+    const timestamp = new Date().toISOString();
+    for (const rawLine of text.split(/\r?\n/)) {
+      const line = rawLine.trimEnd();
+      if (line.length === 0) continue;
+      appendWorkerLog(`${timestamp} ${prefix} ${channel}: ${line}`);
+    }
+  }
+
+  function appendStepOutcome(name: string, taskIndex: number, outcome: BenchmarkStepOutcome): void {
+    const prefix = `[task ${taskIndex}] ${name}`;
+    if (outcome.stdout?.trim()) appendPrefixedLines(prefix, 'stdout', outcome.stdout.trim());
+    if (outcome.stderr?.trim()) appendPrefixedLines(prefix, 'stderr', outcome.stderr.trim());
+    if (outcome.error?.trim()) appendPrefixedLines(prefix, 'error', outcome.error.trim());
   }
 
   async function runFinishHook(status: 'success' | 'error'): Promise<void> {
@@ -240,20 +321,42 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
     });
   }
 
-  async function uploadWorkerLogArtifact(): Promise<void> {
-    if (workerLogLines.length === 0) return;
+  let logUploadInFlight = false;
+
+  async function uploadWorkerLogArtifact(isFinal: boolean): Promise<void> {
+    if (logUploadInFlight) return;
+    const snapshot = workerLogLines.slice();
+    if (snapshot.length === 0) return;
+
+    logUploadInFlight = true;
     try {
+      const bodyText = snapshot.join('\n') + '\n';
+      const body = logCompression === 'gzip' ? await gzip(bodyText) : bodyText;
+      const contentType = logCompression === 'gzip' ? 'application/gzip' : 'text/plain';
       await client.uploadWorkerArtifact(options.benchmarkSlug, options.runId, claimed.workerId, {
         attemptId: claimed.attemptId,
         kind: 'coordinator.log',
-        contentType: 'text/plain',
+        contentType,
         name: 'worker.log',
-        body: workerLogLines.join('\n') + '\n',
+        body,
       });
+      // Only remove the lines that were uploaded; lines appended during the
+      // upload remain buffered for the next flush.
+      workerLogLines.splice(0, snapshot.length);
     } catch {
       // Log upload is best-effort; never fail the run over it.
+    } finally {
+      logUploadInFlight = false;
     }
   }
+
+  const logFlush =
+    logFlushIntervalMs > 0
+      ? setInterval(() => {
+          if (workerLogLines.length > 0) void uploadWorkerLogArtifact(false).catch(() => {});
+        }, logFlushIntervalMs)
+      : undefined;
+  logFlush?.unref?.();
 
   try {
     await sendHeartbeat().catch(() => {});
@@ -281,9 +384,13 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
         }
       }
 
-      function log(message: string, meta?: JsonObject): void {
-        const suffix = meta && Object.keys(meta).length > 0 ? ` ${JSON.stringify(meta)}` : '';
-        appendWorkerLog(`${new Date().toISOString()} [task ${taskIndex}] ${message}${suffix}`);
+      function log(message: string, metaOrOptions?: JsonObject | BenchmarkLogOptions): void {
+        const opts: { level: BenchmarkLogLevel; meta?: JsonObject } = isLogOptions(metaOrOptions)
+          ? { level: metaOrOptions.level ?? 'info', meta: metaOrOptions.meta }
+          : { level: 'info', meta: metaOrOptions };
+        if (!shouldLog(opts.level, logLevel)) return;
+        const suffix = opts.meta && Object.keys(opts.meta).length > 0 ? ` ${JSON.stringify(opts.meta)}` : '';
+        appendWorkerLog(`${new Date().toISOString()} [task ${taskIndex}] [${opts.level}] ${message}${suffix}`);
       }
 
       async function step<T>(name: string, fn: () => Promise<T> | T, stepOptions: DefineStepOptions = {}): Promise<T> {
@@ -314,12 +421,15 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
             await waitForStepReady(name, stepOptions);
           }
           const value = await fn();
-          appendWorkerLog(`${new Date().toISOString()} [task ${taskIndex}] ${name}`);
+          appendWorkerLog(`${new Date().toISOString()} [task ${taskIndex}] [info] ${name}`);
+          if (stepOptions.captureOutput !== false && isStepOutcome(value)) {
+            appendStepOutcome(name, taskIndex, value);
+          }
           return value;
         } catch (error) {
           stepRecord.status = 'error';
           stepRecord.errorCode = getErrorCode(error);
-          appendWorkerLog(`${new Date().toISOString()} [task ${taskIndex}] ${name}`);
+          appendWorkerLog(`${new Date().toISOString()} [task ${taskIndex}] [error] ${name}`);
           appendWorkerLog(`  error: ${error instanceof Error ? error.message : String(error)}`);
           throw error;
         } finally {
@@ -389,7 +499,8 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
     await client.failWorker(options.benchmarkSlug, options.runId, claimed.workerId, claimed.attemptId, error).catch(() => {});
     throw error;
   } finally {
-    await uploadWorkerLogArtifact();
+    if (logFlush) clearInterval(logFlush);
+    await uploadWorkerLogArtifact(true);
     clearInterval(heartbeat);
     clearInterval(resultFlush);
   }

--- a/packages/benchsdk/src/__tests__/client.test.ts
+++ b/packages/benchsdk/src/__tests__/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { gzipSync, gunzipSync } from 'node:zlib';
 import { createBenchmarkClient } from '../client';
 import { BenchmarkApiError, BenchmarkReporter, createSystemMetricsCollector } from '../index';
 import type { BenchmarkAssignment } from '../index';
@@ -541,7 +542,7 @@ describe('createBenchmarkClient', () => {
     expect(upload?.method).toBe('PUT');
     const logBody = String((upload as any)?.body);
     expect(logBody.length).toBeGreaterThan(0);
-    expect(logBody).toContain('[task 0] create');
+    expect(logBody).toContain('[task 0] [info] create');
   });
 
   it('waits for platform step readiness before running a step body', async () => {
@@ -828,6 +829,63 @@ describe('createBenchmarkClient', () => {
       'GET https://platform.test/api/v1/benchmarks/scale/runs/run_1/results/imports',
       'POST https://platform.test/api/v1/benchmarks/scale/runs/run_1/workers/worker_1/release',
     ]);
+  });
+
+  it('downloads a worker artifact and decompresses gzip content', async () => {
+    const gzBody = gzipSync(Buffer.from('hello worker log\n'));
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/workers/worker_1/artifacts/artifact_1')) {
+        return jsonResponse({ artifact: { artifactId: 'artifact_1', contentType: 'application/gzip' }, downloadUrl: 'https://download.test' });
+      }
+      if (url === 'https://download.test') return new Response(gzBody, { status: 200 });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const client = createBenchmarkClient({ baseUrl: 'https://platform.test/api/v1', fetch: fetchMock as typeof fetch });
+
+    const { artifact, downloadUrl } = await client.getWorkerArtifact('scale', 'run_1', 'worker_1', 'artifact_1');
+    expect(artifact.artifactId).toBe('artifact_1');
+    expect(downloadUrl).toBe('https://download.test');
+
+    const text = await client.downloadWorkerArtifact('scale', 'run_1', 'worker_1', 'artifact_1');
+    expect(text).toBe('hello worker log\n');
+
+    const directText = await client.downloadArtifact('https://download.test', { decompress: true });
+    expect(directText).toBe('hello worker log\n');
+  });
+
+  it('uploads gzip-compressed worker logs when logCompression is enabled', async () => {
+    const seen: Array<{ url: string; body: unknown; method?: string }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const body = init?.body && url.startsWith('https://platform.test/') ? JSON.parse(String(init.body)) : init?.body;
+      seen.push({ url, body, method: init?.method });
+      if (url.endsWith('/participants/e2b/workers/claim')) return jsonResponse({ assignment: assignment({ taskRange: { start: 0, end: 0, count: 1 } }) });
+      if (url.endsWith('/events')) return jsonResponse({ eventBatch: { id: 'batch_1' } }, 202);
+      if (url.endsWith('/workers/00000000-0000-4000-8000-000000000002/artifacts')) return jsonResponse({ artifactId: 'artifact_1', uploadUrl: 'https://upload.test' });
+      if (url === 'https://upload.test') return new Response(null, { status: 200 });
+      if (url.endsWith('/complete')) return jsonResponse({ worker: { id: 'worker_1' }, attempt: { id: 'attempt_1' } });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const client = createBenchmarkClient({ baseUrl: 'https://platform.test/api/v1', fetch: fetchMock as typeof fetch });
+    await client.runWorker({
+      benchmarkSlug: 'scale',
+      runId: '00000000-0000-4000-8000-000000000001',
+      participantSlug: 'e2b',
+      logCompression: 'gzip',
+      task: async ({ log }) => {
+        log('compressed entry');
+      },
+    });
+
+    const artifactPost = seen.find((entry) => entry.url.endsWith('/artifacts') && entry.method === 'POST');
+    expect(artifactPost?.body).toMatchObject({ kind: 'coordinator.log', name: 'worker.log', contentType: 'application/gzip' });
+
+    const upload = seen.find((entry) => entry.url === 'https://upload.test');
+    const decompressed = gunzipSync(Buffer.from(upload?.body as ArrayBufferView));
+    expect(decompressed.toString()).toContain('compressed entry');
   });
 
   it('reports custom coordinator progress, barriers, artifacts, and finish best-effort', async () => {

--- a/packages/benchsdk/src/__tests__/public-api.contract.test.ts
+++ b/packages/benchsdk/src/__tests__/public-api.contract.test.ts
@@ -17,7 +17,11 @@ import type { BenchmarkAssignment, BenchmarkClient } from '../index';
 // type resolves against the package barrel (the consumer-compile contract).
 import type {
   BenchmarkArtifact,
+  BenchmarkArtifactDownload,
   BenchmarkClientConfig,
+  BenchmarkLogLevel,
+  BenchmarkLogOptions,
+  BenchmarkStepOutcome,
   BenchmarkConcurrencyPoint,
   BenchmarkAnalyticsReadiness,
   BenchmarkEventRateBucket,
@@ -104,9 +108,13 @@ import type {
 type _PublicTypeSurface = [
   BenchmarkAssignment,
   BenchmarkArtifact,
+  BenchmarkArtifactDownload,
   BenchmarkClient,
   BenchmarkClientConfig,
   BenchmarkConcurrencyPoint,
+  BenchmarkLogLevel,
+  BenchmarkLogOptions,
+  BenchmarkStepOutcome,
   BenchmarkAnalyticsReadiness,
   BenchmarkEventRateBucket,
   BenchmarkFailurePoint,

--- a/packages/benchsdk/src/index.ts
+++ b/packages/benchsdk/src/index.ts
@@ -2,9 +2,13 @@ export { BenchmarkApiError, createBenchmarkClient } from './client';
 export type { BenchmarkClient, BenchmarkClientConfig } from './client';
 
 export type {
+  BenchmarkArtifactDownload,
   BenchmarkAssignment,
   BenchmarkArtifact,
   BenchmarkConcurrencyPoint,
+  BenchmarkLogLevel,
+  BenchmarkLogOptions,
+  BenchmarkStepOutcome,
   BenchmarkAnalyticsReadiness,
   BenchmarkEventRateBucket,
   BenchmarkFailurePoint,


### PR DESCRIPTION
## Summary
Implements the first five `benchsdk` logging improvements we discussed:

1. First-class artifact download helpers in `@benchsdk/api`.
2. Structured/log-leveled `ctx.log` in worker and runner.
3. Capture `stdout`/`stderr`/`error` per step from step return values.
4. Incremental worker log flush during a run.
5. Configurable max log lines and optional gzip compression.

Real-time log tailing (point 6) is intentionally scoped out — it needs a platform streaming endpoint or WebSocket for artifact events and is left for a follow-up.

## Changes
- `@benchsdk/api`: added `BenchmarkArtifactDownload`, `BenchmarkLogLevel`, `BenchmarkLogOptions`, `BenchmarkStepOutcome` types; added `getWorkerArtifact`, `downloadArtifact`, and `downloadWorkerArtifact` client methods; `downloadArtifact` auto-decompresses gzip responses.
- `@benchsdk/worker`: `ctx.log` now accepts `BenchmarkLogOptions` (`{ level, meta }`) and filters by `logLevel`; `step` records `BenchmarkStepOutcome` `stdout`/`stderr`/`error`; logs flush on a `logFlushIntervalMs` timer and at finish; `maxLogLines` and `logCompression` (`'gzip' | false`) are configurable via options or env vars (`BENCHMARK_LOG_*`).
- `@benchsdk/runner`: `LogBuffer` and `TaskContext.log` support log levels; manual `step` captures `BenchmarkStepOutcome` and feeds it into the log buffer.
- `@benchsdk/client`: re-exports new types; public API surface test updated.
- Tests: updated step log assertion and added coverage for `getWorkerArtifact`/`downloadWorkerArtifact` and gzip-compressed log upload.

## Example
```ts
await client.runWorker({
  benchmarkSlug: 'scale',
  runId,
  participantSlug: 'e2b',
  logLevel: 'debug',
  logCompression: 'gzip',
  logFlushIntervalMs: 30_000,
  maxLogLines: 500_000,
  task: async ({ log, step }) => {
    log('starting', { level: 'debug' });
    await step('run', async () => {
      return { stdout: 'ok', stderr: '' };
    });
  },
});
```

Link to Devin session: https://app.devin.ai/sessions/87831059a8154022b099646904220a4b
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->