### PR TITLE
benchsdk: tighten step outcome detection so benchmark result objects aren't logged

### DIFF
--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -89,13 +89,15 @@ function getErrorCode(error: unknown): string {
   return error instanceof Error && error.name ? error.name : 'ERROR';
 }
 
+const STEP_OUTCOME_KEYS = new Set(['stdout', 'stderr', 'error', 'exitCode', 'code', 'signal', 'pid']);
+
 function isStepOutcome(value: unknown): value is BenchmarkStepOutcome {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const o = value as Record<string, unknown>;
-  return (
-    (typeof o.stdout === 'string' || typeof o.stderr === 'string' || typeof o.error === 'string') &&
-    typeof o.then !== 'function'
-  );
+  const keys = Object.keys(o);
+  if (keys.length === 0) return false;
+  if (!keys.every((k) => STEP_OUTCOME_KEYS.has(k))) return false;
+  return typeof o.stdout === 'string' || typeof o.stderr === 'string' || typeof o.error === 'string';
 }
 
 function withTimeout<T>(promise: Promise<T>, ms: number, name: string): Promise<T> {

--- a/packages/benchsdk-worker/src/worker.ts
+++ b/packages/benchsdk-worker/src/worker.ts
@@ -68,13 +68,15 @@ function isLogOptions(value: unknown): value is BenchmarkLogOptions {
   return true;
 }
 
+const STEP_OUTCOME_KEYS = new Set(['stdout', 'stderr', 'error', 'exitCode', 'code', 'signal', 'pid']);
+
 function isStepOutcome(value: unknown): value is BenchmarkStepOutcome {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const o = value as Record<string, unknown>;
-  return (
-    (typeof o.stdout === 'string' || typeof o.stderr === 'string' || typeof o.error === 'string') &&
-    typeof o.then !== 'function'
-  );
+  const keys = Object.keys(o);
+  if (keys.length === 0) return false;
+  if (!keys.every((k) => STEP_OUTCOME_KEYS.has(k))) return false;
+  return typeof o.stdout === 'string' || typeof o.stderr === 'string' || typeof o.error === 'string';
 }
 
 function getErrorCode(error: unknown): string {


### PR DESCRIPTION
## Summary

The new `captureOutput` step logic treats a returned value as a `BenchmarkStepOutcome` (and writes `stdout`/`stderr`/`error` into the worker log) when the value is an object containing any of those keys. That heuristic was too broad: benchmarks like `dax.bench.ts` return a `DaxTimingResult` with an `error` field on failure, so the same `error` message was being captured as step output and then logged again when the task threw `TaskError`.

This change makes `isStepOutcome` only recognize objects whose keys look like command output (`stdout`, `stderr`, `error`, `exitCode`, `code`, `signal`, `pid`) and which actually carry a `stdout`/`stderr`/`error` string. Result objects with unrelated keys (timing results, snapshot IDs, browser pages, etc.) are no longer misclassified.

### Before

```ts
ctx.step('build', () => runDaxBuild(...)); // returns DaxTimingResult { totalMs, phasesCompleted, ..., error? }
// 'error' was logged twice: once as step output, again on the thrown TaskError
```

### After

```ts
ctx.step('run', () => sandbox.runCommand(...)); // { exitCode, stdout, stderr }
// stdout/stderr are captured once; DaxTimingResult is ignored by step capture
```

- Tightens `isStepOutcome` in both `packages/benchsdk-worker/src/worker.ts` and `packages/benchsdk-runner/src/runner.ts`.
- Audited all `*.bench.ts` files; the only steps that return command-like objects (`{ stdout, stderr, exitCode }`) are the `sandbox`/`reliability` benchmarks, and those now capture correctly without double-logging `DaxTimingResult` errors.

Link to Devin session: https://app.devin.ai/sessions/87831059a8154022b099646904220a4b
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->