### PR TITLE
fix(benchsdk-runner): emit canonical ISO [task N] [level] message log format

### DIFF
--- a/packages/benchsdk-runner/src/log-buffer.ts
+++ b/packages/benchsdk-runner/src/log-buffer.ts
@@ -45,7 +45,15 @@ export class LogBuffer {
       ? { level: metaOrOptions.level ?? 'info', meta: metaOrOptions.meta }
       : { level: 'info', meta: metaOrOptions };
     const suffix = opts.meta && Object.keys(opts.meta).length > 0 ? ` ${JSON.stringify(opts.meta)}` : '';
-    this.lines.push(`${new Date().toISOString()} ${message} [${opts.level}]${suffix}`);
+    // The runner's ctx.log passes a leading `[task N]` prefix; place the level
+    // between the task tag and the message to match `@benchsdk/worker` and the
+    // platform's worker-logs parser.
+    const taskMatch = message.match(/^(\[task \d+\])\s*(.*)$/);
+    if (taskMatch) {
+      this.lines.push(`${new Date().toISOString()} ${taskMatch[1]} [${opts.level}] ${taskMatch[2]}${suffix}`);
+    } else {
+      this.lines.push(`${new Date().toISOString()} [${opts.level}] ${message}${suffix}`);
+    }
   }
 
   isEmpty(): boolean {


### PR DESCRIPTION
## Summary

`@benchsdk/runner`'s `LogBuffer.line()` was appending the level as a trailing tag after the message:

```
ISO [task N] novita cold probe failed: AI gateway request timed out [error] {"mode":"cold"}
```

`benchmarks-platform` expects the worker log format used by `@benchsdk/worker`:

```
ISO [task N] [level] novita cold probe failed: AI gateway request timed out {"mode":"cold"}
```

So the platform parser never found `[error]` at the start of the message body and fell back to `info`.

This change reorders `LogBuffer.line()` so it places the level between the `[task N]` prefix and the message, preserving the optional JSON metadata suffix.

### Before
```ts
this.lines.push(`${new Date().toISOString()} ${message}${suffix}`);
```

### After
```ts
const taskMatch = message.match(/^(\[task \d+\])\s*(.*)$/);
if (taskMatch) {
  this.lines.push(`${new Date().toISOString()} ${taskMatch[1]} [${opts.level}] ${taskMatch[2]}${suffix}`);
} else {
  this.lines.push(`${new Date().toISOString()} [${opts.level}] ${message}${suffix}`);
}
```

### Verification
- `pnpm --filter @benchsdk/runner typecheck` passes
- `pnpm --filter @benchsdk/runner test` passes (96/96)


Link to Devin session: https://app.devin.ai/sessions/3ce5e692f07d40c49eb52ac054093d8a
Open in Devin Desktop: https://app.devin.ai/desktop/session/3ce5e692f07d40c49eb52ac054093d8a?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->