### PR TITLE
fix(ai-gateway): build workspace packages before benchmark run

### DIFF
--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -127,10 +127,15 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+      - name: Build workspace packages
+        # The @benchsdk/* packages are built from source and dist/ is not
+        # committed. Build them in topological order so dependents like
+        # @benchsdk/client can resolve @benchsdk/worker during their own build.
+        run: pnpm -r --filter './packages/**' run build
       - name: Run AI gateway benchmark
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.family == 'all' || github.event.inputs.family == '' || github.event.inputs.family == matrix.family.slug
         # Union of every family's vars is loaded regardless of which family


### PR DESCRIPTION
## Summary

The scheduled AI Gateway Benchmark failed this morning because the `@benchsdk/*` workspace packages were built during `pnpm update` via their `prepare` scripts, but `packages/benchsdk-worker` was not built before `packages/benchsdk` (the `@benchsdk/client` umbrella) tried to re-export from it. This produced the `TS2307` error seen in all four matrix legs:

```
packages/benchsdk prepare: src/index.ts(87,8): error TS2307: Cannot find module '@benchsdk/worker'
```

Update `.github/workflows/ai-gateway-benchmarks.yml` to:
- Skip lifecycle scripts during dependency install (`--ignore-scripts`).
- Add an explicit `pnpm -r --filter './packages/**' run build` step so workspace packages are built in topological order, matching `ci.yml` and `release.yml`.

This ensures `@benchsdk/worker`'s `dist/` exists before `@benchsdk/client` and `@benchsdk/runner` are built.

Link to Devin session: https://app.devin.ai/sessions/573dd482368d429699da92e3dbe955d5
Open in Devin Desktop: https://app.devin.ai/desktop/session/573dd482368d429699da92e3dbe955d5?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->