### PR TITLE
benchmarks: add structured, leveled logs to all task definitions

### DIFF
--- a/benchmarks/ai-gateway/shared-task.ts
+++ b/benchmarks/ai-gateway/shared-task.ts
@@ -118,12 +118,15 @@ export function makeAIGatewayTask(maxTokens: number, timeoutMs: number) {
     const steps = phaseSteps(result);
 
     if (result.error) {
-      ctx.log(`${ctx.participant.name} ${result.mode} probe failed: ${result.error}`, probeData(result));
+      ctx.log(`${ctx.participant.name} ${result.mode} probe failed: ${result.error}`, {
+        level: 'error',
+        meta: probeData(result),
+      });
       throw new TaskError(result.error, { code: 'probe_failed', data: probeData(result), steps });
     }
     ctx.log(
       `${ctx.participant.name} ${result.mode} probe: ttfb=${result.ttfbMs}ms ttft=${result.ttftMs}ms`,
-      probeData(result),
+      { level: 'info', meta: probeData(result) },
     );
     return {
       data: probeData(result),

--- a/benchmarks/browser/browser-throughput.bench.ts
+++ b/benchmarks/browser/browser-throughput.bench.ts
@@ -239,7 +239,7 @@ function medianScreenshotMs(actions: ActionResult[]): number | undefined {
 const providerCache = new Map<string, any>();
 
 export const task = defineTask<ThroughputProviderConfig>(async (ctx) => {
-  const { participant, taskIndex, step, measure } = ctx;
+  const { participant, taskIndex, step, measure, log } = ctx;
   const timeout = participant.timeout ?? 120_000;
   const sessionCreateOptions = participant.sessionCreateOptions ?? {};
 
@@ -304,7 +304,7 @@ export const task = defineTask<ThroughputProviderConfig>(async (ctx) => {
     iterationError = err instanceof Error ? err.message : String(err);
   } finally {
     if (browser) {
-      await browser.close().catch(() => { });
+      await browser.close().catch((err: unknown) => log('browser close failed', { level: 'warn', meta: { error: String(err) } }));
     }
     if (session) {
       const releaseStart = performance.now();
@@ -319,23 +319,32 @@ export const task = defineTask<ThroughputProviderConfig>(async (ctx) => {
             ),
           { reportConcurrency: false },
         );
-      } catch {
-        // Swallow release errors — they're recorded via releaseMs but should
-        // not mask the more important action timings.
+      } catch (err: unknown) {
+        log('release failed', { level: 'warn', meta: { error: err instanceof Error ? err.message : String(err) } });
       }
       releaseMs = performance.now() - releaseStart;
     }
   }
 
-  const data = {
+  const totalMs = performance.now() - totalStart;
+  const summary = {
     createMs,
     connectMs,
     releaseMs,
-    totalMs: performance.now() - totalStart,
+    totalMs,
     taskMs,
     actionsCompleted,
     actionsPerSecond,
     ...(screenshotMs !== undefined ? { screenshotMs } : {}),
+  };
+
+  log(
+    iterationError ? 'Browser throughput session failed' : 'Browser throughput session completed',
+    { level: iterationError ? 'error' : 'info', meta: iterationError ? { ...summary, error: iterationError } : summary },
+  );
+
+  const data = {
+    ...summary,
     actions: actions as unknown as JsonValue,
     ...(iterationError ? { errorMessage: iterationError } : {}),
   };

--- a/benchmarks/browser/browser.bench.ts
+++ b/benchmarks/browser/browser.bench.ts
@@ -43,7 +43,7 @@ export const config = defineBenchmarkConfig({
 const providerCache = new Map<string, any>();
 
 export const task = defineTask<BrowserProviderConfig>(async (ctx) => {
-  const { participant, step } = ctx;
+  const { participant, step, log } = ctx;
   const timeout = participant.timeout ?? 120_000;
   const sessionCreateOptions = participant.sessionCreateOptions ?? {};
 
@@ -91,7 +91,7 @@ export const task = defineTask<BrowserProviderConfig>(async (ctx) => {
       );
       timings.navigateMs = performance.now() - navStart;
     } finally {
-      if (browser) await browser.close().catch(() => {});
+      if (browser) await browser.close().catch((err: unknown) => log('browser close failed', { level: 'warn', meta: { error: String(err) } }));
       const releaseStart = performance.now();
       await step(
         'release',
@@ -102,10 +102,12 @@ export const task = defineTask<BrowserProviderConfig>(async (ctx) => {
     }
 
     timings.totalMs = performance.now() - totalStart;
+    log('Browser lifecycle completed', { level: 'info', meta: timings });
     return { data: { ...timings } };
   } catch (err) {
     timings.totalMs = performance.now() - totalStart;
     const message = err instanceof Error ? err.message : String(err);
+    log('Browser lifecycle failed', { level: 'error', meta: { ...timings, error: message } });
     throw new TaskError(message, { code: 'BROWSER_ERROR', data: { ...timings, errorMessage: message } });
   }
 });

--- a/benchmarks/reliability/sandbox-opencode.bench.ts
+++ b/benchmarks/reliability/sandbox-opencode.bench.ts
@@ -1,8 +1,15 @@
 import '../src/env.js';
 import { defineBenchmarkConfig, defineTask, TaskError } from '@benchsdk/runner';
 import { withTimeout } from '../src/util/timeout.js';
+import { formatError } from '../src/util/error.js';
 import { providers } from '../sandbox/providers.js';
 import type { ProviderConfig } from '../sandbox/types.js';
+
+function preview(text: string | null | undefined, max = 2000): string | null {
+  if (!text) return null;
+  if (text.length <= max) return text;
+  return text.slice(0, max) + '...';
+}
 
 export const config = defineBenchmarkConfig({
   benchmarkSlug: 'tensorlake-opencode-reliability',
@@ -15,7 +22,7 @@ export const config = defineBenchmarkConfig({
 });
 
 export const task = defineTask<ProviderConfig>(async (ctx) => {
-  const { participant, step } = ctx;
+  const { participant, step, log } = ctx;
   const compute = participant.createCompute();
 
   let sandbox: any;
@@ -38,8 +45,13 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
         { timeout: 60_000 },
       );
       if (result.exitCode !== 0) {
+        log('OpenCode install failed', {
+          level: 'error',
+          meta: { exitCode: result.exitCode, stderr: preview(result.stderr) },
+        });
         throw new TaskError(`OpenCode install failed (exit ${result.exitCode})`);
       }
+      log('OpenCode install succeeded', { level: 'info', meta: { exitCode: result.exitCode } });
     });
 
     const output = await step('run', async () =>
@@ -49,12 +61,21 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
       ),
     );
 
+    const stdout = output.stdout || '';
     if (output.exitCode !== 0) {
+      log('OpenCode run failed', {
+        level: 'error',
+        meta: { exitCode: output.exitCode, stdout: preview(stdout), stderr: preview(output.stderr) },
+      });
       throw new TaskError(`OpenCode run failed (exit ${output.exitCode})`);
     }
 
-    const stdout = output.stdout || '';
-    if (!stdout.includes('tensorlake-ok')) {
+    const foundOk = stdout.includes('tensorlake-ok');
+    log('OpenCode run completed', {
+      level: foundOk ? 'info' : 'error',
+      meta: { exitCode: output.exitCode, outputLength: stdout.length, foundOk, stdout: preview(stdout) },
+    });
+    if (!foundOk) {
       throw new TaskError(`OpenCode output did not include "tensorlake-ok": ${stdout}`.trim());
     }
   } finally {
@@ -68,7 +89,7 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
             'Destroy timeout',
           ),
         { reportConcurrency: false },
-      ).catch((err: unknown) => console.warn(`[cleanup] destroy failed: ${String(err)}`));
+      ).catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { error: formatError(err) } }));
     }
   }
 });

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -227,6 +227,7 @@ function daxPhaseSteps(t: DaxTimingResult): TaskStepRecord[] {
 
 export const task = defineTask<ProviderConfig>(async (ctx) => {
   const p = ctx.participant;
+  const { log } = ctx;
   const compute = p.createCompute();
   const opts = getSandboxOptionsWithResources(p.name, p.sandboxOptions);
 
@@ -246,14 +247,36 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
       .step('destroy', () => withTimeout(sandbox.destroy(), p.destroyTimeoutMs ?? destroyTimeoutMs, 'Destroy timeout'), {
         reportConcurrency: false,
       })
-      .catch((err) => console.warn(`    [cleanup] destroy failed: ${formatError(err)}`));
+      .catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { error: formatError(err) } }));
   }
 
   const data = timing as unknown as JsonObject;
   const steps = daxPhaseSteps(timing);
 
   if (timing.error) {
+    log('Dax build failed', {
+      level: 'error',
+      meta: {
+        provider: p.name,
+        totalMs: timing.totalMs,
+        phasesCompleted: `${timing.phasesCompleted}/${timing.phasesTotal}`,
+        error: timing.error,
+      },
+    });
     throw new TaskError(timing.error, { code: 'dax_failed', data, steps });
   }
