### PR TITLE
Add @benchsdk/cli library and unify platform commands under bench

### DIFF
--- a/.agents/skills/benchsdk-cli/SKILL.md
+++ b/.agents/skills/benchsdk-cli/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: benchsdk-cli
+description: Install, authenticate, and use the unified bench CLI to query and run ComputeSDK benchmarks. Covers device-code OAuth, API keys, config files, and non-interactive/CI use.
+---
+
+# `bench` CLI
+
+The `bench` binary is the unified CLI for the ComputeSDK benchmarks platform.
+`bench run` executes benchmark files; all other commands query platform data.
+
+## Installation
+
+The CLI ships with `@benchsdk/runner`. From the benchmarks repo root:
+
+```bash
+pnpm install
+pnpm -r --filter "./packages/**" build
+```
+
+Run via the built binary:
+
+```bash
+node packages/benchsdk-runner/dist/bin.cjs --version
+```
+
+Or add `packages/benchsdk-runner` to your `PATH` so `bench --version` works.
+
+## Authentication
+
+The CLI tries credentials in this order:
+
+1. `--api-key <key>`
+2. `BENCHMARKS_PLATFORM_TOKEN` (a better-auth session token — does not refresh)
+3. `BENCHMARKS_PLATFORM_API_KEY` or `COMPUTESDK_API_KEY` (an org-scoped `bp_...` key)
+4. OAuth tokens from `~/.benchsdk/credentials.json` (from `bench auth login`)
+
+API keys and tokens are useful for non-interactive environments. OAuth is
+interactive and stores a refresh token under `~/.benchsdk`.
+
+### Device-code login
+
+```bash
+bench auth login --base-url https://platform.computesdk.com
+```
+
+This prints a URL and a user code. Approve the device in the browser; the CLI
+polls and stores the access/refresh token pair. Access tokens last 1 hour;
+refresh tokens are 30-day sliding windows and rotate on every refresh.
+
+### Check status
+
+```bash
+bench auth status
+bench auth status --json
+```
+
+### Log out
+
+```bash
+bench auth logout
+```
+
+This removes `~/.benchsdk/credentials.json`.
+
+## Configuration file
+
+`~/.benchsdk/config.json` stores non-secret defaults:
+
+```json
+{
+  "baseUrl": "https://platform.computesdk.com",
+  "org": "computesdk",
+  "format": "table"
+}
+```
+
+`--base-url`, `--org`, and `--format` override this file. Credentials live in
+`~/.benchsdk/credentials.json` and are created with `0600` file permissions.
+
+## Common commands
+
+### Organizations
+
+```bash
+bench org list
+bench org use computesdk
+```
+
+`bench org use` switches the active organization and rewrites the stored access
+token with the new organization claim.
+
+### Benchmarks
+
+```bash
+bench benchmarks list
+bench benchmarks list --limit 20 --offset 40
+bench benchmarks list --json
+```
+
+### Runs
+
+```bash
+bench runs list my-benchmark
+bench runs show my-benchmark <runId>
+```
+
+### Results
+
+```bash
+bench results my-benchmark
+bench results my-benchmark --run <runId>
+bench results my-benchmark --format json
+```
+
+### Artifacts
+
+```bash
+bench artifacts list my-benchmark <runId>
+bench artifacts list my-benchmark <runId> --worker <workerId>
+```
+
+### Export
+
+```bash
+bench export my-benchmark --out ./exports
+bench export my-benchmark --run <runId> --out ./exports
+```
+
+## Running benchmarks
+
+`bench run` still executes benchmark files via `@benchsdk/runner`:
+
+```bash
+bench run path/to/file.bench.ts --iterations 4 --concurrency 2
+```
+
+You can also use an org-scoped `bp_` key for non-interactive runs:
+
+```bash
+BENCHMARKS_PLATFORM_API_KEY=bp_... bench run path/to/file.bench.ts
+```
+
+## Non-interactive / CI use
+
+Set environment variables so the CLI never tries to open a browser:
+
+```bash
+export BENCHMARKS_PLATFORM_URL=https://platform.computesdk.com
+export BENCHMARKS_PLATFORM_API_KEY=bp_...
+
+bench benchmarks list --json --limit 100
+```
+
+If no credentials are present and `CI` is set or stdin is not a TTY, the CLI
+fails fast with an `AuthError`.
+
+## Environment variables
+
+- `BENCHMARKS_PLATFORM_URL` — platform root URL (default: `https://platform.computesdk.com`)
+- `BENCHMARKS_PLATFORM_API_KEY` / `COMPUTESDK_API_KEY` — API key
+- `BENCHMARKS_PLATFORM_TOKEN` — bearer/session token
+- `CI` — when set, the CLI avoids interactive prompts
+
+## Global flags
+
+- `--base-url <url>` — override the platform URL
+- `--api-key <key>` — use an API key for this command
+- `--org <slug>` — override the active organization
+- `--format json|table` — output format
+- `--json` — shortcut for `--format json`
+- `--verbose` — print stack traces and extra diagnostics on errors
+- `--version`
+- `--help` and `bench <command> --help`
+
+## Exit codes
+
+- `0` — success
+- `1` — general error or API failure
+- `2` — authentication error
+
+## Troubleshooting
+
+- `bench --version` shows `0.0.0` — the `dist/` output is stale or the
+  `package.json` was not found. Rebuild with `pnpm --filter @benchsdk/cli build`.
+- `Cannot find module .../dist/bin.cjs` — build `@benchsdk/runner` first:
+  `pnpm --filter @benchsdk/runner build`.
+- `Your session has expired` — the refresh token is expired or revoked. Run
+  `bench auth login` again, or use `BENCHMARKS_PLATFORM_API_KEY`.
+- 401/403 on list commands — verify the active org with `bench auth status` or
+  pass `--org <slug>`.
+- The CLI auto-refreshes access tokens within 5 minutes of expiry. If a command
+  fails with an auth error, the refresh token may also be expired.
+
+## Secrets needed
+
+None for local development with `BENCHMARKS_PLATFORM_API_KEY` if one is
+provided. For OAuth login in CI, prefer `BENCHMARKS_PLATFORM_API_KEY` or
+`BENCHMARKS_PLATFORM_TOKEN` instead of `bench auth login`.

--- a/packages/benchsdk-api/src/client.ts
+++ b/packages/benchsdk-api/src/client.ts
@@ -256,8 +256,11 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
       return data.benchmark;
     },
 
-    async listBenchmarks() {
-      const data = await request<{ items?: BenchmarkResource[]; benchmarks?: BenchmarkResource[] }>('GET', '/benchmarks');
+    async listBenchmarks(options: { limit?: number; offset?: number } = {}) {
+      const data = await request<{ items?: BenchmarkResource[]; benchmarks?: BenchmarkResource[] }>(
+        'GET',
+        `/benchmarks${queryString(options)}`,
+      );
       return data.items ?? data.benchmarks ?? [];
     },
 
@@ -269,8 +272,11 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
       );
     },
 
-    async listRuns(benchmarkSlug) {
-      const data = await request<{ items: BenchmarkRun[] }>('GET', `/benchmarks/${encodePath(benchmarkSlug)}/runs`);
+    async listRuns(benchmarkSlug, options: { limit?: number; offset?: number } = {}) {
+      const data = await request<{ items: BenchmarkRun[] }>(
+        'GET',
+        `/benchmarks/${encodePath(benchmarkSlug)}/runs${queryString(options)}`,
+      );
       return data.items;
     },
 
@@ -436,18 +442,18 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
       return response;
     },
 
