### PR TITLE
fix(ai-gateway): include thoughtsTokenCount in Gemini output token total

### DIFF
--- a/benchmarks/ai-gateway/phase-probe.ts
+++ b/benchmarks/ai-gateway/phase-probe.ts
@@ -145,11 +145,18 @@ function extractOutputTokens(wireFormat: AIGatewayWireFormat, buf: string): numb
     return m.length > 0 ? Number(m[m.length - 1][1]) : undefined;
   }
   if (wireFormat === 'gemini') {
-    // Gemini streams cumulative usage under `usageMetadata.candidatesTokenCount`
-    // on each chunk (mirroring Anthropic's message_start/message_delta
-    // pattern) — take the last match, same rationale as the openai branch above.
-    const m = [...buf.matchAll(/"usageMetadata"\s*:\s*\{[^}]*"candidatesTokenCount"\s*:\s*(\d+)/g)];
-    return m.length > 0 ? Number(m[m.length - 1][1]) : undefined;
+    // Gemini streams cumulative usage under `usageMetadata` on each chunk
+    // (mirroring Anthropic's message_start/message_delta pattern) — take the
+    // last match, same rationale as the openai branch above. Thinking models
+    // split output into `candidatesTokenCount` (visible answer tokens) and
+    // `thoughtsTokenCount` (internal reasoning tokens); report the total.
+    const m = [...buf.matchAll(/"usageMetadata"\s*:\s*\{([^}]*)\}/g)];
+    if (m.length === 0) return undefined;
+    const usage = m[m.length - 1][1];
+    const candidates = usage.match(/"candidatesTokenCount"\s*:\s*(\d+)/)?.[1];
+    const thoughts = usage.match(/"thoughtsTokenCount"\s*:\s*(\d+)/)?.[1];
+    const total = (candidates ? Number(candidates) : 0) + (thoughts ? Number(thoughts) : 0);
+    return total > 0 ? total : undefined;
   }
   // Anthropic and the Responses API both stream cumulative usage under a
   // "usage" object keyed by "output_tokens" (Anthropic: message_start/

--- a/benchmarks/ai-gateway/phase-probe.ts
+++ b/benchmarks/ai-gateway/phase-probe.ts
@@ -147,15 +147,16 @@ function extractOutputTokens(wireFormat: AIGatewayWireFormat, buf: string): numb
   if (wireFormat === 'gemini') {
     // Gemini streams cumulative usage under `usageMetadata` on each chunk
     // (mirroring Anthropic's message_start/message_delta pattern) — take the
-    // last match, same rationale as the openai branch above. Thinking models
-    // split output into `candidatesTokenCount` (visible answer tokens) and
-    // `thoughtsTokenCount` (internal reasoning tokens); report the total.
-    const m = [...buf.matchAll(/"usageMetadata"\s*:\s*\{([^}]*)\}/g)];
-    if (m.length === 0) return undefined;
-    const usage = m[m.length - 1][1];
-    const candidates = usage.match(/"candidatesTokenCount"\s*:\s*(\d+)/)?.[1];
-    const thoughts = usage.match(/"thoughtsTokenCount"\s*:\s*(\d+)/)?.[1];
-    const total = (candidates ? Number(candidates) : 0) + (thoughts ? Number(thoughts) : 0);
+    // last match for each field, same rationale as the openai branch above.
+    // Thinking models split output into `candidatesTokenCount` (visible answer
+    // tokens) and `thoughtsTokenCount` (internal reasoning tokens); report the
+    // total. Match the fields independently because `usageMetadata` can
+    // contain nested arrays/objects like `promptTokensDetails`.
+    const candMatches = [...buf.matchAll(/"candidatesTokenCount"\s*:\s*(\d+)/g)];
+    const thoughtMatches = [...buf.matchAll(/"thoughtsTokenCount"\s*:\s*(\d+)/g)];
+    const candidates = candMatches.length > 0 ? Number(candMatches[candMatches.length - 1][1]) : 0;
+    const thoughts = thoughtMatches.length > 0 ? Number(thoughtMatches[thoughtMatches.length - 1][1]) : 0;
+    const total = candidates + thoughts;
     return total > 0 ? total : undefined;
   }
   // Anthropic and the Responses API both stream cumulative usage under a


### PR DESCRIPTION
## Summary

The Gemini-family AI gateway benchmark was only reading `usageMetadata.candidatesTokenCount` when computing `outputTokens`. For Gemini thinking models, the native response splits generated output between `candidatesTokenCount` (visible answer tokens) and `thoughtsTokenCount` (internal reasoning tokens). Providers that proxy the native Gemini shape, such as Cloudflare AI Gateway, therefore reported only the visible-token fraction — e.g. 6 tokens instead of the actual 196 (190 thoughts + 6 candidates).

Now `extractOutputTokens` for `wireFormat: 'gemini'` takes the last `usageMetadata` object and sums `candidatesTokenCount` + `thoughtsTokenCount` (when present), returning the total generated output tokens. This applies uniformly to all native-Gemini participants (`cloudflare-ai-gateway`, `neon`, and `gemini-direct`).

```ts
// before
"usageMetadata.candidatesTokenCount" -> 6

// after
"usageMetadata": { "candidatesTokenCount": 6, "thoughtsTokenCount": 190 } -> 196
```

Link to Devin session: https://app.devin.ai/sessions/2690727b7b174dc99d82f88ec4a72552
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->