+
+  log('Dax build completed', {
+    level: 'info',
+    meta: {
+      provider: p.name,
+      totalMs: timing.totalMs,
+      phasesCompleted: `${timing.phasesCompleted}/${timing.phasesTotal}`,
+      ...(timing.commit ? { commit: timing.commit } : {}),
+      ...(timing.bunVersion ? { bunVersion: timing.bunVersion } : {}),
+      ...(timing.nodeVersion ? { nodeVersion: timing.nodeVersion } : {}),
+      ...(timing.architecture ? { architecture: timing.architecture } : {}),
+    },
+  });
   return { data, steps, latencyMs: timing.totalMs };
 });

--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -57,12 +57,12 @@ export const config = defineBenchmarkConfig({
 
 /** The slice of a provider's sandbox this workload actually touches. */
 interface TtiSandbox {
-  runCommand(command: string): Promise<{ exitCode: number; stderr?: string }>;
+  runCommand(command: string): Promise<{ exitCode: number; stdout?: string; stderr?: string }>;
   destroy(): Promise<unknown>;
 }
 
 export const task = defineTask<ProviderConfig>(async (ctx) => {
-  const { participant, step, measure } = ctx;
+  const { participant, step, measure, log } = ctx;
   const compute = participant.createCompute();
 
   const start = performance.now();
@@ -75,21 +75,24 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
   );
 
   try {
-    await step('exec.task', async () => {
-      const result = await withTimeout(
+    const result = await step('exec.task', async () => {
+      const r = await withTimeout(
         sandbox.runCommand('node -v'),
         COMMAND_TIMEOUT_MS,
         'First command execution timed out',
       );
-      if (result.exitCode !== 0) {
-        throw new Error(`Command failed with exit code ${result.exitCode}: ${result.stderr || 'Unknown error'}`);
+      if (r.exitCode !== 0) {
+        log('node -v failed', { level: 'error', meta: { exitCode: r.exitCode, stderr: r.stderr ?? null } });
+        throw new Error(`Command failed with exit code ${r.exitCode}: ${r.stderr || 'Unknown error'}`);
       }
+      return r;
     });
+    log('node -v succeeded', { level: 'info', meta: { version: result.stdout?.trim() ?? null, exitCode: result.exitCode } });
     measure({ ttiMs: performance.now() - start });
   } finally {
     await step('destroy', () =>
       withTimeout(sandbox.destroy(), participant.destroyTimeoutMs ?? DESTROY_TIMEOUT_MS, 'Destroy timeout'),
       { reportConcurrency: false },
-    ).catch((err) => console.warn(`    [cleanup] destroy failed: ${formatError(err)}`));
+    ).catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { error: formatError(err) } }));
   }
 });

--- a/benchmarks/storage/snapshot-fork.bench.ts
+++ b/benchmarks/storage/snapshot-fork.bench.ts
@@ -79,14 +79,7 @@ function randomId(): string {
   return Math.random().toString(36).substring(2, 15);
 }
 
-/** Best-effort cleanup that never throws — logs and swallows. */
-async function safeCleanup(label: string, fn: () => Promise<unknown>): Promise<void> {
-  try {
-    await withTimeout(Promise.resolve(fn()), 30_000, `${label} timed out`);
-  } catch (err) {
-    console.warn(`    [cleanup] ${label} failed: ${formatError(err)}`);
-  }
-}
+
 
 /** One `Storage` per participant, and a single random payload buffer for the run. */
 const storageCache = new Map<string, Storage>();
@@ -100,8 +93,16 @@ const datasetBytes = spec.objectCount * spec.objectSizeBytes;
  * storage.
  */
 export const task = defineTask<StorageProviderConfig>(async (ctx) => {
-  const { participant, step } = ctx;
+  const { participant, step, log } = ctx;
   const timeout = participant.timeout ?? 60_000;
+
+  const safeCleanup = async (label: string, fn: () => Promise<unknown>): Promise<void> => {
+    try {
+      await withTimeout(Promise.resolve(fn()), 30_000, `${label} timed out`);
+    } catch (err) {
+      log('cleanup failed', { level: 'warn', meta: { label, error: formatError(err) } });
+    }
+  };
 
   let storage = storageCache.get(participant.name);
   if (!storage) {
@@ -163,20 +164,34 @@ export const task = defineTask<StorageProviderConfig>(async (ctx) => {
     const forkFirstReadMs = performance.now() - readStart;
     const verified = bytes.length === payload.length;
 
-    return {
-      data: {
-        seedMs,
-        snapshotCreateMs,
-        forkFromSnapshotMs,
-        forkFromLiveMs,
-        forkFirstReadMs,
-        verified,
-        datasetBytes,
-        objectCount: spec.objectCount,
-      },
+    const data = {
+      seedMs,
+      snapshotCreateMs,
+      forkFromSnapshotMs,
+      forkFromLiveMs,
+      forkFirstReadMs,
+      verified,
+      datasetBytes,
+      objectCount: spec.objectCount,
     };
+    log('Snapshot/fork lifecycle completed', { level: 'info', meta: data });
+    return { data };
   } catch (err) {
     const message = formatError(err);
+    log('Snapshot/fork lifecycle failed', {
+      level: 'error',
+      meta: {
+        seedMs: 0,
+        snapshotCreateMs: 0,
+        forkFromSnapshotMs: 0,
+        forkFromLiveMs: 0,
+        forkFirstReadMs: 0,
+        verified: false,
+        datasetBytes,
+        objectCount: spec.objectCount,
+        error: message,
+      },
+    });
     throw new TaskError(message, {
       code: 'SNAPSHOT_FORK_ERROR',
       data: {

--- a/benchmarks/storage/storage.bench.ts
+++ b/benchmarks/storage/storage.bench.ts
@@ -114,7 +114,7 @@ function randomId(): string {
 const storageCache = new Map<string, Storage>();
 
 export const task = defineTask<StorageProviderConfig>(async (ctx) => {
-  const { participant, step, measure } = ctx;
+  const { participant, step, measure, log } = ctx;
   const timeout = participant.timeout ?? 30_000;
 
   // When running multiple file sizes per run, each phase is named after the size.
@@ -165,17 +165,25 @@ export const task = defineTask<StorageProviderConfig>(async (ctx) => {
       'delete',
       () => withTimeout(storage!.delete(key), 10_000, 'Delete timed out'),
       { reportConcurrency: false },
-    ).catch((err) => console.warn(`    [cleanup] delete failed: ${formatError(err)}`));
+    ).catch((err: unknown) => log('delete cleanup failed', { level: 'warn', meta: { key, error: formatError(err) } }));
 
+    log('Storage lifecycle completed', {
+      level: 'info',
+      meta: { fileSize: fileSizeLabel, fileSizeBytes, uploadMs, downloadMs, throughputMbps, key },
+    });
     return { data: { file_size: fileSizeLabel, uploadMs, downloadMs, throughputMbps, fileSizeBytes } };
   } catch (err) {
     // Attempt cleanup even on failure.
     try {
       await withTimeout(storage!.delete(key), 10_000, 'Delete timed out');
-    } catch {
-      // Ignore cleanup errors on the failure path.
+    } catch (cleanupErr: unknown) {
+      log('cleanup delete failed', { level: 'warn', meta: { key, error: formatError(cleanupErr) } });
     }
     const message = formatError(err);
+    log('Storage lifecycle failed', {
+      level: 'error',
+      meta: { fileSize: fileSizeLabel, fileSizeBytes, uploadMs, downloadMs, throughputMbps, key, error: message },
+    });
     throw new TaskError(message, {
       code: 'STORAGE_ERROR',
       data: { file_size: fileSizeLabel, uploadMs: 0, downloadMs: 0, throughputMbps: 0, fileSizeBytes },


### PR DESCRIPTION
## Summary

Audit and update every active benchmark task to emit `ctx.log` calls with explicit levels and structured metadata. Previously many tasks relied only on step timing and `TaskError` data, so worker logs did not contain command output, failure context, or lifecycle summaries.

## Changes

- `ai-gateway/shared-task.ts`
  - Logs probe failures at `error` level and successes at `info` level with `meta: probeData(result)`.
- `browser/browser.bench.ts`
  - Logs lifecycle completion/failure and browser-close warnings with `meta: timings`.
- `browser/browser-throughput.bench.ts`
  - Logs session summary, release failures, and browser-close warnings.
- `reliability/sandbox-opencode.bench.ts`
  - Adds a `preview` helper to cap captured stdout/stderr length.
  - Logs install/run success/failure and cleanup warnings with exit codes and output previews.
- `sandbox/dax.bench.ts`
  - Logs DAX build success/failure summary including provider, total time, phases completed, commit, and tool versions.
  - Logs `destroy` cleanup failures.
- `sandbox/tti.bench.ts`
  - Logs `node -v` success/failure, records the reported Node version, and logs cleanup warnings.
- `storage/storage.bench.ts`
  - Logs storage lifecycle completion/failure with throughput and timings, plus cleanup warnings.
- `storage/snapshot-fork.bench.ts`
  - Replaces top-level `safeCleanup` with a closure using `ctx.log`.
  - Logs snapshot/fork lifecycle completion/failure and cleanup warnings.

## Verification

- `pnpm -r build` passed
- `pnpm typecheck` passed
- `pnpm --filter @benchsdk/client test` passed
- `pnpm --filter @benchsdk/runner test` passed

Link to Devin session: https://app.devin.ai/sessions/87831059a8154022b099646904220a4b
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->