-    async listRunArtifacts(benchmarkSlug, runId) {
+    async listRunArtifacts(benchmarkSlug, runId, options: { limit?: number; offset?: number } = {}) {
       const data = await request<{ items?: BenchmarkArtifact[]; artifacts?: BenchmarkArtifact[] }>(
         'GET',
-        `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/artifacts`,
+        `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/artifacts${queryString(options)}`,
       );
       return normalizeArtifacts(data);
     },
 
-    async listWorkerArtifacts(benchmarkSlug, runId, workerId) {
+    async listWorkerArtifacts(benchmarkSlug, runId, workerId, options: { limit?: number; offset?: number } = {}) {
       const data = await request<{ items?: BenchmarkArtifact[]; artifacts?: BenchmarkArtifact[] }>(
         'GET',
-        `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/workers/${encodePath(workerId)}/artifacts`,
+        `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/workers/${encodePath(workerId)}/artifacts${queryString(options)}`,
       );
       return normalizeArtifacts(data);
     },
@@ -476,7 +482,7 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
     async getBenchmarkResults(benchmarkSlug, input: BenchmarkResultsOverviewInput = {}) {
       return request<BenchmarkResultsOverview>(
         'GET',
-        `/benchmarks/${encodePath(benchmarkSlug)}/results${queryString({ limit: input.limit })}`,
+        `/benchmarks/${encodePath(benchmarkSlug)}/results${queryString({ limit: input.limit, offset: input.offset })}`,
       );
     },
 

--- a/packages/benchsdk-api/src/client.ts
+++ b/packages/benchsdk-api/src/client.ts
@@ -82,6 +82,14 @@ function getApiKey(input?: string): string | undefined {
   return process.env.BENCHMARKS_PLATFORM_API_KEY ?? process.env.COMPUTESDK_API_KEY;
 }
 
+function getAuthToken(config: BenchmarkClientConfig): string | undefined {
+  if (config.token) return config.token;
+  if (typeof process !== 'undefined' && process.env.BENCHMARKS_PLATFORM_TOKEN) {
+    return process.env.BENCHMARKS_PLATFORM_TOKEN;
+  }
+  return getApiKey(config.apiKey);
+}
+
 function getErrorCode(error: unknown): string {
   if (error instanceof Error && 'code' in error && typeof (error as { code: unknown }).code === 'string' && (error as { code: string }).code) {
     return (error as { code: string }).code;
@@ -166,7 +174,7 @@ async function downloadArtifactBody(
 
 export function createBenchmarkClient(config: BenchmarkClientConfig = {}): BenchmarkClient {
   const baseUrl = trimTrailingSlash(config.baseUrl ?? DEFAULT_BASE_URL);
-  const apiKey = getApiKey(config.apiKey);
+  const authToken = getAuthToken(config);
   const fetchImpl = config.fetch ?? (typeof fetch !== 'undefined' ? fetch : undefined);
 
   if (!fetchImpl) {
@@ -176,7 +184,9 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
 
   async function request<T>(method: string, path: string, body?: JsonObject): Promise<T> {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+    if (authToken) headers.Authorization = `Bearer ${authToken}`;
+    if (config.orgSlug) headers['X-Org-Slug'] = config.orgSlug;
+    else if (config.orgId) headers['X-Organization-Id'] = config.orgId;
 
     const response = await doFetch(`${baseUrl}${path}`, {
       method,

--- a/packages/benchsdk-api/src/types.ts
+++ b/packages/benchsdk-api/src/types.ts
@@ -316,6 +316,7 @@ export interface BenchmarkStepResultSummary {
 
 export interface BenchmarkResultsOverviewInput {
   limit?: number;
+  offset?: number;
 }
 
 export type BenchmarkAnalyticsReadiness = 'ready' | 'complete' | 'partial' | 'pending' | 'unavailable' | 'failed';
@@ -687,14 +688,14 @@ export interface BenchmarkClient {
   upsertBenchmark(slug: string, input: UpsertBenchmarkInput): Promise<BenchmarkResource>;
   updateBenchmark(slug: string, input: UpdateBenchmarkInput): Promise<BenchmarkResource>;
   getBenchmark(slug: string): Promise<BenchmarkResource>;
-  listBenchmarks(): Promise<BenchmarkResource[]>;
+  listBenchmarks(options?: { limit?: number; offset?: number }): Promise<BenchmarkResource[]>;
   createRun(benchmarkSlug: string, input: CreateRunInput): Promise<{
     run: BenchmarkRun;
     participants: BenchmarkParticipant[];
     /** The slug of the org the run was attributed to, resolved server-side from the caller's API key. */
     organizationSlug: string;
   }>;
-  listRuns(benchmarkSlug: string): Promise<BenchmarkRun[]>;
+  listRuns(benchmarkSlug: string, options?: { limit?: number; offset?: number }): Promise<BenchmarkRun[]>;
   getRun(benchmarkSlug: string, runId: string): Promise<BenchmarkRun>;
   updateRun(benchmarkSlug: string, runId: string, input: UpdateRunInput): Promise<BenchmarkRun>;
   upsertParticipant(
@@ -772,8 +773,8 @@ export interface BenchmarkClient {
     workerId: string,
     input: UploadWorkerArtifactInput,
   ): Promise<CreateWorkerArtifactResponse>;
-  listRunArtifacts(benchmarkSlug: string, runId: string): Promise<BenchmarkArtifact[]>;
-  listWorkerArtifacts(benchmarkSlug: string, runId: string, workerId: string): Promise<BenchmarkArtifact[]>;
+  listRunArtifacts(benchmarkSlug: string, runId: string, options?: { limit?: number; offset?: number }): Promise<BenchmarkArtifact[]>;
+  listWorkerArtifacts(benchmarkSlug: string, runId: string, workerId: string, options?: { limit?: number; offset?: number }): Promise<BenchmarkArtifact[]>;
   getWorkerArtifact(
     benchmarkSlug: string,
     runId: string,

--- a/packages/benchsdk-api/src/types.ts
+++ b/packages/benchsdk-api/src/types.ts
@@ -6,6 +6,12 @@ export interface BenchmarkClientConfig {
   baseUrl?: string;
   /** Bearer token. Defaults to BENCHMARKS_PLATFORM_API_KEY, then COMPUTESDK_API_KEY. */
   apiKey?: string;
+  /** OAuth/session token. Takes precedence over apiKey when both are set. */
+  token?: string;
+  /** Explicit organization slug for OAuth requests. Sent as the X-Org-Slug header. */
+  orgSlug?: string;
+  /** Explicit organization id for OAuth requests. Sent as the X-Organization-Id header (orgSlug takes precedence). */
+  orgId?: string;
   /** Custom fetch implementation, mostly useful for tests. */
   fetch?: typeof fetch;
 }

--- a/packages/benchsdk-cli/package.json
+++ b/packages/benchsdk-cli/package.json
@@ -6,9 +6,6 @@
   "description": "CLI for querying ComputeSDK benchmarks platform data",
   "author": "Garrison",
   "license": "MIT",
-  "bin": {
-    "csdk-bench": "./dist/bin.cjs"
-  },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/benchsdk-cli/package.json
+++ b/packages/benchsdk-cli/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@benchsdk/cli",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "description": "CLI for querying ComputeSDK benchmarks platform data",
+  "author": "Garrison",
+  "license": "MIT",
+  "bin": {
+    "csdk-bench": "./dist/bin.cjs"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rimraf dist",
+    "dev": "tsup --watch",
+    "lint": "eslint",
+    "prepare": "tsup",
+    "pretest": "tsup",
+    "test": "vitest run --passWithNoTests",
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "computesdk",
+    "benchmark",
+    "cli"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/computesdk/benchmarks.git",
+    "directory": "packages/benchsdk-cli"
+  },
+  "homepage": "https://www.computesdk.com",
+  "bugs": {
+    "url": "https://github.com/computesdk/benchmarks/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@benchsdk/api": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.37.0",
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/benchsdk-cli/src/__tests__/cli.test.ts
+++ b/packages/benchsdk-cli/src/__tests__/cli.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseGlobalArgs, parseSubcommandOptions } from '../cli.js';
+import { getPlatformBaseUrl, getApiBaseUrl, getAuthBaseUrl } from '../platform.js';
+
+describe('parseGlobalArgs', () => {
+  it('parses global options and keeps positionals', () => {
+    const result = parseGlobalArgs(['--base-url', 'http://localhost:3000', 'benchmarks', 'list']);
+    expect(result.values).toEqual({ 'base-url': 'http://localhost:3000' });
+    expect(result.positionals).toEqual(['benchmarks', 'list']);
+  });
+
+  it('parses boolean flags', () => {
+    const result = parseGlobalArgs(['--json', 'results', 'my-bench']);
+    expect(result.values.json).toBe(true);
+    expect(result.positionals).toEqual(['results', 'my-bench']);
+  });
+
+  it('ignores unknown options so subcommands can parse them', () => {
+    const result = parseGlobalArgs(['results', 'my-bench', '--run', 'run-123', '--json']);
+    expect(result.positionals).toEqual(['results', 'my-bench', '--run', 'run-123']);
+    expect(result.values.json).toBe(true);
+  });
+});
+
+describe('parseSubcommandOptions', () => {
+  it('parses string and number options with positional values', () => {
+    const { options, positionals } = parseSubcommandOptions([
+      'list',
+      'my-bench',
+      '--limit',
+      '10',
+      '--run',
+      'run-123',
+    ]);
+    expect(options).toEqual({ limit: 10, run: 'run-123' });
+    expect(positionals).toEqual(['list', 'my-bench']);
+  });
+
+  it('parses --key=value syntax', () => {
+    const { options, positionals } = parseSubcommandOptions(['my-bench', '--out=/tmp/export']);
+    expect(options).toEqual({ out: '/tmp/export' });
+    expect(positionals).toEqual(['my-bench']);
+  });
+
+  it('throws on unknown options', () => {
+    expect(() => parseSubcommandOptions(['my-bench', '--unknown', 'x'])).toThrow('Unknown option');
+  });
+
+  it('throws on missing values', () => {
+    expect(() => parseSubcommandOptions(['my-bench', '--run'])).toThrow('requires a value');
+  });
+
+  it('throws on non-numeric limit', () => {
+    expect(() => parseSubcommandOptions(['my-bench', '--limit', 'abc'])).toThrow('number');
+  });
+});
+
+describe('platform URL helpers', () => {
+  const originalEnv = process.env.BENCHMARKS_PLATFORM_URL;
+
+  beforeEach(() => {
+    delete process.env.BENCHMARKS_PLATFORM_URL;
+  });
+
+  afterEach(() => {
+    if (originalEnv) process.env.BENCHMARKS_PLATFORM_URL = originalEnv;
+    else delete process.env.BENCHMARKS_PLATFORM_URL;
+  });
+
+  it('uses default platform URL', () => {
+    expect(getPlatformBaseUrl()).toBe('https://platform.computesdk.com');
+    expect(getApiBaseUrl()).toBe('https://platform.computesdk.com/api/v1');
+    expect(getAuthBaseUrl()).toBe('https://platform.computesdk.com/api/auth');
+  });
+
+  it('uses environment override', () => {
+    process.env.BENCHMARKS_PLATFORM_URL = 'http://localhost:3000';
+    expect(getPlatformBaseUrl()).toBe('http://localhost:3000');
+    expect(getApiBaseUrl()).toBe('http://localhost:3000/api/v1');
+    expect(getAuthBaseUrl()).toBe('http://localhost:3000/api/auth');
+  });
+
+  it('does not double-append /api/v1', () => {
+    expect(getApiBaseUrl('http://localhost:3000/api/v1')).toBe('http://localhost:3000/api/v1');
+    expect(getAuthBaseUrl('http://localhost:3000/api/v1')).toBe('http://localhost:3000/api/auth');
+  });
+});
+
+describe('auth device flow', () => {
+  it('requestDeviceCode fetches /device/code', async () => {
+    const { requestDeviceCode } = await import('../auth.js');
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () =>
+        JSON.stringify({
+          device_code: 'dc',
+          user_code: 'UC-1234',
+          verification_uri: 'http://localhost:3000/device',
+          expires_in: 900,
+          interval: 5,
+        }),
+    });
+    globalThis.fetch = fetchSpy;
+
+    const result = await requestDeviceCode('http://localhost:3000/api/auth', 'benchsdk-cli');
+    expect(result.device_code).toBe('dc');
+    expect(result.user_code).toBe('UC-1234');
+    expect(fetchSpy).toHaveBeenCalledWith('http://localhost:3000/api/auth/device/code', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ client_id: 'benchsdk-cli' }),
+    });
+  });
+});

--- a/packages/benchsdk-cli/src/__tests__/cli.test.ts
+++ b/packages/benchsdk-cli/src/__tests__/cli.test.ts
@@ -20,6 +20,12 @@ describe('parseGlobalArgs', () => {
     expect(result.positionals).toEqual(['results', 'my-bench', '--run', 'run-123']);
     expect(result.values.json).toBe(true);
   });
+
+  it('keeps values containing = when passed as --key=value', () => {
+    const result = parseGlobalArgs(['--api-key=sk-abc==', '--base-url=http://h?a=b']);
+    expect(result.values['api-key']).toBe('sk-abc==');
+    expect(result.values['base-url']).toBe('http://h?a=b');
+  });
 });
 
 describe('parseSubcommandOptions', () => {
@@ -39,6 +45,12 @@ describe('parseSubcommandOptions', () => {
   it('parses --key=value syntax', () => {
     const { options, positionals } = parseSubcommandOptions(['my-bench', '--out=/tmp/export']);
     expect(options).toEqual({ out: '/tmp/export' });
+    expect(positionals).toEqual(['my-bench']);
+  });
+
+  it('keeps values containing = in --key=value syntax', () => {
+    const { options, positionals } = parseSubcommandOptions(['my-bench', '--out=/a=b=c']);
+    expect(options).toEqual({ out: '/a=b=c' });
     expect(positionals).toEqual(['my-bench']);
   });
 

--- a/packages/benchsdk-cli/src/auth.ts
+++ b/packages/benchsdk-cli/src/auth.ts
@@ -1,0 +1,117 @@
+export interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval: number;
+}
+
+export interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  scope?: string;
+}
+
+export class DeviceFlowError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'DeviceFlowError';
+  }
+}
+
+export async function requestDeviceCode(authBaseUrl: string, clientId = 'benchsdk-cli'): Promise<DeviceCodeResponse> {
+  const response = await fetch(`${authBaseUrl}/device/code`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ client_id: clientId }),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    let description = `Device code request failed: ${response.status} ${response.statusText}`;
+    try {
+      const body = JSON.parse(text) as { error_description?: string };
+      if (body.error_description) description = body.error_description;
+    } catch {
+      // ignore
+    }
+    throw new DeviceFlowError('server_error', description);
+  }
+  return JSON.parse(text) as DeviceCodeResponse;
+}
+
+export async function exchangeDeviceToken(
+  authBaseUrl: string,
+  deviceCode: string,
+  clientId = 'benchsdk-cli',
+): Promise<TokenResponse> {
+  const response = await fetch(`${authBaseUrl}/device/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      device_code: deviceCode,
+      client_id: clientId,
+    }),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    let body: { error?: string; error_description?: string } = {};
+    try {
+      body = JSON.parse(text);
+    } catch {
+      // ignore
+    }
+    const code = body.error ?? 'server_error';
+    if (
+      code === 'authorization_pending' ||
+      code === 'slow_down' ||
+      code === 'expired_token' ||
+      code === 'access_denied' ||
+      code === 'invalid_grant'
+    ) {
+      throw new DeviceFlowError(code, body.error_description ?? `Device flow error: ${code}`);
+    }
+    throw new Error(body.error_description ?? `Device token exchange failed: ${response.status} ${response.statusText}`);
+  }
+  return JSON.parse(text) as TokenResponse;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function pollDeviceToken(
+  authBaseUrl: string,
+  deviceCode: string,
+  intervalSeconds: number,
+  expiresInSeconds: number,
+): Promise<TokenResponse> {
+  const start = Date.now();
+  let interval = intervalSeconds * 1000;
+  const expiresIn = expiresInSeconds * 1000;
+
+  while (Date.now() - start < expiresIn) {
+    await sleep(interval);
+
+    try {
+      const token = await exchangeDeviceToken(authBaseUrl, deviceCode);
+      return token;
+    } catch (err) {
+      if (err instanceof DeviceFlowError) {
+        if (err.code === 'authorization_pending') continue;
+        if (err.code === 'slow_down') {
+          interval += 5000;
+          continue;
+        }
+      }
+      throw err;
+    }
+  }
+
+  throw new DeviceFlowError('expired_token', 'Device code expired before authorization completed.');
+}

--- a/packages/benchsdk-cli/src/auth.ts
+++ b/packages/benchsdk-cli/src/auth.ts
@@ -9,8 +9,10 @@ export interface DeviceCodeResponse {
 
 export interface TokenResponse {
   access_token: string;
+  refresh_token: string;
   token_type: string;
   expires_in: number;
+  refresh_expires_in: number;
   scope?: string;
 }
 
@@ -21,6 +23,13 @@ export class DeviceFlowError extends Error {
   ) {
     super(message);
     this.name = 'DeviceFlowError';
+  }
+}
+
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthError';
   }
 }
 
@@ -49,7 +58,7 @@ export async function exchangeDeviceToken(
   deviceCode: string,
   clientId = 'benchsdk-cli',
 ): Promise<TokenResponse> {
-  const response = await fetch(`${authBaseUrl}/device/token`, {
+  const response = await fetch(`${authBaseUrl}/cli/device-token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -81,6 +90,32 @@ export async function exchangeDeviceToken(
   return JSON.parse(text) as TokenResponse;
 }
 
+export async function refreshAccessToken(
+  authBaseUrl: string,
+  refreshToken: string,
+  clientId = 'benchsdk-cli',
+): Promise<TokenResponse> {
+  const response = await fetch(`${authBaseUrl}/cli/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      refresh_token: refreshToken,
+      client_id: clientId,
+    }),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    let body: { error?: string; error_description?: string } = {};
+    try {
+      body = JSON.parse(text);
+    } catch {
+      // ignore
+    }
+    throw new AuthError(body.error_description ?? `Token refresh failed: ${response.status} ${response.statusText}`);
+  }
+  return JSON.parse(text) as TokenResponse;
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -90,6 +125,7 @@ export async function pollDeviceToken(
   deviceCode: string,
   intervalSeconds: number,
   expiresInSeconds: number,
+  clientId = 'benchsdk-cli',
 ): Promise<TokenResponse> {
   const start = Date.now();
   let interval = intervalSeconds * 1000;
@@ -99,7 +135,7 @@ export async function pollDeviceToken(
     await sleep(interval);
 
     try {
-      const token = await exchangeDeviceToken(authBaseUrl, deviceCode);
+      const token = await exchangeDeviceToken(authBaseUrl, deviceCode, clientId);
       return token;
     } catch (err) {
       if (err instanceof DeviceFlowError) {

--- a/packages/benchsdk-cli/src/bin.ts
+++ b/packages/benchsdk-cli/src/bin.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { run } from './cli.js';
+
+run(process.argv.slice(2));

--- a/packages/benchsdk-cli/src/bin.ts
+++ b/packages/benchsdk-cli/src/bin.ts
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-import { run } from './cli.js';
-
-run(process.argv.slice(2));

--- a/packages/benchsdk-cli/src/cli.ts
+++ b/packages/benchsdk-cli/src/cli.ts
@@ -1,0 +1,407 @@
+import { writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { BenchmarkApiError } from '@benchsdk/api';
+import { requestDeviceCode, pollDeviceToken } from './auth.js';
+import { loadCredentials, saveCredentials, clearCredentials } from './config.js';
+import { createApiClient, getMe, listOrganizations, setActiveOrganization } from './client.js';
+import { printData, type OutputOptions } from './output.js';
+import { getPlatformBaseUrl } from './platform.js';
+
+const USAGE = `Usage: csdk-bench [options] <command>
+
+Commands:
+  auth login                         Authenticate with OAuth device flow
+  auth logout                        Remove saved credentials
+  auth status                        Show current user and active organization
+  org list                           List organizations
+  org use <slug>                     Set active organization
+  benchmarks list                    List benchmarks
+  runs list <benchmark-slug> [--limit N]
+  runs show <benchmark-slug> <runId>
+  results <benchmark-slug> [--run <id>] [--format json|table]
+  artifacts list <benchmark-slug> <runId> [--worker <id>]
+  export <benchmark-slug> [--run <id>] [--out <dir>]
+
+Options:
+  --base-url <url>                   Platform root URL (default: https://platform.computesdk.com)
+  --api-key <key>                    Use an API key instead of OAuth
+  --org <slug>                       Organization slug for this command
+  --json                             Output JSON (also --format json on results)
+  --help                             Show this help
+`;
+
+interface GlobalOptions {
+  'base-url'?: string;
+  'api-key'?: string;
+  org?: string;
+  json?: boolean;
+  help?: boolean;
+}
+
+interface ParsedOptions {
+  values: GlobalOptions;
+  positionals: string[];
+}
+
+function parseGlobalArgs(argv: string[]): ParsedOptions {
+  const values: GlobalOptions = {};
+  const positionals: string[] = [];
+  const stringGlobals = new Set(['base-url', 'api-key', 'org']);
+  const booleanGlobals = new Set(['json', 'help']);
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) {
+      positionals.push(arg);
+      i += 1;
+      continue;
+    }
+
+    const [namePart, valuePart] = arg.split('=');
+    const key = namePart.slice(2);
+
+    if (stringGlobals.has(key)) {
+      const rawValue = valuePart ?? argv[i + 1];
+      if (rawValue === undefined) throw new Error(`Option --${key} requires a value`);
+      (values as Record<string, string>)[key] = rawValue;
+      i += valuePart !== undefined ? 1 : 2;
+    } else if (booleanGlobals.has(key)) {
+      if (valuePart !== undefined) {
+        (values as Record<string, boolean>)[key] = valuePart === 'true' || valuePart === '1';
+        i += 1;
+      } else {
+        (values as Record<string, boolean>)[key] = true;
+        i += 1;
+      }
+    } else {
+      // Unknown option: leave it for the subcommand parser.
+      positionals.push(arg);
+      i += 1;
+    }
+  }
+
+  return { values, positionals };
+}
+
+const subcommandOptionSchema = {
+  limit: { type: 'number' as const },
+  run: { type: 'string' as const },
+  format: { type: 'string' as const },
+  worker: { type: 'string' as const },
+  out: { type: 'string' as const },
+};
+
+function parseSubcommandOptions(args: string[]): { options: Record<string, string | number>; positionals: string[] } {
+  const options: Record<string, string | number> = {};
+  const positionals: string[] = [];
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    if (!arg.startsWith('--')) {
+      positionals.push(arg);
+      i += 1;
+      continue;
+    }
+
+    const [namePart, valuePart] = arg.split('=');
+    const key = namePart.slice(2);
+    const schema = subcommandOptionSchema[key as keyof typeof subcommandOptionSchema];
+    if (!schema) throw new Error(`Unknown option: ${arg}`);
+
+    let rawValue: string;
+    if (valuePart !== undefined) {
+      rawValue = valuePart;
+      i += 1;
+    } else {
+      if (i + 1 >= args.length) throw new Error(`Option --${key} requires a value`);
+      rawValue = args[i + 1];
+      i += 2;
+    }
+
+    if (schema.type === 'number') {
+      const n = Number(rawValue);
+      if (!Number.isFinite(n)) throw new Error(`Option --${key} must be a number`);
+      options[key] = n;
+    } else {
+      options[key] = rawValue;
+    }
+  }
+  return { options, positionals };
+}
+
+async function printErrorAndExit(err: unknown): Promise<never> {
+  if (err instanceof BenchmarkApiError) {
+    console.error(`API error: ${err.message}`);
+    if (err.body) console.error(err.body);
+  } else if (err instanceof Error) {
+    console.error(err.message);
+  } else {
+    console.error('Unexpected error:', err);
+  }
+  process.exit(1);
+}
+
+async function handleAuthLogin(overrides: { baseUrl?: string }): Promise<void> {
+  const baseUrl = getPlatformBaseUrl(overrides.baseUrl);
+  const authBaseUrl = `${baseUrl}/api/auth`;
+  const { device_code, user_code, verification_uri_complete, verification_uri, expires_in, interval } =
+    await requestDeviceCode(authBaseUrl);
+
+  console.log(`To sign in, visit:`);
+  console.log(verification_uri_complete ?? verification_uri);
+  console.log(`User code: ${user_code}`);
+
+  const { access_token } = await pollDeviceToken(authBaseUrl, device_code, interval, expires_in);
+  await saveCredentials({ baseUrl, token: access_token, kind: 'oauth' });
+
+  console.log('Authenticated.');
+
+  const { api, auth } = await createApiClient({ baseUrl });
+  try {
+    const me = await getMe(auth);
+    if (!me.activeOrganizationId && me.organizations.length === 1) {
+      const org = me.organizations[0];
+      await setActiveOrganization(auth, org.slug);
+      await saveCredentials({ baseUrl, token: access_token, kind: 'oauth', orgSlug: org.slug, orgId: org.id });
+      console.log(`Set active organization to ${org.slug}`);
+    }
+  } catch {
+    // organization auto-select is best-effort
+  }
+}
+
+async function handleAuthLogout(): Promise<void> {
+  await clearCredentials();
+  console.log('Logged out.');
+}
+
+async function handleAuthStatus(
+  overrides: { baseUrl?: string; apiKey?: string },
+  outputOptions: OutputOptions = {},
+): Promise<void> {
+  const { auth } = await createApiClient(overrides);
+  const me = await getMe(auth);
+  const activeOrg = me.organizations.find((o) => o.id === me.activeOrganizationId);
+  printData(
+    {
+      user: me.user,
+      activeOrganization: activeOrg ?? null,
+      organizations: me.organizations,
+    },
+    outputOptions,
+  );
+}
+
+async function handleOrgList(
+  overrides: { baseUrl?: string; apiKey?: string },
+  outputOptions: OutputOptions = {},
+): Promise<void> {
+  const { auth } = await createApiClient(overrides);
+  const organizations = await listOrganizations(auth);
+  printData(organizations, outputOptions);
+}
+
+async function handleOrgUse(slug: string, overrides: { baseUrl?: string; apiKey?: string }): Promise<void> {
+  const credentials = (await loadCredentials()) ?? {};
+  const { auth } = await createApiClient(overrides);
+  const result = await setActiveOrganization(auth, slug);
+  if (!result.organization) {
+    throw new Error(`Could not set active organization to ${slug}`);
+  }
+  await saveCredentials({
+    ...credentials,
+    baseUrl: auth.baseUrl,
+    orgSlug: result.organization.slug,
+    orgId: result.organization.id,
+  });
+  console.log(`Active organization set to ${result.organization.slug} (${result.organization.id})`);
+}
+
+async function handleBenchmarksList(
+  overrides: { baseUrl?: string; apiKey?: string; org?: string },
+  outputOptions: OutputOptions = {},
+): Promise<void> {
+  const { api } = await createApiClient(overrides);
+  const benchmarks = await api.listBenchmarks();
+  printData(benchmarks, outputOptions);
+}
+
+async function handleRunsList(
+  benchmarkSlug: string,
+  limit: number | undefined,
+  overrides: { baseUrl?: string; apiKey?: string; org?: string },
+  outputOptions: OutputOptions = {},
+): Promise<void> {
+  const { api } = await createApiClient(overrides);
+  const runs = await api.listRuns(benchmarkSlug);
+  printData(limit ? runs.slice(0, limit) : runs, outputOptions);
+}
+
+async function handleRunsShow(
+  benchmarkSlug: string,
+  runId: string,
+  overrides: { baseUrl?: string; apiKey?: string; org?: string },
+  outputOptions: OutputOptions = {},
+): Promise<void> {
+  const { api } = await createApiClient(overrides);
+  const run = await api.getRun(benchmarkSlug, runId);
+  printData(run, outputOptions);
+}
+
+async function handleResults(
+  benchmarkSlug: string,
+  options: { run?: string; format?: string },
+  overrides: { baseUrl?: string; apiKey?: string; org?: string },
+  outputOptions: OutputOptions = {},
+): Promise<void> {
+  const { api } = await createApiClient(overrides);
+  const results = options.run
+    ? await api.getRunResults(benchmarkSlug, options.run as string)
+    : await api.getBenchmarkResults(benchmarkSlug);
+  printData(results, { json: outputOptions.json || options.format === 'json' });
+}
+
+async function handleArtifactsList(
+  benchmarkSlug: string,
+  runId: string,
+  workerId: string | undefined,
+  overrides: { baseUrl?: string; apiKey?: string; org?: string },
+  outputOptions: OutputOptions = {},
+): Promise<void> {
+  const { api } = await createApiClient(overrides);
+  const artifacts = workerId
+    ? await api.listWorkerArtifacts(benchmarkSlug, runId, workerId)
+    : await api.listRunArtifacts(benchmarkSlug, runId);
+  printData(artifacts, outputOptions);
+}
+
+async function handleExport(
+  benchmarkSlug: string,
+  options: { run?: string; out?: string },
+  overrides: { baseUrl?: string; apiKey?: string; org?: string },
+): Promise<void> {
+  const { api } = await createApiClient(overrides);
+  const outDir = options.out ?? '.';
+  await mkdir(outDir, { recursive: true });
+
+  if (options.run) {
+    const runId = options.run as string;
+    const [run, results] = await Promise.all([api.getRun(benchmarkSlug, runId), api.getRunResults(benchmarkSlug, runId)]);
+    const payload = { benchmarkSlug, runId, run, results };
+    const path = join(outDir, `${benchmarkSlug}-${runId}.json`);
+    await writeFile(path, JSON.stringify(payload, null, 2));
+    console.log(`Exported to ${path}`);
+  } else {
+    const results = await api.getBenchmarkResults(benchmarkSlug);
+    const path = join(outDir, `${benchmarkSlug}.json`);
+    await writeFile(path, JSON.stringify(results, null, 2));
+    console.log(`Exported to ${path}`);
+  }
+}
+
+export async function run(argv: string[]): Promise<void> {
+  let { values, positionals } = parseGlobalArgs(argv);
+  if (values.help || positionals.length === 0) {
+    console.log(USAGE);
+    process.exit(values.help ? 0 : 1);
+  }
+
+  const [command, ...rest] = positionals;
+  const overrides = {
+    baseUrl: values['base-url'],
+    apiKey: values['api-key'],
+    org: values.org,
+  };
+  const outputOptions: OutputOptions = { json: !!values.json };
+
+  try {
+    switch (command) {
+      case 'auth': {
+        const [sub, ...subRest] = rest;
+        const { positionals: subPositionals } = parseSubcommandOptions(subRest);
+        if (sub === 'login') {
+          await handleAuthLogin(overrides);
+        } else if (sub === 'logout') {
+          await handleAuthLogout();
+        } else if (sub === 'status') {
+          await handleAuthStatus(overrides, outputOptions);
+        } else {
+          throw new Error(USAGE);
+        }
+        break;
+      }
+      case 'org': {
+        const [sub, ...subRest] = rest;
+        const { positionals: subPositionals } = parseSubcommandOptions(subRest);
+        if (sub === 'list') {
+          await handleOrgList(overrides, outputOptions);
+        } else if (sub === 'use') {
+          const slug = subPositionals[0];
+          if (!slug) throw new Error('Organization slug required: csdk-bench org use <slug>');
+          await handleOrgUse(slug, overrides);
+        } else {
+          throw new Error(USAGE);
+        }
+        break;
+      }
+      case 'benchmarks': {
+        const [sub, ...subRest] = rest;
+        if (sub === 'list') {
+          await handleBenchmarksList(overrides, outputOptions);
+        } else {
+          throw new Error(USAGE);
+        }
+        break;
+      }
+      case 'runs': {
+        const { options, positionals: subPositionals } = parseSubcommandOptions(rest);
+        const [sub, slug, runId] = subPositionals;
+        if (sub === 'list') {
+          if (!slug) throw new Error('Benchmark slug required: csdk-bench runs list <benchmark-slug>');
+          await handleRunsList(slug, options.limit as number | undefined, overrides, outputOptions);
+        } else if (sub === 'show') {
+          if (!slug || !runId) throw new Error('Usage: csdk-bench runs show <benchmark-slug> <runId>');
+          await handleRunsShow(slug, runId, overrides, outputOptions);
+        } else {
+          throw new Error(USAGE);
+        }
+        break;
+      }
+      case 'results': {
+        const { options, positionals: subPositionals } = parseSubcommandOptions(rest);
+        const [slug] = subPositionals;
+        if (!slug) throw new Error('Benchmark slug required: csdk-bench results <benchmark-slug>');
+        await handleResults(slug, options, overrides, outputOptions);
+        break;
+      }
+      case 'artifacts': {
+        const [sub, ...subRest] = rest;
+        const { options, positionals: subPositionals } = parseSubcommandOptions(subRest);
+        if (sub === 'list') {
+          const [slug, runId] = subPositionals;
+          if (!slug || !runId) throw new Error('Usage: csdk-bench artifacts list <benchmark-slug> <runId>');
+          await handleArtifactsList(slug, runId, options.worker as string | undefined, overrides, outputOptions);
+        } else {
+          throw new Error(USAGE);
+        }
+        break;
+      }
+      case 'export': {
+        const { options, positionals: subPositionals } = parseSubcommandOptions(rest);
+        const [slug] = subPositionals;
+        if (!slug) throw new Error('Benchmark slug required: csdk-bench export <benchmark-slug>');
+        await handleExport(slug, options, overrides);
+        break;
+      }
+      default:
+        throw new Error(USAGE);
+    }
+    process.exit(0);
+  } catch (err) {
+    await printErrorAndExit(err);
+  }
+}
+
+export { parseGlobalArgs, parseSubcommandOptions };
+

--- a/packages/benchsdk-cli/src/cli.ts
+++ b/packages/benchsdk-cli/src/cli.ts
@@ -12,18 +12,30 @@ let packageVersion: string | undefined;
 
 async function getVersion(): Promise<string> {
   if (packageVersion) return packageVersion;
-  try {
-    const pkgPath =
-      typeof __dirname !== 'undefined'
-        ? join(__dirname, '..', 'package.json')
-        : fileURLToPath(new URL('../../package.json', import.meta.url));
-    const pkg = JSON.parse(await readFile(pkgPath, 'utf-8')) as {
-      version?: string;
-    };
-    packageVersion = pkg.version ?? '0.0.0';
-  } catch {
-    packageVersion = '0.0.0';
+
+  const candidates: string[] = [];
+  if (typeof __dirname !== 'undefined') {
+    candidates.push(join(__dirname, '..', 'package.json'));
   }
+  if (typeof __dirname === 'undefined') {
+    const base = import.meta.url;
+    candidates.push(fileURLToPath(new URL('../package.json', base)));
+    candidates.push(fileURLToPath(new URL('../../package.json', base)));
+  }
+
+  for (const pkgPath of candidates) {
+    try {
+      const pkg = JSON.parse(await readFile(pkgPath, 'utf-8')) as { version?: string };
+      if (pkg.version) {
+        packageVersion = pkg.version;
+        return packageVersion;
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+
+  packageVersion = '0.0.0';
   return packageVersion;
 }
 

--- a/packages/benchsdk-cli/src/cli.ts
+++ b/packages/benchsdk-cli/src/cli.ts
@@ -1,11 +1,26 @@
-import { writeFile, mkdir } from 'node:fs/promises';
+import { writeFile, mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { BenchmarkApiError } from '@benchsdk/api';
-import { requestDeviceCode, pollDeviceToken } from './auth.js';
-import { loadCredentials, saveCredentials, clearCredentials } from './config.js';
+import { requestDeviceCode, pollDeviceToken, AuthError } from './auth.js';
+import { loadCredentials, saveCredentials, clearCredentials, loadConfig } from './config.js';
 import { createApiClient, getMe, listOrganizations, setActiveOrganization } from './client.js';
 import { printData, type OutputOptions } from './output.js';
 import { getPlatformBaseUrl } from './platform.js';
+
+let packageVersion: string | undefined;
+
+async function getVersion(): Promise<string> {
+  if (packageVersion) return packageVersion;
+  try {
+    const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf-8')) as {
+      version?: string;
+    };
+    packageVersion = pkg.version ?? '0.0.0';
+  } catch {
+    packageVersion = '0.0.0';
+  }
+  return packageVersion;
+}
 
 const USAGE = `Usage: bench [options] <command>
 
@@ -15,18 +30,26 @@ Commands:
   auth status                        Show current user and active organization
   org list                           List organizations
   org use <slug>                     Set active organization
-  benchmarks list                    List benchmarks
-  runs list <benchmark-slug> [--limit N]
-  runs show <benchmark-slug> <runId>
+  benchmarks list [--limit N] [--offset N]
+                                     List benchmarks
+  runs list <benchmark-slug> [--limit N] [--offset N]
+                                     List benchmark runs
+  runs show <benchmark-slug> <runId> Show a single run
   results <benchmark-slug> [--run <id>] [--format json|table]
+                                     Show benchmark or run results
   artifacts list <benchmark-slug> <runId> [--worker <id>]
+                                     List run artifacts
   export <benchmark-slug> [--run <id>] [--out <dir>]
+                                     Export benchmark or run results to JSON
 
 Options:
   --base-url <url>                   Platform root URL (default: https://platform.computesdk.com)
   --api-key <key>                    Use an API key instead of OAuth
   --org <slug>                       Organization slug for this command
-  --json                             Output JSON (also --format json on results)
+  --format json|table                Output format (also --json for JSON)
+  --json                             Output JSON
+  --verbose                          Include extra diagnostics on errors
+  --version                          Show version
   --help                             Show this help
 `;
 
@@ -34,7 +57,10 @@ interface GlobalOptions {
   'base-url'?: string;
   'api-key'?: string;
   org?: string;
+  format?: 'json' | 'table';
   json?: boolean;
+  verbose?: boolean;
+  version?: boolean;
   help?: boolean;
 }
 
@@ -43,11 +69,11 @@ interface ParsedOptions {
   positionals: string[];
 }
 
-function parseGlobalArgs(argv: string[]): ParsedOptions {
+export function parseGlobalArgs(argv: string[]): ParsedOptions {
   const values: GlobalOptions = {};
   const positionals: string[] = [];
-  const stringGlobals = new Set(['base-url', 'api-key', 'org']);
-  const booleanGlobals = new Set(['json', 'help']);
+  const stringGlobals = new Set(['base-url', 'api-key', 'org', 'format']);
+  const booleanGlobals = new Set(['json', 'verbose', 'version', 'help']);
 
   let i = 0;
   while (i < argv.length) {
@@ -88,13 +114,13 @@ function parseGlobalArgs(argv: string[]): ParsedOptions {
 
 const subcommandOptionSchema = {
   limit: { type: 'number' as const },
+  offset: { type: 'number' as const },
   run: { type: 'string' as const },
-  format: { type: 'string' as const },
   worker: { type: 'string' as const },
   out: { type: 'string' as const },
 };
 
-function parseSubcommandOptions(args: string[]): { options: Record<string, string | number>; positionals: string[] } {
+export function parseSubcommandOptions(args: string[]): { options: Record<string, string | number>; positionals: string[] } {
   const options: Record<string, string | number> = {};
   const positionals: string[] = [];
   let i = 0;
@@ -135,43 +161,102 @@ function parseSubcommandOptions(args: string[]): { options: Record<string, strin
   return { options, positionals };
 }
 
-async function printErrorAndExit(err: unknown): Promise<never> {
+function commandHelp(command?: string): string {
+  switch (command) {
+    case 'auth':
+      return `Usage: bench auth <subcommand>
+
+Subcommands:
+  login      Authenticate with OAuth device flow
+  logout     Remove saved credentials
+  status     Show current user and active organization`;
+    case 'org':
+      return `Usage: bench org <subcommand>
+
+Subcommands:
+  list       List organizations
+  use <slug> Set active organization`;
+    case 'benchmarks':
+      return `Usage: bench benchmarks list [--limit N] [--offset N]`;
+    case 'runs':
+      return `Usage: bench runs list <benchmark-slug> [--limit N] [--offset N]
+       bench runs show <benchmark-slug> <runId>`;
+    case 'results':
+      return `Usage: bench results <benchmark-slug> [--run <id>] [--format json|table]`;
+    case 'artifacts':
+      return `Usage: bench artifacts list <benchmark-slug> <runId> [--worker <id>]`;
+    case 'export':
+      return `Usage: bench export <benchmark-slug> [--run <id>] [--out <dir>]`;
+    default:
+      return USAGE;
+  }
+}
+
+async function printErrorAndExit(err: unknown, verbose = false): Promise<never> {
   if (err instanceof BenchmarkApiError) {
     console.error(`API error: ${err.message}`);
     if (err.body) console.error(err.body);
+  } else if (err instanceof AuthError) {
+    console.error(err.message);
+    if (verbose && err.stack) console.error(err.stack);
+    process.exit(2);
   } else if (err instanceof Error) {
     console.error(err.message);
+    if (verbose && err.stack) console.error(err.stack);
   } else {
     console.error('Unexpected error:', err);
   }
   process.exit(1);
 }
 
-async function handleAuthLogin(overrides: { baseUrl?: string }): Promise<void> {
+async function handleAuthLogin(overrides: { baseUrl?: string; verbose?: boolean }): Promise<void> {
   const baseUrl = getPlatformBaseUrl(overrides.baseUrl);
   const authBaseUrl = `${baseUrl}/api/auth`;
+  const clientId = 'benchsdk-cli';
   const { device_code, user_code, verification_uri_complete, verification_uri, expires_in, interval } =
-    await requestDeviceCode(authBaseUrl);
+    await requestDeviceCode(authBaseUrl, clientId);
 
   console.log(`To sign in, visit:`);
   console.log(verification_uri_complete ?? verification_uri);
   console.log(`User code: ${user_code}`);
 
-  const { access_token } = await pollDeviceToken(authBaseUrl, device_code, interval, expires_in);
-  await saveCredentials({ baseUrl, token: access_token, kind: 'oauth' });
+  const response = await pollDeviceToken(authBaseUrl, device_code, interval, expires_in, clientId);
+  const now = Date.now();
+  await saveCredentials({
+    baseUrl,
+    token: response.access_token,
+    refreshToken: response.refresh_token,
+    tokenExpiresAt: now + response.expires_in * 1000,
+    refreshExpiresAt: now + response.refresh_expires_in * 1000,
+    kind: 'oauth',
+  });
 
   console.log('Authenticated.');
 
-  const { api, auth } = await createApiClient({ baseUrl });
   try {
+    const { auth } = await createApiClient({ baseUrl });
     const me = await getMe(auth);
     if (!me.activeOrganizationId && me.organizations.length === 1) {
       const org = me.organizations[0];
       await setActiveOrganization(auth, org.slug);
-      await saveCredentials({ baseUrl, token: access_token, kind: 'oauth', orgSlug: org.slug, orgId: org.id });
+      const existing = (await loadCredentials()) ?? {};
+      await saveCredentials({
+        ...existing,
+        baseUrl,
+        token: auth.token,
+        refreshToken: auth.refreshToken,
+        tokenExpiresAt: auth.tokenExpiresAt,
+        refreshExpiresAt: auth.refreshExpiresAt,
+        orgSlug: org.slug,
+        orgId: org.id,
+        kind: 'oauth',
+      });
       console.log(`Set active organization to ${org.slug}`);
     }
-  } catch {
+  } catch (err) {
+    if (overrides.verbose) {
+      console.error('Organization auto-select failed:', err instanceof Error ? err.message : err);
+    }
     // organization auto-select is best-effort
   }
 }
@@ -217,30 +302,36 @@ async function handleOrgUse(slug: string, overrides: { baseUrl?: string; apiKey?
   await saveCredentials({
     ...credentials,
     baseUrl: auth.baseUrl,
+    token: auth.token,
+    refreshToken: auth.refreshToken,
+    tokenExpiresAt: auth.tokenExpiresAt,
+    refreshExpiresAt: auth.refreshExpiresAt,
     orgSlug: result.organization.slug,
     orgId: result.organization.id,
+    kind: 'oauth',
   });
   console.log(`Active organization set to ${result.organization.slug} (${result.organization.id})`);
 }
 
 async function handleBenchmarksList(
   overrides: { baseUrl?: string; apiKey?: string; org?: string },
+  options: { limit?: number; offset?: number },
   outputOptions: OutputOptions = {},
 ): Promise<void> {
   const { api } = await createApiClient(overrides);
-  const benchmarks = await api.listBenchmarks();
+  const benchmarks = await api.listBenchmarks(options);
   printData(benchmarks, outputOptions);
 }
 
 async function handleRunsList(
   benchmarkSlug: string,
-  limit: number | undefined,
+  options: { limit?: number; offset?: number },
   overrides: { baseUrl?: string; apiKey?: string; org?: string },
   outputOptions: OutputOptions = {},
 ): Promise<void> {
   const { api } = await createApiClient(overrides);
-  const runs = await api.listRuns(benchmarkSlug);
-  printData(limit ? runs.slice(0, limit) : runs, outputOptions);
+  const runs = await api.listRuns(benchmarkSlug, options);
+  printData(runs, outputOptions);
 }
 
 async function handleRunsShow(
@@ -264,7 +355,7 @@ async function handleResults(
   const results = options.run
     ? await api.getRunResults(benchmarkSlug, options.run as string)
     : await api.getBenchmarkResults(benchmarkSlug);
-  printData(results, { json: outputOptions.json || options.format === 'json' });
+  printData(results, { ...outputOptions, format: options.format === 'json' ? 'json' : outputOptions.format });
 }
 
 async function handleArtifactsList(
@@ -305,28 +396,58 @@ async function handleExport(
   }
 }
 
+function toOutputOptions(values: GlobalOptions): OutputOptions {
+  return {
+    json: !!values.json,
+    format: values.format ?? (values.json ? 'json' : 'table'),
+  };
+}
+
 export async function run(argv: string[]): Promise<void> {
-  let { values, positionals } = parseGlobalArgs(argv);
-  if (values.help || positionals.length === 0) {
-    console.log(USAGE);
-    process.exit(values.help ? 0 : 1);
+  let values: GlobalOptions;
+  let positionals: string[];
+  try {
+    ({ values, positionals } = parseGlobalArgs(argv));
+  } catch (err) {
+    await printErrorAndExit(err, false);
+    return;
   }
 
-  const [command, ...rest] = positionals;
+  if (values.version) {
+    console.log(await getVersion());
+    process.exit(0);
+  }
+
+  if (values.help || positionals.length === 0) {
+    if (values.help && positionals.length > 0) {
+      console.log(commandHelp(positionals[0]));
+    } else {
+      console.log(USAGE);
+    }
+    process.exit(values.help || positionals.length === 0 ? 0 : 1);
+  }
+
+  const config = (await loadConfig()) ?? {};
   const overrides = {
-    baseUrl: values['base-url'],
+    baseUrl: values['base-url'] ?? config.baseUrl,
     apiKey: values['api-key'],
-    org: values.org,
+    org: values.org ?? config.org,
   };
-  const outputOptions: OutputOptions = { json: !!values.json };
+  const outputOptions: OutputOptions = toOutputOptions(values);
 
   try {
+    const [command, ...rest] = positionals;
+
+    if (rest.includes('--help')) {
+      console.log(commandHelp(command));
+      process.exit(0);
+    }
+
     switch (command) {
       case 'auth': {
         const [sub, ...subRest] = rest;
-        const { positionals: subPositionals } = parseSubcommandOptions(subRest);
         if (sub === 'login') {
-          await handleAuthLogin(overrides);
+          await handleAuthLogin({ baseUrl: overrides.baseUrl, verbose: values.verbose });
         } else if (sub === 'logout') {
           await handleAuthLogout();
         } else if (sub === 'status') {
@@ -352,8 +473,9 @@ export async function run(argv: string[]): Promise<void> {
       }
       case 'benchmarks': {
         const [sub, ...subRest] = rest;
+        const { options } = parseSubcommandOptions(subRest);
         if (sub === 'list') {
-          await handleBenchmarksList(overrides, outputOptions);
+          await handleBenchmarksList(overrides, options, outputOptions);
         } else {
           throw new Error(USAGE);
         }
@@ -364,7 +486,7 @@ export async function run(argv: string[]): Promise<void> {
         const [sub, slug, runId] = subPositionals;
         if (sub === 'list') {
           if (!slug) throw new Error('Benchmark slug required: bench runs list <benchmark-slug>');
-          await handleRunsList(slug, options.limit as number | undefined, overrides, outputOptions);
+          await handleRunsList(slug, options, overrides, outputOptions);
         } else if (sub === 'show') {
           if (!slug || !runId) throw new Error('Usage: bench runs show <benchmark-slug> <runId>');
           await handleRunsShow(slug, runId, overrides, outputOptions);
@@ -404,9 +526,7 @@ export async function run(argv: string[]): Promise<void> {
     }
     process.exit(0);
   } catch (err) {
-    await printErrorAndExit(err);
+    await printErrorAndExit(err, values.verbose);
   }
 }
-
-export { parseGlobalArgs, parseSubcommandOptions };
 

--- a/packages/benchsdk-cli/src/cli.ts
+++ b/packages/benchsdk-cli/src/cli.ts
@@ -1,5 +1,6 @@
 import { writeFile, mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { BenchmarkApiError } from '@benchsdk/api';
 import { requestDeviceCode, pollDeviceToken, AuthError } from './auth.js';
 import { loadCredentials, saveCredentials, clearCredentials, loadConfig } from './config.js';
@@ -12,7 +13,11 @@ let packageVersion: string | undefined;
 async function getVersion(): Promise<string> {
   if (packageVersion) return packageVersion;
   try {
-    const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf-8')) as {
+    const pkgPath =
+      typeof __dirname !== 'undefined'
+        ? join(__dirname, '..', 'package.json')
+        : fileURLToPath(new URL('../../package.json', import.meta.url));
+    const pkg = JSON.parse(await readFile(pkgPath, 'utf-8')) as {
       version?: string;
     };
     packageVersion = pkg.version ?? '0.0.0';

--- a/packages/benchsdk-cli/src/cli.ts
+++ b/packages/benchsdk-cli/src/cli.ts
@@ -7,7 +7,7 @@ import { createApiClient, getMe, listOrganizations, setActiveOrganization } from
 import { printData, type OutputOptions } from './output.js';
 import { getPlatformBaseUrl } from './platform.js';
 
-const USAGE = `Usage: csdk-bench [options] <command>
+const USAGE = `Usage: bench [options] <command>
 
 Commands:
   auth login                         Authenticate with OAuth device flow
@@ -343,7 +343,7 @@ export async function run(argv: string[]): Promise<void> {
           await handleOrgList(overrides, outputOptions);
         } else if (sub === 'use') {
           const slug = subPositionals[0];
-          if (!slug) throw new Error('Organization slug required: csdk-bench org use <slug>');
+          if (!slug) throw new Error('Organization slug required: bench org use <slug>');
           await handleOrgUse(slug, overrides);
         } else {
           throw new Error(USAGE);
@@ -363,10 +363,10 @@ export async function run(argv: string[]): Promise<void> {
         const { options, positionals: subPositionals } = parseSubcommandOptions(rest);
         const [sub, slug, runId] = subPositionals;
         if (sub === 'list') {
-          if (!slug) throw new Error('Benchmark slug required: csdk-bench runs list <benchmark-slug>');
+          if (!slug) throw new Error('Benchmark slug required: bench runs list <benchmark-slug>');
           await handleRunsList(slug, options.limit as number | undefined, overrides, outputOptions);
         } else if (sub === 'show') {
-          if (!slug || !runId) throw new Error('Usage: csdk-bench runs show <benchmark-slug> <runId>');
+          if (!slug || !runId) throw new Error('Usage: bench runs show <benchmark-slug> <runId>');
           await handleRunsShow(slug, runId, overrides, outputOptions);
         } else {
           throw new Error(USAGE);
@@ -376,7 +376,7 @@ export async function run(argv: string[]): Promise<void> {
       case 'results': {
         const { options, positionals: subPositionals } = parseSubcommandOptions(rest);
         const [slug] = subPositionals;
-        if (!slug) throw new Error('Benchmark slug required: csdk-bench results <benchmark-slug>');
+        if (!slug) throw new Error('Benchmark slug required: bench results <benchmark-slug>');
         await handleResults(slug, options, overrides, outputOptions);
         break;
       }
@@ -385,7 +385,7 @@ export async function run(argv: string[]): Promise<void> {
         const { options, positionals: subPositionals } = parseSubcommandOptions(subRest);
         if (sub === 'list') {
           const [slug, runId] = subPositionals;
-          if (!slug || !runId) throw new Error('Usage: csdk-bench artifacts list <benchmark-slug> <runId>');
+          if (!slug || !runId) throw new Error('Usage: bench artifacts list <benchmark-slug> <runId>');
           await handleArtifactsList(slug, runId, options.worker as string | undefined, overrides, outputOptions);
         } else {
           throw new Error(USAGE);
@@ -395,7 +395,7 @@ export async function run(argv: string[]): Promise<void> {
       case 'export': {
         const { options, positionals: subPositionals } = parseSubcommandOptions(rest);
         const [slug] = subPositionals;
-        if (!slug) throw new Error('Benchmark slug required: csdk-bench export <benchmark-slug>');
+        if (!slug) throw new Error('Benchmark slug required: bench export <benchmark-slug>');
         await handleExport(slug, options, overrides);
         break;
       }

--- a/packages/benchsdk-cli/src/cli.ts
+++ b/packages/benchsdk-cli/src/cli.ts
@@ -58,11 +58,13 @@ function parseGlobalArgs(argv: string[]): ParsedOptions {
       continue;
     }
 
-    const [namePart, valuePart] = arg.split('=');
+    const eqIndex = arg.indexOf('=');
+    const namePart = eqIndex === -1 ? arg : arg.slice(0, eqIndex);
+    const valuePart = eqIndex === -1 ? undefined : arg.slice(eqIndex + 1);
     const key = namePart.slice(2);
 
     if (stringGlobals.has(key)) {
-      const rawValue = valuePart ?? argv[i + 1];
+      const rawValue = valuePart !== undefined ? valuePart : argv[i + 1];
       if (rawValue === undefined) throw new Error(`Option --${key} requires a value`);
       (values as Record<string, string>)[key] = rawValue;
       i += valuePart !== undefined ? 1 : 2;
@@ -104,7 +106,9 @@ function parseSubcommandOptions(args: string[]): { options: Record<string, strin
       continue;
     }
 
-    const [namePart, valuePart] = arg.split('=');
+    const eqIndex = arg.indexOf('=');
+    const namePart = eqIndex === -1 ? arg : arg.slice(0, eqIndex);
+    const valuePart = eqIndex === -1 ? undefined : arg.slice(eqIndex + 1);
     const key = namePart.slice(2);
     const schema = subcommandOptionSchema[key as keyof typeof subcommandOptionSchema];
     if (!schema) throw new Error(`Unknown option: ${arg}`);
@@ -113,10 +117,11 @@ function parseSubcommandOptions(args: string[]): { options: Record<string, strin
     if (valuePart !== undefined) {
       rawValue = valuePart;
       i += 1;
-    } else {
-      if (i + 1 >= args.length) throw new Error(`Option --${key} requires a value`);
+    } else if (i + 1 < args.length) {
       rawValue = args[i + 1];
       i += 2;
+    } else {
+      throw new Error(`Option --${key} requires a value`);
     }
 
     if (schema.type === 'number') {

--- a/packages/benchsdk-cli/src/client.ts
+++ b/packages/benchsdk-cli/src/client.ts
@@ -1,15 +1,27 @@
 import { createBenchmarkClient, type BenchmarkClient, BenchmarkApiError } from '@benchsdk/api';
-import { loadCredentials, type Credentials } from './config.js';
+import {
+  loadCredentials,
+  saveCredentials,
+  loadConfig,
+  mergeConfig,
+  type Credentials,
+  type Config,
+} from './config.js';
+import { refreshAccessToken, AuthError } from './auth.js';
 import { getApiBaseUrl, getAuthBaseUrl, getPlatformBaseUrl } from './platform.js';
 
 export interface CliAuth {
   token?: string;
+  refreshToken?: string;
+  tokenExpiresAt?: number;
+  refreshExpiresAt?: number;
   apiKey?: string;
   orgSlug?: string;
   orgId?: string;
   baseUrl: string;
   apiBaseUrl: string;
   authBaseUrl: string;
+  format?: 'json' | 'table';
 }
 
 function tokenFromEnvironment(): string | undefined {
@@ -17,8 +29,66 @@ function tokenFromEnvironment(): string | undefined {
   return process.env.BENCHMARKS_PLATFORM_TOKEN;
 }
 
+function apiKeyFromEnvironment(): string | undefined {
+  if (typeof process === 'undefined') return undefined;
+  return process.env.BENCHMARKS_PLATFORM_API_KEY ?? process.env.COMPUTESDK_API_KEY;
+}
+
+function isNonInteractive(): boolean {
+  if (typeof process === 'undefined') return false;
+  return !!process.env.CI || process.stdin.isTTY === false;
+}
+
+function computeTokenExpiry(expiresInSeconds: number): number {
+  return Date.now() + expiresInSeconds * 1000;
+}
+
+function updateCredentialsWithTokenResponse(
+  credentials: Credentials,
+  response: { access_token: string; refresh_token: string; expires_in: number; refresh_expires_in: number },
+): Credentials {
+  return {
+    ...credentials,
+    token: response.access_token,
+    refreshToken: response.refresh_token,
+    tokenExpiresAt: computeTokenExpiry(response.expires_in),
+    refreshExpiresAt: computeTokenExpiry(response.refresh_expires_in),
+  };
+}
+
+async function refreshIfNeeded(auth: CliAuth, credentials: Credentials): Promise<Credentials> {
+  if (!auth.token || auth.apiKey) return credentials;
+
+  const now = Date.now();
+  const expiry = auth.tokenExpiresAt ?? 0;
+  const refreshExpiry = auth.refreshExpiresAt ?? 0;
+
+  // Refresh when the access token expires within 5 minutes or has already expired,
+  // but only if we have a refresh token and it is still valid.
+  if (now < expiry - 5 * 60 * 1000) {
+    return credentials;
+  }
+
+  if (!auth.refreshToken || now >= refreshExpiry) {
+    throw new AuthError(
+      'Your session has expired. Run `bench auth login` or set BENCHMARKS_PLATFORM_API_KEY.',
+    );
+  }
+
+  try {
+    const response = await refreshAccessToken(auth.authBaseUrl, auth.refreshToken);
+    const updated = updateCredentialsWithTokenResponse(credentials, response);
+    await saveCredentials(updated);
+    return updated;
+  } catch {
+    throw new AuthError(
+      'Failed to refresh your session. Run `bench auth login` or set BENCHMARKS_PLATFORM_API_KEY.',
+    );
+  }
+}
+
 export function getAuthHeader(auth: CliAuth): string | undefined {
-  const token = auth.token ?? auth.apiKey ?? process.env.BENCHMARKS_PLATFORM_API_KEY ?? process.env.COMPUTESDK_API_KEY;
+  const token = auth.token ?? auth.apiKey ?? apiKeyFromEnvironment();
   if (!token) return undefined;
   return `Bearer ${token}`;
 }
@@ -28,20 +98,73 @@ export async function resolveAuth(override?: {
   apiKey?: string;
   org?: string;
 }): Promise<CliAuth> {
+  const config = (await loadConfig()) ?? ({} as Config);
   const credentials = (await loadCredentials()) ?? ({} as Credentials);
-  const platformUrl = override?.baseUrl ?? credentials.baseUrl ?? getPlatformBaseUrl();
+  const mergedConfig = mergeConfig(config, {
+    baseUrl: override?.baseUrl,
+    org: override?.org,
+  });
+
+  const platformUrl = mergedConfig.baseUrl ?? credentials.baseUrl ?? getPlatformBaseUrl();
   const apiBaseUrl = getApiBaseUrl(platformUrl);
   const authBaseUrl = getAuthBaseUrl(platformUrl);
-  const token = override?.apiKey ? undefined : (credentials.token ?? tokenFromEnvironment());
-  const apiKey = override?.apiKey;
-  const orgSlug = override?.org ?? credentials.orgSlug;
+  const orgSlug = override?.org ?? credentials.orgSlug ?? config.org;
   const orgId = credentials.orgId;
+  const format = config.format;
 
-  if (!token && !apiKey && !process.env.BENCHMARKS_PLATFORM_API_KEY && !process.env.COMPUTESDK_API_KEY) {
-    throw new Error('Not authenticated. Run `bench auth login` or set BENCHMARKS_PLATFORM_API_KEY.');
+  let token = tokenFromEnvironment() ?? credentials.token;
+  let apiKey = override?.apiKey;
+  let refreshToken = credentials.refreshToken;
+  let tokenExpiresAt = credentials.tokenExpiresAt;
+  let refreshExpiresAt = credentials.refreshExpiresAt;
+
+  if (apiKey) {
+    token = undefined;
+    refreshToken = undefined;
+  } else if (apiKeyFromEnvironment()) {
+    apiKey = apiKeyFromEnvironment();
+    token = undefined;
+    refreshToken = undefined;
+  } else if (token && token !== credentials.token) {
+    // Environment token does not refresh through the CLI.
+    refreshToken = undefined;
+    tokenExpiresAt = undefined;
   }
 
-  return { token, apiKey, orgSlug, orgId, baseUrl: platformUrl, apiBaseUrl, authBaseUrl };
+  let auth: CliAuth = {
+    token,
+    refreshToken,
+    tokenExpiresAt,
+    refreshExpiresAt,
+    apiKey,
+    orgSlug,
+    orgId,
+    baseUrl: platformUrl,
+    apiBaseUrl,
+    authBaseUrl,
+    format,
+  };
+
+  if (auth.token && auth.refreshToken && !auth.apiKey) {
+    const updated = await refreshIfNeeded(auth, credentials);
+    auth = {
+      ...auth,
+      token: updated.token,
+      refreshToken: updated.refreshToken,
+      tokenExpiresAt: updated.tokenExpiresAt,
+      refreshExpiresAt: updated.refreshExpiresAt,
+    };
+  }
+
+  if (!auth.token && !auth.apiKey && !apiKeyFromEnvironment() && !tokenFromEnvironment()) {
+    if (isNonInteractive()) {
+      throw new AuthError(
+        'No credentials found in non-interactive mode. Set BENCHMARKS_PLATFORM_API_KEY or BENCHMARKS_PLATFORM_TOKEN.',
+      );
+    }
+  }
+
+  return auth;
 }
 
 export async function createApiClient(override?: { baseUrl?: string; apiKey?: string; org?: string }): Promise<{
@@ -65,7 +188,7 @@ export async function getMe(auth: CliAuth): Promise<{
   organizations: { id: string; name: string; slug: string }[];
 }> {
   const authorization = getAuthHeader(auth);
-  if (!authorization) throw new Error('Not authenticated.');
+  if (!authorization) throw new AuthError('Not authenticated.');
   const response = await fetch(`${auth.apiBaseUrl}/me`, {
     headers: { Authorization: authorization },
   });
@@ -82,7 +205,7 @@ export async function getMe(auth: CliAuth): Promise<{
 
 export async function listOrganizations(auth: CliAuth): Promise<{ id: string; name: string; slug: string }[]> {
   const authorization = getAuthHeader(auth);
-  if (!authorization) throw new Error('Not authenticated.');
+  if (!authorization) throw new AuthError('Not authenticated.');
   const response = await fetch(`${auth.apiBaseUrl}/organizations`, {
     headers: { Authorization: authorization },
   });
@@ -103,7 +226,7 @@ export async function setActiveOrganization(
   slug: string,
 ): Promise<{ activeOrganizationId: string | null; organization: { id: string; name: string; slug: string } | null }> {
   const authorization = getAuthHeader(auth);
-  if (!authorization) throw new Error('Not authenticated.');
+  if (!authorization) throw new AuthError('Not authenticated.');
   const response = await fetch(`${auth.apiBaseUrl}/organizations`, {
     method: 'POST',
     headers: {
@@ -120,8 +243,20 @@ export async function setActiveOrganization(
       text,
     );
   }
-  return JSON.parse(text) as {
+  const result = JSON.parse(text) as {
     activeOrganizationId: string | null;
     organization: { id: string; name: string; slug: string } | null;
+    accessToken?: string | null;
+    expiresIn?: number;
+  };
+
+  if (result.accessToken) {
+    auth.token = result.accessToken;
+    auth.tokenExpiresAt = computeTokenExpiry(result.expiresIn ?? 3600);
+  }
+
+  return {
+    activeOrganizationId: result.activeOrganizationId,
+    organization: result.organization,
   };
 }

--- a/packages/benchsdk-cli/src/client.ts
+++ b/packages/benchsdk-cli/src/client.ts
@@ -38,7 +38,7 @@ export async function resolveAuth(override?: {
   const orgId = credentials.orgId;
 
   if (!token && !apiKey && !process.env.BENCHMARKS_PLATFORM_API_KEY && !process.env.COMPUTESDK_API_KEY) {
-    throw new Error('Not authenticated. Run `csdk-bench auth login` or set BENCHMARKS_PLATFORM_API_KEY.');
+    throw new Error('Not authenticated. Run `bench auth login` or set BENCHMARKS_PLATFORM_API_KEY.');
   }
 
   return { token, apiKey, orgSlug, orgId, baseUrl: platformUrl, apiBaseUrl, authBaseUrl };

--- a/packages/benchsdk-cli/src/client.ts
+++ b/packages/benchsdk-cli/src/client.ts
@@ -1,0 +1,127 @@
+import { createBenchmarkClient, type BenchmarkClient, BenchmarkApiError } from '@benchsdk/api';
+import { loadCredentials, type Credentials } from './config.js';
+import { getApiBaseUrl, getAuthBaseUrl, getPlatformBaseUrl } from './platform.js';
+
+export interface CliAuth {
+  token?: string;
+  apiKey?: string;
+  orgSlug?: string;
+  orgId?: string;
+  baseUrl: string;
+  apiBaseUrl: string;
+  authBaseUrl: string;
+}
+
+function tokenFromEnvironment(): string | undefined {
+  if (typeof process === 'undefined') return undefined;
+  return process.env.BENCHMARKS_PLATFORM_TOKEN;
+}
+
+export function getAuthHeader(auth: CliAuth): string | undefined {
+  const token = auth.token ?? auth.apiKey ?? process.env.BENCHMARKS_PLATFORM_API_KEY ?? process.env.COMPUTESDK_API_KEY;
+  if (!token) return undefined;
+  return `Bearer ${token}`;
+}
+
+export async function resolveAuth(override?: {
+  baseUrl?: string;
+  apiKey?: string;
+  org?: string;
+}): Promise<CliAuth> {
+  const credentials = (await loadCredentials()) ?? ({} as Credentials);
+  const platformUrl = override?.baseUrl ?? credentials.baseUrl ?? getPlatformBaseUrl();
+  const apiBaseUrl = getApiBaseUrl(platformUrl);
+  const authBaseUrl = getAuthBaseUrl(platformUrl);
+  const token = override?.apiKey ? undefined : (credentials.token ?? tokenFromEnvironment());
+  const apiKey = override?.apiKey;
+  const orgSlug = override?.org ?? credentials.orgSlug;
+  const orgId = credentials.orgId;
+
+  if (!token && !apiKey && !process.env.BENCHMARKS_PLATFORM_API_KEY && !process.env.COMPUTESDK_API_KEY) {
+    throw new Error('Not authenticated. Run `csdk-bench auth login` or set BENCHMARKS_PLATFORM_API_KEY.');
+  }
+
+  return { token, apiKey, orgSlug, orgId, baseUrl: platformUrl, apiBaseUrl, authBaseUrl };
+}
+
+export async function createApiClient(override?: { baseUrl?: string; apiKey?: string; org?: string }): Promise<{
+  api: BenchmarkClient;
+  auth: CliAuth;
+}> {
+  const auth = await resolveAuth(override);
+  const api = createBenchmarkClient({
+    baseUrl: auth.apiBaseUrl,
+    token: auth.token,
+    apiKey: auth.apiKey,
+    orgSlug: auth.orgSlug,
+    orgId: auth.orgId,
+  });
+  return { api, auth };
+}
+
+export async function getMe(auth: CliAuth): Promise<{
+  user: { id: string; name?: string | null; email?: string | null };
+  activeOrganizationId: string | null;
+  organizations: { id: string; name: string; slug: string }[];
+}> {
+  const authorization = getAuthHeader(auth);
+  if (!authorization) throw new Error('Not authenticated.');
+  const response = await fetch(`${auth.apiBaseUrl}/me`, {
+    headers: { Authorization: authorization },
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new BenchmarkApiError(`Me request failed: ${response.status} ${response.statusText}`, response.status, text);
+  }
+  return JSON.parse(text) as {
+    user: { id: string; name?: string | null; email?: string | null };
+    activeOrganizationId: string | null;
+    organizations: { id: string; name: string; slug: string }[];
+  };
+}
+
+export async function listOrganizations(auth: CliAuth): Promise<{ id: string; name: string; slug: string }[]> {
+  const authorization = getAuthHeader(auth);
+  if (!authorization) throw new Error('Not authenticated.');
+  const response = await fetch(`${auth.apiBaseUrl}/organizations`, {
+    headers: { Authorization: authorization },
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new BenchmarkApiError(
+      `Organizations request failed: ${response.status} ${response.statusText}`,
+      response.status,
+      text,
+    );
+  }
+  const data = JSON.parse(text) as { items: { id: string; name: string; slug: string }[] };
+  return data.items ?? [];
+}
+
+export async function setActiveOrganization(
+  auth: CliAuth,
+  slug: string,
+): Promise<{ activeOrganizationId: string | null; organization: { id: string; name: string; slug: string } | null }> {
+  const authorization = getAuthHeader(auth);
+  if (!authorization) throw new Error('Not authenticated.');
+  const response = await fetch(`${auth.apiBaseUrl}/organizations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: authorization,
+    },
+    body: JSON.stringify({ slug }),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new BenchmarkApiError(
+      `Set active organization failed: ${response.status} ${response.statusText}`,
+      response.status,
+      text,
+    );
+  }
+  return JSON.parse(text) as {
+    activeOrganizationId: string | null;
+    organization: { id: string; name: string; slug: string } | null;
+  };
+}

--- a/packages/benchsdk-cli/src/config.ts
+++ b/packages/benchsdk-cli/src/config.ts
@@ -5,13 +5,23 @@ import { join } from 'node:path';
 export interface Credentials {
   baseUrl?: string;
   token?: string;
+  refreshToken?: string;
+  tokenExpiresAt?: number;
+  refreshExpiresAt?: number;
   orgSlug?: string;
   orgId?: string;
   kind?: 'oauth' | 'api-key';
 }
 
+export interface Config {
+  baseUrl?: string;
+  org?: string;
+  format?: 'json' | 'table';
+}
+
 const CONFIG_DIR = join(homedir(), '.benchsdk');
 const CREDENTIALS_PATH = join(CONFIG_DIR, 'credentials.json');
+const CONFIG_PATH = join(CONFIG_DIR, 'config.json');
 
 export async function loadCredentials(): Promise<Credentials | null> {
   try {
@@ -35,4 +45,27 @@ export async function clearCredentials(): Promise<void> {
     if (err instanceof Error && 'code' in err && err.code === 'ENOENT') return;
     throw err;
   }
+}
+
+export async function loadConfig(): Promise<Config | null> {
+  try {
+    const raw = await readFile(CONFIG_PATH, 'utf-8');
+    return JSON.parse(raw) as Config;
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+export async function saveConfig(config: Config): Promise<void> {
+  await mkdir(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  await writeFile(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 });
+}
+
+export function mergeConfig(defaults: Config, overrides: Config): Config {
+  return {
+    baseUrl: overrides.baseUrl ?? defaults.baseUrl,
+    org: overrides.org ?? defaults.org,
+    format: overrides.format ?? defaults.format,
+  };
 }

--- a/packages/benchsdk-cli/src/config.ts
+++ b/packages/benchsdk-cli/src/config.ts
@@ -1,0 +1,38 @@
+import { homedir } from 'node:os';
+import { mkdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export interface Credentials {
+  baseUrl?: string;
+  token?: string;
+  orgSlug?: string;
+  orgId?: string;
+  kind?: 'oauth' | 'api-key';
+}
+
+const CONFIG_DIR = join(homedir(), '.benchsdk');
+const CREDENTIALS_PATH = join(CONFIG_DIR, 'credentials.json');
+
+export async function loadCredentials(): Promise<Credentials | null> {
+  try {
+    const raw = await readFile(CREDENTIALS_PATH, 'utf-8');
+    return JSON.parse(raw) as Credentials;
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+export async function saveCredentials(credentials: Credentials): Promise<void> {
+  await mkdir(CONFIG_DIR, { recursive: true });
+  await writeFile(CREDENTIALS_PATH, JSON.stringify(credentials, null, 2));
+}
+
+export async function clearCredentials(): Promise<void> {
+  try {
+    await rm(CREDENTIALS_PATH);
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') return;
+    throw err;
+  }
+}

--- a/packages/benchsdk-cli/src/config.ts
+++ b/packages/benchsdk-cli/src/config.ts
@@ -24,8 +24,8 @@ export async function loadCredentials(): Promise<Credentials | null> {
 }
 
 export async function saveCredentials(credentials: Credentials): Promise<void> {
-  await mkdir(CONFIG_DIR, { recursive: true });
-  await writeFile(CREDENTIALS_PATH, JSON.stringify(credentials, null, 2));
+  await mkdir(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  await writeFile(CREDENTIALS_PATH, JSON.stringify(credentials, null, 2), { mode: 0o600 });
 }
 
 export async function clearCredentials(): Promise<void> {

--- a/packages/benchsdk-cli/src/index.ts
+++ b/packages/benchsdk-cli/src/index.ts
@@ -1,0 +1,2 @@
+export { run } from './cli.js';
+export type { Credentials } from './config.js';

--- a/packages/benchsdk-cli/src/output.ts
+++ b/packages/benchsdk-cli/src/output.ts
@@ -1,0 +1,31 @@
+export interface OutputOptions {
+  json?: boolean;
+}
+
+export function printData(data: unknown, options: OutputOptions = {}): void {
+  if (options.json) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) {
+      console.log('No results.');
+      return;
+    }
+    console.table(data);
+    return;
+  }
+
+  if (data === null || data === undefined) {
+    console.log('No results.');
+    return;
+  }
+
+  if (typeof data === 'object') {
+    console.dir(data, { depth: null });
+    return;
+  }
+
+  console.log(data);
+}

--- a/packages/benchsdk-cli/src/output.ts
+++ b/packages/benchsdk-cli/src/output.ts
@@ -1,20 +1,29 @@
 export interface OutputOptions {
   json?: boolean;
+  format?: 'json' | 'table';
+}
+
+function isJson(options: OutputOptions): boolean {
+  return !!options.json || options.format === 'json';
 }
 
 export function printData(data: unknown, options: OutputOptions = {}): void {
-  if (options.json) {
+  if (isJson(options)) {
     console.log(JSON.stringify(data, null, 2));
     return;
   }
+
+  const format = options.format ?? 'table';
 
   if (Array.isArray(data)) {
     if (data.length === 0) {
       console.log('No results.');
       return;
     }
-    console.table(data);
-    return;
+    if (format === 'table') {
+      console.table(data);
+      return;
+    }
   }
 
   if (data === null || data === undefined) {

--- a/packages/benchsdk-cli/src/platform.ts
+++ b/packages/benchsdk-cli/src/platform.ts
@@ -1,0 +1,17 @@
+export const DEFAULT_PLATFORM_URL = 'https://platform.computesdk.com';
+
+export function getPlatformBaseUrl(override?: string): string {
+  const base = override ?? process.env.BENCHMARKS_PLATFORM_URL ?? DEFAULT_PLATFORM_URL;
+  return base.replace(/\/+$/, '');
+}
+
+export function getApiBaseUrl(platformUrl?: string): string {
+  const base = getPlatformBaseUrl(platformUrl);
+  if (base.endsWith('/api/v1')) return base;
+  return `${base}/api/v1`;
+}
+
+export function getAuthBaseUrl(platformUrl?: string): string {
+  const base = getPlatformBaseUrl(platformUrl).replace(/\/api\/v1$/, '');
+  return `${base}/api/auth`;
+}

--- a/packages/benchsdk-cli/tsconfig.json
+++ b/packages/benchsdk-cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/benchsdk-cli/tsup.config.ts
+++ b/packages/benchsdk-cli/tsup.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
-    bin: 'src/bin.ts',
   },
   format: ['cjs', 'esm'],
   dts: { entry: { index: 'src/index.ts' } },

--- a/packages/benchsdk-cli/tsup.config.ts
+++ b/packages/benchsdk-cli/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    bin: 'src/bin.ts',
+  },
+  format: ['cjs', 'esm'],
+  dts: { entry: { index: 'src/index.ts' } },
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  external: ['@benchsdk/api'],
+});

--- a/packages/benchsdk-cli/tsup.config.ts
+++ b/packages/benchsdk-cli/tsup.config.ts
@@ -10,4 +10,10 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   external: ['@benchsdk/api'],
+  esbuildOptions(options) {
+    options.logOverride = {
+      ...(options.logOverride || {}),
+      'empty-import-meta': 'silent' as import('esbuild').LogLevel,
+    };
+  },
 });

--- a/packages/benchsdk-runner/package.json
+++ b/packages/benchsdk-runner/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@benchsdk/api": "workspace:*",
+    "@benchsdk/cli": "workspace:*",
     "@benchsdk/worker": "workspace:*"
   },
   "devDependencies": {

--- a/packages/benchsdk-runner/src/cli.ts
+++ b/packages/benchsdk-runner/src/cli.ts
@@ -16,6 +16,7 @@
  */
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { run as runPlatformCli } from '@benchsdk/cli';
 import { parseCliArgs, runBenchmark } from './runner.js';
 import { NoAvailableParticipantsError } from './no-available-participants.js';
 import type { BaseParticipant } from '@benchsdk/worker';
@@ -66,8 +67,12 @@ export async function runBenchmarkFile(argv: string[]): Promise<void> {
   await runBenchmark(config as BenchmarkConfig<BaseParticipant>, task as BenchmarkTask<BaseParticipant>, flags);
 }
 
-/** Executable entry: runs the file and maps outcomes to process exit codes. */
+/** Executable entry: dispatches to benchmark execution or platform data commands. */
 export async function run(argv: string[]): Promise<void> {
+  if (argv[0] !== 'run') {
+    return runPlatformCli(argv);
+  }
+
   try {
     await runBenchmarkFile(argv);
     // Provider SDKs can leave sockets/timers open; exit explicitly so a

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       '@benchsdk/api':
         specifier: workspace:*
         version: link:../benchsdk-api
+      '@benchsdk/cli':
+        specifier: workspace:*
+        version: link:../benchsdk-cli
       '@benchsdk/worker':
         specifier: workspace:*
         version: link:../benchsdk-worker

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,34 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
+  packages/benchsdk-cli:
+    dependencies:
+      '@benchsdk/api':
+        specifier: workspace:*
+        version: link:../benchsdk-api
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.43
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
+      eslint:
+        specifier: ^8.37.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.10
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.21)(tsx@4.23.12)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.43)
+
   packages/benchsdk-runner:
     dependencies:
       '@benchsdk/api':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - packages/benchsdk
   - packages/create-bench
   - packages/benchsdk-runner
+  - packages/benchsdk-cli


### PR DESCRIPTION
Adds a new `@benchsdk/cli` workspace library that queries benchmarks-platform data, and wires it into the existing `@benchsdk/runner` `bench` binary so the same `bench` command handles both benchmark execution and platform data access.

Changes
- New workspace package `@benchsdk/cli` (no standalone binary):
  - `auth login|logout|status`
  - `org list|use <slug>`
  - `benchmarks list`
  - `runs list <slug> [--limit N]`, `runs show <slug> <runId>`
  - `results <slug> [--run <id>] [--format json|table]`
  - `artifacts list <slug> <runId> [--worker <id>]`
  - `export <slug> [--run <id>] [--out <dir>]`
- `packages/benchsdk-runner/src/cli.ts` now dispatches:
  - `bench run <file.bench.ts> ...` → existing benchmark runner.
  - All other commands → `@benchsdk/cli` (`bench auth login`, `bench org list`, etc.).
- Device-code OAuth against `platform.computesdk.com` (or `BENCHMARKS_PLATFORM_URL`), storing credentials in `~/.benchsdk/credentials.json` with `0600` perms.
- Falls back to `BENCHMARKS_PLATFORM_API_KEY` / `BENCHMARKS_PLATFORM_TOKEN` / `COMPUTESDK_API_KEY` and `BENCHMARKS_PLATFORM_URL` for non-interactive use.
- Extends `@benchsdk/api` `BenchmarkClientConfig` with `token`, `orgSlug`, `orgId` and injects `Authorization` + `X-Org-*` headers.
- Adds `packages/benchsdk-cli/src/__tests__/cli.test.ts` for parser and auth helpers.

Verified
- `pnpm -r --filter "./packages/**" typecheck` passes.
- `pnpm --filter @benchsdk/cli test` and `pnpm --filter @benchsdk/runner test` pass.
- Local end-to-end against a running `benchmarks-platform` stack: device-code login, `bench auth status`, `bench org list`, `bench benchmarks list` all work via the unified `bench` binary.

Note: `pnpm typecheck` at the repo root has pre-existing `customCliFlags` errors in `benchmarks/ai-gateway/...` and `benchmarks/storage/...` that are unrelated to this change.

Link to Devin session: https://app.devin.ai/sessions/c8b0b4ea8c004ac592c218c0cd383aff
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->