### PR TITLE
Require platform API key or OAuth token for CLI, API client, and bench run

### DIFF
--- a/.agents/skills/benchsdk-cli/SKILL.md
+++ b/.agents/skills/benchsdk-cli/SKILL.md
@@ -35,7 +35,8 @@ The CLI tries credentials in this order:
 4. OAuth tokens from `~/.benchsdk/credentials.json` (from `bench auth login`)
 
 API keys and tokens are useful for non-interactive environments. OAuth is
-interactive and stores a refresh token under `~/.benchsdk`.
+interactive and stores a refresh token under `~/.benchsdk`. At least one
+credential is required for any command that touches the platform.
 
 ### Device-code login
 
@@ -151,8 +152,7 @@ export BENCHMARKS_PLATFORM_API_KEY=bp_...
 bench benchmarks list --json --limit 100
 ```
 
-If no credentials are present and `CI` is set or stdin is not a TTY, the CLI
-fails fast with an `AuthError`.
+If no credentials are present, the CLI fails fast with an `AuthError`.
 
 ## Environment variables
 

--- a/WRITING_BENCHMARKS.md
+++ b/WRITING_BENCHMARKS.md
@@ -29,9 +29,12 @@ pnpm exec bench run examples/01-hello.bench.ts --dry-run
 
 ## Platform credentials
 
-To report results to the platform instead of running dry, set:
+To report results to the platform instead of running dry, authenticate with one of:
 
-- `BENCHMARKS_PLATFORM_API_KEY` — a ComputeSDK benchmarks platform API key.
+- `BENCHMARKS_PLATFORM_API_KEY` — a ComputeSDK benchmarks platform API key (required by the runner; an org-scoped `bp_...` key).
+- `BENCHMARKS_PLATFORM_TOKEN` — an OAuth session/bearer token (used by the CLI and low-level client).
+
+You can also log in interactively with `bench auth login` to store an OAuth token in `~/.benchsdk/credentials.json`.
 
 To point at a different platform endpoint (for example, a staging environment or local development proxy), also set `BENCHMARKS_PLATFORM_URL` to the root URL (no `/api/v1` suffix; the runner appends it). The default is `https://platform.computesdk.com`.
 

--- a/WRITING_BENCHMARKS.md
+++ b/WRITING_BENCHMARKS.md
@@ -23,22 +23,22 @@ If you are working inside this repo, you can run any `*.bench.ts` file directly:
 # 1. Build the workspace packages once (packages/*/dist is not committed)
 pnpm -r --filter "./packages/**" build
 
-# 2. Run a benchmark without uploading to the platform
-pnpm exec bench run examples/01-hello.bench.ts --dry-run
+# 2. Run a benchmark locally without uploading to the platform
+BENCHMARKS_PLATFORM_API_KEY=bp-... pnpm exec bench run examples/01-hello.bench.ts --dry-run
 ```
 
 ## Platform credentials
 
-To report results to the platform instead of running dry, authenticate with one of:
+To report results to the platform, authenticate with one of:
 
-- `BENCHMARKS_PLATFORM_API_KEY` — a ComputeSDK benchmarks platform API key (required by the runner; an org-scoped `bp_...` key).
+- `BENCHMARKS_PLATFORM_API_KEY` — a ComputeSDK benchmarks platform API key (an org-scoped `bp_...` key).
 - `BENCHMARKS_PLATFORM_TOKEN` — an OAuth session/bearer token (used by the CLI and low-level client).
 
 You can also log in interactively with `bench auth login` to store an OAuth token in `~/.benchsdk/credentials.json`.
 
 To point at a different platform endpoint (for example, a staging environment or local development proxy), also set `BENCHMARKS_PLATFORM_URL` to the root URL (no `/api/v1` suffix; the runner appends it). The default is `https://platform.computesdk.com`.
 
-`--dry-run` / `--no-ingest` / `BENCHSDK_NO_INGEST=1` skip platform reporting entirely.
+`--dry-run` / `--no-ingest` / `BENCHSDK_NO_INGEST=1` skip platform uploading/reporting, but a platform API key or OAuth token is still required for every `bench run` invocation.
 
 ## Anatomy of a benchmark file
 
@@ -401,7 +401,7 @@ bench run <file.bench.ts> [flags]
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run`, `--no-ingest` | Run locally without platform reporting. |
+| `--dry-run`, `--no-ingest` | Skip uploading to the platform (still requires auth). |
 | `--provider a,b` | Run only the named participants. Repeatable. |
 | `--iterations N` | Override total iterations (per phase when phases exist). |
 | `--concurrency N` | Override max in-flight tasks. |
@@ -457,10 +457,10 @@ See the [`examples/`](./examples) directory for runnable benchmarks covering eve
 10. `10-shared-run.bench.ts` — `--run-key`.
 11. `11-logging.bench.ts` — structured `log` levels, step output capture, and `captureOutput`.
 
-Run any example in dry-run mode:
+Run any example locally:
 
 ```bash
-pnpm exec bench run examples/01-hello.bench.ts --dry-run
+BENCHMARKS_PLATFORM_API_KEY=bp-... pnpm exec bench run examples/01-hello.bench.ts --dry-run
 ```
 
 ## Common gotchas

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,12 +1,12 @@
 # benchsdk Examples
 
-Each `*.bench.ts` file here demonstrates one benchsdk capability. All examples are self-contained, use only local Node APIs, and can be run without platform credentials by adding `--dry-run`.
+Each `*.bench.ts` file here demonstrates one benchsdk capability. All examples are self-contained and use only local Node APIs, but `bench run` requires a platform API key or OAuth token even with `--dry-run` (the flag only skips uploading).
 
 ## Running an example
 
 ```bash
 pnpm -r --filter "./packages/**" build
-pnpm exec bench run examples/01-hello.bench.ts --dry-run
+BENCHMARKS_PLATFORM_API_KEY=bp-... pnpm exec bench run examples/01-hello.bench.ts --dry-run
 ```
 
 ## Examples

--- a/packages/benchsdk-api/src/client.ts
+++ b/packages/benchsdk-api/src/client.ts
@@ -84,6 +84,7 @@ function getApiKey(input?: string): string | undefined {
 
 function getAuthToken(config: BenchmarkClientConfig): string | undefined {
   if (config.token) return config.token;
+  if (config.apiKey) return config.apiKey;
   if (typeof process !== 'undefined' && process.env.BENCHMARKS_PLATFORM_TOKEN) {
     return process.env.BENCHMARKS_PLATFORM_TOKEN;
   }

--- a/packages/benchsdk-api/src/client.ts
+++ b/packages/benchsdk-api/src/client.ts
@@ -177,7 +177,7 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
   const authToken = getAuthToken(config);
   if (!authToken) {
     throw new Error(
-      'A platform API key or OAuth token is required. Set BENCHMARKS_PLATFORM_API_KEY or BENCHMARKS_PLATFORM_TOKEN in your environment, or pass apiKey/token to createBenchmarkClient.'
+      'A platform API key or OAuth token is required. Set BENCHMARKS_PLATFORM_API_KEY or BENCHMARKS_PLATFORM_TOKEN in your environment, or pass apiKey/token to createBenchmarkClient. Create an API key at https://platform.computesdk.com in your organization settings (Settings → API keys).'
     );
   }
 

--- a/packages/benchsdk-api/src/client.ts
+++ b/packages/benchsdk-api/src/client.ts
@@ -175,6 +175,12 @@ async function downloadArtifactBody(
 export function createBenchmarkClient(config: BenchmarkClientConfig = {}): BenchmarkClient {
   const baseUrl = trimTrailingSlash(config.baseUrl ?? DEFAULT_BASE_URL);
   const authToken = getAuthToken(config);
+  if (!authToken) {
+    throw new Error(
+      'A platform API key or OAuth token is required. Set BENCHMARKS_PLATFORM_API_KEY or BENCHMARKS_PLATFORM_TOKEN in your environment, or pass apiKey/token to createBenchmarkClient.'
+    );
+  }
+
   const fetchImpl = config.fetch ?? (typeof fetch !== 'undefined' ? fetch : undefined);
 
   if (!fetchImpl) {

--- a/packages/benchsdk-cli/src/__tests__/client.test.ts
+++ b/packages/benchsdk-cli/src/__tests__/client.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as config from '../config.js';
+import { resolveAuth, createApiClient } from '../client.js';
+import { createBenchmarkClient } from '@benchsdk/api';
+
+vi.mock('@benchsdk/api', () => ({
+  createBenchmarkClient: vi.fn(() => ({ client: 'fake' })),
+}));
+
+describe('resolveAuth', () => {
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    originalEnv['BENCHMARKS_PLATFORM_API_KEY'] = process.env.BENCHMARKS_PLATFORM_API_KEY;
+    originalEnv['BENCHMARKS_PLATFORM_TOKEN'] = process.env.BENCHMARKS_PLATFORM_TOKEN;
+    originalEnv['BENCHMARKS_PLATFORM_URL'] = process.env.BENCHMARKS_PLATFORM_URL;
+    delete process.env.BENCHMARKS_PLATFORM_API_KEY;
+    delete process.env.BENCHMARKS_PLATFORM_TOKEN;
+    delete process.env.BENCHMARKS_PLATFORM_URL;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('uses saved OAuth credentials including baseUrl, orgSlug, and orgId', async () => {
+    vi.spyOn(config, 'loadConfig').mockResolvedValue({});
+    vi.spyOn(config, 'loadCredentials').mockResolvedValue({
+      token: 'saved-token',
+      refreshToken: 'saved-refresh',
+      tokenExpiresAt: Date.now() + 1_000_000,
+      refreshExpiresAt: Date.now() + 1_000_000,
+      baseUrl: 'https://saved.example.com',
+      orgSlug: 'saved-org',
+      orgId: 'saved-org-id',
+      kind: 'oauth',
+    });
+
+    const auth = await resolveAuth();
+
+    expect(auth.token).toBe('saved-token');
+    expect(auth.refreshToken).toBe('saved-refresh');
+    expect(auth.baseUrl).toBe('https://saved.example.com');
+    expect(auth.apiBaseUrl).toBe('https://saved.example.com/api/v1');
+    expect(auth.orgSlug).toBe('saved-org');
+    expect(auth.orgId).toBe('saved-org-id');
+    expect(auth.apiKey).toBeUndefined();
+  });
+
+  it('prefers BENCHMARKS_PLATFORM_API_KEY over saved OAuth and does not inherit saved org/baseUrl', async () => {
+    process.env.BENCHMARKS_PLATFORM_API_KEY = 'env-api-key';
+    vi.spyOn(config, 'loadConfig').mockResolvedValue({});
+    vi.spyOn(config, 'loadCredentials').mockResolvedValue({
+      token: 'saved-token',
+      refreshToken: 'saved-refresh',
+      tokenExpiresAt: Date.now() + 1_000_000,
+      baseUrl: 'https://saved.example.com',
+      orgSlug: 'saved-org',
+      orgId: 'saved-org-id',
+      kind: 'oauth',
+    });
+
+    const auth = await resolveAuth();
+
+    expect(auth.apiKey).toBe('env-api-key');
+    expect(auth.token).toBeUndefined();
+    expect(auth.refreshToken).toBeUndefined();
+    expect(auth.baseUrl).toBe('https://platform.computesdk.com');
+    expect(auth.orgSlug).toBeUndefined();
+    expect(auth.orgId).toBeUndefined();
+  });
+
+  it('prefers BENCHMARKS_PLATFORM_TOKEN over saved OAuth and does not inherit saved org/baseUrl', async () => {
+    process.env.BENCHMARKS_PLATFORM_TOKEN = 'env-token';
+    vi.spyOn(config, 'loadConfig').mockResolvedValue({});
+    vi.spyOn(config, 'loadCredentials').mockResolvedValue({
+      token: 'saved-token',
+      refreshToken: 'saved-refresh',
+      tokenExpiresAt: Date.now() + 1_000_000,
+      baseUrl: 'https://saved.example.com',
+      orgSlug: 'saved-org',
+      orgId: 'saved-org-id',
+      kind: 'oauth',
+    });
+
+    const auth = await resolveAuth();
+
+    expect(auth.token).toBe('env-token');
+    expect(auth.refreshToken).toBeUndefined();
+    expect(auth.baseUrl).toBe('https://platform.computesdk.com');
+    expect(auth.orgSlug).toBeUndefined();
+    expect(auth.orgId).toBeUndefined();
+  });
+
+  it('uses explicit config and overrides over saved credentials', async () => {
+    vi.spyOn(config, 'loadConfig').mockResolvedValue({
+      baseUrl: 'https://config.example.com',
+      org: 'config-org',
+    });
+    vi.spyOn(config, 'loadCredentials').mockResolvedValue({
+      token: 'saved-token',
+      refreshToken: 'saved-refresh',
+      tokenExpiresAt: Date.now() + 1_000_000,
+      baseUrl: 'https://saved.example.com',
+      orgSlug: 'saved-org',
+      orgId: 'saved-org-id',
+      kind: 'oauth',
+    });
+
+    const auth = await resolveAuth({ baseUrl: 'https://override.example.com', org: 'override-org' });
+
+    expect(auth.baseUrl).toBe('https://override.example.com');
+    expect(auth.orgSlug).toBe('override-org');
+    expect(auth.orgId).toBe('saved-org-id');
+  });
+
+  it('uses explicit override apiKey and ignores saved credentials entirely', async () => {
+    vi.spyOn(config, 'loadConfig').mockResolvedValue({});
+    vi.spyOn(config, 'loadCredentials').mockResolvedValue({
+      token: 'saved-token',
+      baseUrl: 'https://saved.example.com',
+      orgSlug: 'saved-org',
+      kind: 'oauth',
+    });
+
+    const auth = await resolveAuth({ apiKey: 'override-api-key' });
+
+    expect(auth.apiKey).toBe('override-api-key');
+    expect(auth.token).toBeUndefined();
+    expect(auth.baseUrl).toBe('https://platform.computesdk.com');
+    expect(auth.orgSlug).toBeUndefined();
+    expect(auth.orgId).toBeUndefined();
+  });
+
+  it('throws AuthError when no credentials are available', async () => {
+    vi.spyOn(config, 'loadConfig').mockResolvedValue({});
+    vi.spyOn(config, 'loadCredentials').mockResolvedValue(null);
+
+    await expect(resolveAuth()).rejects.toThrow('No credentials found');
+  });
+});
+
+describe('createApiClient', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.BENCHMARKS_PLATFORM_API_KEY;
+    delete process.env.BENCHMARKS_PLATFORM_TOKEN;
+  });
+
+  it('passes resolved auth to createBenchmarkClient', async () => {
+    vi.spyOn(config, 'loadConfig').mockResolvedValue({});
+    vi.spyOn(config, 'loadCredentials').mockResolvedValue({
+      apiKey: 'api-key',
+      baseUrl: 'https://platform.example.com',
+      orgSlug: 'my-org',
+      orgId: 'my-org-id',
+      kind: 'api-key',
+    });
+
+    const { api, auth } = await createApiClient();
+
+    expect(auth.apiKey).toBe('api-key');
+    expect(auth.orgSlug).toBe('my-org');
+    expect(auth.orgId).toBe('my-org-id');
+    expect(auth.apiBaseUrl).toBe('https://platform.example.com/api/v1');
+    expect(api).toEqual({ client: 'fake' });
+    expect(createBenchmarkClient).toHaveBeenCalledWith({
+      baseUrl: 'https://platform.example.com/api/v1',
+      apiKey: 'api-key',
+      token: undefined,
+      orgSlug: 'my-org',
+      orgId: 'my-org-id',
+    });
+  });
+});

--- a/packages/benchsdk-cli/src/__tests__/client.test.ts
+++ b/packages/benchsdk-cli/src/__tests__/client.test.ts
@@ -96,6 +96,18 @@ describe('resolveAuth', () => {
     expect(auth.orgId).toBeUndefined();
   });
 
+  it('prefers BENCHMARKS_PLATFORM_TOKEN over BENCHMARKS_PLATFORM_API_KEY when both are set', async () => {
+    process.env.BENCHMARKS_PLATFORM_TOKEN = 'env-token';
+    process.env.BENCHMARKS_PLATFORM_API_KEY = 'env-api-key';
+    vi.spyOn(config, 'loadConfig').mockResolvedValue({});
+    vi.spyOn(config, 'loadCredentials').mockResolvedValue(null);
+
+    const auth = await resolveAuth();
+
+    expect(auth.token).toBe('env-token');
+    expect(auth.apiKey).toBeUndefined();
+  });
+
   it('uses explicit config and overrides over saved credentials', async () => {
     vi.spyOn(config, 'loadConfig').mockResolvedValue({
       baseUrl: 'https://config.example.com',

--- a/packages/benchsdk-cli/src/client.ts
+++ b/packages/benchsdk-cli/src/client.ts
@@ -34,11 +34,6 @@ function apiKeyFromEnvironment(): string | undefined {
   return process.env.BENCHMARKS_PLATFORM_API_KEY;
 }
 
-function isNonInteractive(): boolean {
-  if (typeof process === 'undefined') return false;
-  return !!process.env.CI || process.stdin.isTTY === false;
-}
-
 function computeTokenExpiry(expiresInSeconds: number): number {
   return Date.now() + expiresInSeconds * 1000;
 }
@@ -157,11 +152,9 @@ export async function resolveAuth(override?: {
   }
 
   if (!auth.token && !auth.apiKey && !apiKeyFromEnvironment() && !tokenFromEnvironment()) {
-    if (isNonInteractive()) {
-      throw new AuthError(
-        'No credentials found in non-interactive mode. Set BENCHMARKS_PLATFORM_API_KEY or BENCHMARKS_PLATFORM_TOKEN.',
-      );
-    }
+    throw new AuthError(
+      'No credentials found. Set BENCHMARKS_PLATFORM_API_KEY or BENCHMARKS_PLATFORM_TOKEN.',
+    );
   }
 
   return auth;

--- a/packages/benchsdk-cli/src/client.ts
+++ b/packages/benchsdk-cli/src/client.ts
@@ -100,31 +100,54 @@ export async function resolveAuth(override?: {
     org: override?.org,
   });
 
-  const platformUrl = mergedConfig.baseUrl ?? credentials.baseUrl ?? getPlatformBaseUrl();
-  const apiBaseUrl = getApiBaseUrl(platformUrl);
-  const authBaseUrl = getAuthBaseUrl(platformUrl);
-  const orgSlug = override?.org ?? credentials.orgSlug ?? config.org;
-  const orgId = credentials.orgId;
-  const format = config.format;
+  const envApiKey = apiKeyFromEnvironment();
+  const envToken = tokenFromEnvironment();
 
-  let token = tokenFromEnvironment() ?? credentials.token;
-  let apiKey = override?.apiKey;
-  let refreshToken = credentials.refreshToken;
-  let tokenExpiresAt = credentials.tokenExpiresAt;
-  let refreshExpiresAt = credentials.refreshExpiresAt;
+  let token: string | undefined;
+  let apiKey: string | undefined;
+  let refreshToken: string | undefined;
+  let tokenExpiresAt: number | undefined;
+  let refreshExpiresAt: number | undefined;
+  let platformUrl: string;
+  let orgSlug: string | undefined;
+  let orgId: string | undefined;
 
-  if (apiKey) {
+  if (override?.apiKey) {
+    apiKey = override.apiKey;
     token = undefined;
     refreshToken = undefined;
-  } else if (apiKeyFromEnvironment()) {
-    apiKey = apiKeyFromEnvironment();
+    platformUrl = getPlatformBaseUrl(override.baseUrl ?? config.baseUrl);
+    orgSlug = override.org ?? config.org;
+    orgId = undefined;
+  } else if (envApiKey) {
+    apiKey = envApiKey;
     token = undefined;
     refreshToken = undefined;
-  } else if (token && token !== credentials.token) {
-    // Environment token does not refresh through the CLI.
+    platformUrl = getPlatformBaseUrl(mergedConfig.baseUrl);
+    orgSlug = mergedConfig.org;
+    orgId = undefined;
+  } else if (envToken) {
+    token = envToken;
     refreshToken = undefined;
     tokenExpiresAt = undefined;
+    refreshExpiresAt = undefined;
+    platformUrl = getPlatformBaseUrl(mergedConfig.baseUrl);
+    orgSlug = mergedConfig.org;
+    orgId = undefined;
+  } else {
+    token = credentials.token;
+    apiKey = credentials.apiKey;
+    refreshToken = credentials.refreshToken;
+    tokenExpiresAt = credentials.tokenExpiresAt;
+    refreshExpiresAt = credentials.refreshExpiresAt;
+    platformUrl = getPlatformBaseUrl(mergedConfig.baseUrl ?? credentials.baseUrl);
+    orgSlug = mergedConfig.org ?? credentials.orgSlug;
+    orgId = credentials.orgId;
   }
+
+  const apiBaseUrl = getApiBaseUrl(platformUrl);
+  const authBaseUrl = getAuthBaseUrl(platformUrl);
+  const format = config.format;
 
   let auth: CliAuth = {
     token,
@@ -151,7 +174,7 @@ export async function resolveAuth(override?: {
     };
   }
 
-  if (!auth.token && !auth.apiKey && !apiKeyFromEnvironment() && !tokenFromEnvironment()) {
+  if (!auth.token && !auth.apiKey) {
     throw new AuthError(
       'No credentials found. Set BENCHMARKS_PLATFORM_API_KEY or BENCHMARKS_PLATFORM_TOKEN, or run `bench auth login` for OAuth. Create an API key at https://platform.computesdk.com in your organization settings (Settings → API keys).',
     );

--- a/packages/benchsdk-cli/src/client.ts
+++ b/packages/benchsdk-cli/src/client.ts
@@ -153,7 +153,7 @@ export async function resolveAuth(override?: {
 
   if (!auth.token && !auth.apiKey && !apiKeyFromEnvironment() && !tokenFromEnvironment()) {
     throw new AuthError(
-      'No credentials found. Set BENCHMARKS_PLATFORM_API_KEY or BENCHMARKS_PLATFORM_TOKEN.',
+      'No credentials found. Set BENCHMARKS_PLATFORM_API_KEY or BENCHMARKS_PLATFORM_TOKEN, or run `bench auth login` for OAuth. Create an API key at https://platform.computesdk.com in your organization settings (Settings → API keys).',
     );
   }
 

--- a/packages/benchsdk-cli/src/client.ts
+++ b/packages/benchsdk-cli/src/client.ts
@@ -119,18 +119,18 @@ export async function resolveAuth(override?: {
     platformUrl = getPlatformBaseUrl(override.baseUrl ?? config.baseUrl);
     orgSlug = override.org ?? config.org;
     orgId = undefined;
-  } else if (envApiKey) {
-    apiKey = envApiKey;
-    token = undefined;
-    refreshToken = undefined;
-    platformUrl = getPlatformBaseUrl(mergedConfig.baseUrl);
-    orgSlug = mergedConfig.org;
-    orgId = undefined;
   } else if (envToken) {
     token = envToken;
     refreshToken = undefined;
     tokenExpiresAt = undefined;
     refreshExpiresAt = undefined;
+    platformUrl = getPlatformBaseUrl(mergedConfig.baseUrl);
+    orgSlug = mergedConfig.org;
+    orgId = undefined;
+  } else if (envApiKey) {
+    apiKey = envApiKey;
+    token = undefined;
+    refreshToken = undefined;
     platformUrl = getPlatformBaseUrl(mergedConfig.baseUrl);
     orgSlug = mergedConfig.org;
     orgId = undefined;

--- a/packages/benchsdk-cli/src/config.ts
+++ b/packages/benchsdk-cli/src/config.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 export interface Credentials {
   baseUrl?: string;
   token?: string;
+  apiKey?: string;
   refreshToken?: string;
   tokenExpiresAt?: number;
   refreshExpiresAt?: number;

--- a/packages/benchsdk-cli/src/index.ts
+++ b/packages/benchsdk-cli/src/index.ts
@@ -1,4 +1,5 @@
 export { run } from './cli.js';
 export { resolveAuth, createApiClient } from './client.js';
+export { AuthError } from './auth.js';
 export type { CliAuth } from './client.js';
 export type { Credentials } from './config.js';

--- a/packages/benchsdk-cli/src/index.ts
+++ b/packages/benchsdk-cli/src/index.ts
@@ -1,2 +1,4 @@
 export { run } from './cli.js';
+export { resolveAuth, createApiClient } from './client.js';
+export type { CliAuth } from './client.js';
 export type { Credentials } from './config.js';

--- a/packages/benchsdk-runner/README.md
+++ b/packages/benchsdk-runner/README.md
@@ -56,6 +56,8 @@ Run it with the CLI (flags override the config knobs):
 bench run benchmarks/sandbox/sandbox-tti.bench.ts --iterations 100 --concurrency 20 --provider e2b,modal
 ```
 
+`bench run` requires `BENCHMARKS_PLATFORM_API_KEY` for platform reporting, or use `--dry-run` / `--no-ingest` / `BENCHSDK_NO_INGEST=1` to run locally without uploading.
+
 To load a TypeScript benchmark without a build step, run the CLI under a TS loader:
 
 ```sh

--- a/packages/benchsdk-runner/README.md
+++ b/packages/benchsdk-runner/README.md
@@ -56,7 +56,7 @@ Run it with the CLI (flags override the config knobs):
 bench run benchmarks/sandbox/sandbox-tti.bench.ts --iterations 100 --concurrency 20 --provider e2b,modal
 ```
 
-`bench run` requires `BENCHMARKS_PLATFORM_API_KEY` for platform reporting, or use `--dry-run` / `--no-ingest` / `BENCHSDK_NO_INGEST=1` to run locally without uploading.
+`bench run` requires `BENCHMARKS_PLATFORM_API_KEY` or `BENCHMARKS_PLATFORM_TOKEN` even for `--dry-run` / `--no-ingest` / `BENCHSDK_NO_INGEST=1`; those flags only skip uploading, they do not skip auth.
 
 To load a TypeScript benchmark without a build step, run the CLI under a TS loader:
 

--- a/packages/benchsdk-runner/README.md
+++ b/packages/benchsdk-runner/README.md
@@ -56,7 +56,7 @@ Run it with the CLI (flags override the config knobs):
 bench run benchmarks/sandbox/sandbox-tti.bench.ts --iterations 100 --concurrency 20 --provider e2b,modal
 ```
 
-`bench run` requires `BENCHMARKS_PLATFORM_API_KEY` or `BENCHMARKS_PLATFORM_TOKEN` even for `--dry-run` / `--no-ingest` / `BENCHSDK_NO_INGEST=1`; those flags only skip uploading, they do not skip auth.
+`bench run` requires platform auth — `BENCHMARKS_PLATFORM_API_KEY`, `BENCHMARKS_PLATFORM_TOKEN`, or a token saved via `bench auth login` — even for `--dry-run` / `--no-ingest` / `BENCHSDK_NO_INGEST=1`; those flags only skip uploading, they do not skip auth.
 
 To load a TypeScript benchmark without a build step, run the CLI under a TS loader:
 

--- a/packages/benchsdk-runner/src/__tests__/cli.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { runBenchmarkFile } from '../cli';
 import { NoAvailableParticipantsError } from '../no-available-participants.js';
+import { AuthError } from '@benchsdk/cli';
 
 const fixture = (name: string) => `src/__tests__/fixtures/${name}`;
 
@@ -29,11 +30,24 @@ describe('runBenchmarkFile', () => {
   });
 
   it('imports a valid module and drives the run, surfacing NoAvailableParticipantsError', async () => {
-    // The fixture's participant requires an env var that is never set, so the
-    // run env-gates to zero participants before any network call. Extra CLI
-    // flags after the file are forwarded to the runner without error.
+    process.env.BENCHMARKS_PLATFORM_API_KEY = 'test-key';
+    try {
+      // The fixture's participant requires an env var that is never set, so the
+      // run env-gates to zero participants after auth is validated. Extra CLI
+      // flags after the file are forwarded to the runner without error.
+      await expect(
+        runBenchmarkFile(['run', fixture('good.bench.ts'), '--iterations', '3']),
+      ).rejects.toBeInstanceOf(NoAvailableParticipantsError);
+    } finally {
+      delete process.env.BENCHMARKS_PLATFORM_API_KEY;
+    }
+  });
+
+  it('rejects before checking participants when no platform credentials are set', async () => {
+    delete process.env.BENCHMARKS_PLATFORM_API_KEY;
+    delete process.env.BENCHMARKS_PLATFORM_TOKEN;
     await expect(
       runBenchmarkFile(['run', fixture('good.bench.ts'), '--iterations', '3']),
-    ).rejects.toBeInstanceOf(NoAvailableParticipantsError);
+    ).rejects.toBeInstanceOf(AuthError);
   });
 });

--- a/packages/benchsdk-runner/src/__tests__/runner.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/runner.test.ts
@@ -24,9 +24,19 @@ vi.mock('@benchsdk/worker', () => ({
   selectParticipants: (all: any[], names?: string[]) => (names ? all.filter((p) => names.includes(p.name)) : all),
 }));
 
+vi.mock('@benchsdk/cli', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@benchsdk/cli')>();
+  return {
+    ...original,
+    resolveAuth: vi.fn(),
+  };
+});
+
 import { parseCliArgs, mergeConfig, runBenchmark } from '../runner';
 import { TaskError, defineTask } from '../bench-config';
 import { NoAvailableParticipantsError } from '../no-available-participants';
+import { resolveAuth, AuthError } from '@benchsdk/cli';
+import type { CliAuth } from '@benchsdk/cli';
 import type { BenchmarkConfig } from '../bench-config';
 import type { TaskResultRecord } from '@benchsdk/api';
 
@@ -265,12 +275,32 @@ describe('runBenchmark', () => {
       return { assignment, records };
     });
     createBenchmarkClient.mockReturnValue(fakeClient);
+    vi.mocked(resolveAuth).mockImplementation(async () => {
+      const token = process.env.BENCHMARKS_PLATFORM_TOKEN;
+      const apiKey = process.env.BENCHMARKS_PLATFORM_API_KEY;
+      if (!token && !apiKey) {
+        throw new AuthError('No credentials found');
+      }
+      return {
+        apiBaseUrl: 'https://platform.computesdk.com/api/v1',
+        baseUrl: 'https://platform.computesdk.com',
+        authBaseUrl: 'https://platform.computesdk.com/auth',
+        format: 'table',
+        apiKey: token ? undefined : apiKey,
+        token: token || undefined,
+        orgSlug: process.env.BENCHMARKS_TEST_ORG_SLUG,
+        orgId: process.env.BENCHMARKS_TEST_ORG_ID,
+      } as CliAuth;
+    });
   });
 
   afterEach(() => {
     delete process.env.E2B_API_KEY;
     delete process.env.MODAL_TOKEN;
     delete process.env.BENCHMARKS_PLATFORM_API_KEY;
+    delete process.env.BENCHMARKS_PLATFORM_TOKEN;
+    delete process.env.BENCHMARKS_TEST_ORG_SLUG;
+    delete process.env.BENCHMARKS_TEST_ORG_ID;
     delete process.env.BENCHSDK_NO_INGEST;
   });
 
@@ -546,7 +576,20 @@ describe('runBenchmark', () => {
       { name: 'e2b', missing: ['E2B_API_KEY'] },
       { name: 'modal', missing: ['MODAL_TOKEN'] },
     ]);
-    expect(createBenchmarkClient).not.toHaveBeenCalled();
+    expect(createBenchmarkClient).toHaveBeenCalled();
+  });
+
+  it('throws AuthError before checking participants when no platform credentials are set', async () => {
+    delete process.env.BENCHMARKS_PLATFORM_API_KEY;
+    delete process.env.BENCHMARKS_PLATFORM_TOKEN;
+
+    const err = await runBenchmark(
+      { benchmarkSlug: 's', benchmarkName: 'n', participants },
+      defineTask(async () => ({})),
+      [],
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(AuthError);
   });
 
   it('participant mode: tags data.phase from the schedule via measure', async () => {
@@ -1186,5 +1229,38 @@ describe('runBenchmark', () => {
       expect(onComplete).toHaveBeenCalledWith(outcome);
       expect(outcome.runId).toBe('no-ingest');
     });
+  });
+
+  it('propagates resolved orgSlug and orgId to round-mode reporter claims', async () => {
+    process.env.BENCHMARKS_PLATFORM_TOKEN = 'oauth-token';
+    process.env.BENCHMARKS_TEST_ORG_SLUG = 'my-org';
+    process.env.BENCHMARKS_TEST_ORG_ID = 'my-org-id';
+    delete process.env.BENCHMARKS_PLATFORM_API_KEY;
+
+    const task = vi.fn(async () => ({ data: { ok: true } }));
+    const config: BenchmarkConfig<typeof participants[number]> = {
+      benchmarkSlug: 's',
+      benchmarkName: 'n',
+      iterations: 1,
+      groupBy: 'round',
+      participants: [participants[0]],
+    };
+
+    await runBenchmark(config, defineTask(task), []);
+
+    expect(createBenchmarkClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'oauth-token',
+        orgSlug: 'my-org',
+        orgId: 'my-org-id',
+      }),
+    );
+    expect(reporterClaim).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'oauth-token',
+        orgSlug: 'my-org',
+        orgId: 'my-org-id',
+      }),
+    );
   });
 });

--- a/packages/benchsdk-runner/src/__tests__/runner.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/runner.test.ts
@@ -1113,7 +1113,7 @@ describe('runBenchmark', () => {
 
       const outcome = await runBenchmark(config, defineTask(task), ['--no-ingest']);
 
-      expect(createBenchmarkClient).not.toHaveBeenCalled();
+      expect(createBenchmarkClient).toHaveBeenCalled();
       expect(fakeClient.upsertBenchmark).not.toHaveBeenCalled();
       expect(fakeClient.createRun).not.toHaveBeenCalled();
       expect(runWorker).not.toHaveBeenCalled();
@@ -1137,7 +1137,7 @@ describe('runBenchmark', () => {
 
       const outcome = await runBenchmark(config, defineTask(task), ['--no-ingest']);
 
-      expect(createBenchmarkClient).not.toHaveBeenCalled();
+      expect(createBenchmarkClient).toHaveBeenCalled();
       expect(fakeClient.upsertBenchmark).not.toHaveBeenCalled();
       expect(fakeClient.createRun).not.toHaveBeenCalled();
       expect(fakeClient.planWorkers).not.toHaveBeenCalled();
@@ -1159,7 +1159,7 @@ describe('runBenchmark', () => {
 
       const outcome = await runBenchmark(config, defineTask(task), []);
 
-      expect(createBenchmarkClient).not.toHaveBeenCalled();
+      expect(createBenchmarkClient).toHaveBeenCalled();
       expect(fakeClient.createRun).not.toHaveBeenCalled();
       expect(outcome.runId).toBe('no-ingest');
     });

--- a/packages/benchsdk-runner/src/__tests__/runner.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/runner.test.ts
@@ -1163,5 +1163,28 @@ describe('runBenchmark', () => {
       expect(fakeClient.createRun).not.toHaveBeenCalled();
       expect(outcome.runId).toBe('no-ingest');
     });
+
+    it('does not submit a run summary in dry-run even with scoring configured', async () => {
+      const onScore = vi.fn((lowerIsBetter) => ({
+        metrics: [lowerIsBetter('ttiMs', { unit: 'ms', ceiling: 1000, weights: { median: 1, p95: 0, p99: 0 } })],
+      }));
+      const onComplete = vi.fn();
+      const config: BenchmarkConfig<typeof participants[number]> = {
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        iterations: 2,
+        participants: [participants[0]],
+        onScore,
+        onComplete,
+      };
+
+      const outcome = await runBenchmark(config, defineTask(async () => ({ data: { ttiMs: 100 } })), ['--no-ingest']);
+
+      expect(fakeClient.submitRunSummary).not.toHaveBeenCalled();
+      expect(onScore).not.toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(onComplete).toHaveBeenCalledWith(outcome);
+      expect(outcome.runId).toBe('no-ingest');
+    });
   });
 });

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -410,8 +410,8 @@ function resolvePlatform(): { baseUrl: string; apiKey: string } {
   const apiKey = process.env.BENCHMARKS_PLATFORM_API_KEY;
   if (!apiKey) {
     throw new Error(
-      'An API key is required. Set BENCHMARKS_PLATFORM_API_KEY in your environment. Create an org-scoped API key in your ' +
-        'organization settings on the platform.'
+      'An API key is required. Set BENCHMARKS_PLATFORM_API_KEY in your environment. Create an org-scoped API key at ' +
+        `${root} in your organization settings (Settings → API keys).`
     );
   }
   return {

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -17,6 +17,7 @@
 import { execSync } from 'node:child_process';
 import os from 'node:os';
 import { createBenchmarkClient } from '@benchsdk/api';
+import { resolveAuth } from '@benchsdk/cli';
 import {
   BenchmarkReporter,
   filterParticipantsByEnv,
@@ -71,10 +72,6 @@ export interface CliArgs {
   /** When true, run locally and do not ingest/report to the platform. */
   noIngest?: boolean;
 }
-
-// Matches @benchsdk/api's DEFAULT_BASE_URL origin. `resolvePlatform()`
-// appends `/api/v1`. Override for local development via BENCHMARKS_PLATFORM_URL.
-const DEFAULT_PLATFORM_URL = 'https://platform.computesdk.com';
 
 function isEnvNoIngest(): boolean {
   const v = process.env.BENCHSDK_NO_INGEST;
@@ -405,23 +402,6 @@ function defaultOnResult(record: TaskResultRecord, meta: { iterations: number; p
   }
 }
 
-function resolvePlatform(): { baseUrl: string; apiKey?: string; token?: string } {
-  const root = (process.env.BENCHMARKS_PLATFORM_URL || DEFAULT_PLATFORM_URL).replace(/\/+$/, '');
-  const apiKey = process.env.BENCHMARKS_PLATFORM_API_KEY;
-  const token = process.env.BENCHMARKS_PLATFORM_TOKEN;
-  if (!apiKey && !token) {
-    throw new Error(
-      'A platform API key or OAuth token is required. Set BENCHMARKS_PLATFORM_API_KEY or BENCHMARKS_PLATFORM_TOKEN in your environment. Create an org-scoped API key at ' +
-        `${root} in your organization settings (Settings → API keys).`
-    );
-  }
-  return {
-    baseUrl: `${root}/api/v1`,
-    ...(apiKey ? { apiKey } : {}),
-    ...(token ? { token } : {}),
-  };
-}
-
 /**
  * Resolves `--shape <name>` against the config's declared `shapes`. Throws with
  * the known names if the shape is unknown, so a typo fails loudly instead of
@@ -535,8 +515,14 @@ export async function runBenchmark<T extends BaseParticipant>(
   const resolved = mergeConfig(config, args);
   const available = resolveParticipants(config, resolved);
 
-  const { baseUrl, apiKey, token } = resolvePlatform();
-  const client = createBenchmarkClient({ baseUrl, apiKey, token });
+  const auth = await resolveAuth();
+  const client = createBenchmarkClient({
+    baseUrl: auth.apiBaseUrl,
+    apiKey: auth.apiKey,
+    token: auth.token,
+    orgSlug: auth.orgSlug,
+    orgId: auth.orgId,
+  });
 
   const schedule = buildSchedule(config, resolved, task);
   const totalTasks = schedule.length;
@@ -592,7 +578,7 @@ export async function runBenchmark<T extends BaseParticipant>(
         config: runConfig,
       });
       runId = run.id;
-      dashboardUrl = dashboardUrlFor(baseUrl, organizationSlug, config.benchmarkSlug, run.id);
+      dashboardUrl = dashboardUrlFor(auth.apiBaseUrl, organizationSlug, config.benchmarkSlug, run.id);
       for (const participant of available) {
         await client!.upsertParticipant(config.benchmarkSlug, runId, participant.name, { totalTasks });
       }
@@ -606,7 +592,7 @@ export async function runBenchmark<T extends BaseParticipant>(
         config: runConfig,
       });
       runId = run.id;
-      dashboardUrl = dashboardUrlFor(baseUrl, organizationSlug, config.benchmarkSlug, run.id);
+      dashboardUrl = dashboardUrlFor(auth.apiBaseUrl, organizationSlug, config.benchmarkSlug, run.id);
       console.log(`Run created: ${run.name} (${runId})`);
       console.log(`View at: ${dashboardUrl}\n`);
     }
@@ -616,7 +602,7 @@ export async function runBenchmark<T extends BaseParticipant>(
 
   let participantRecords: ParticipantRecords[];
   if (resolved.groupBy === 'round') {
-    participantRecords = await runGroupedByRound(config, schedule, available, resolved, client, runId, baseUrl, apiKey, token, onResult, noIngest);
+    participantRecords = await runGroupedByRound(config, schedule, available, resolved, client, runId, auth.apiBaseUrl, auth.apiKey, auth.token, onResult, noIngest);
   } else {
     participantRecords = await runGroupedByParticipant(config, schedule, available, resolved, client, runId, onResult, noIngest);
   }
@@ -628,7 +614,7 @@ export async function runBenchmark<T extends BaseParticipant>(
     participants: participantRecords,
     config: resolved,
   };
-  if (client && (config.onScore || config.scoring)) {
+  if (!noIngest && (config.onScore || config.scoring)) {
     try {
       const spec = config.onScore
         ? await config.onScore(lowerIsBetter, higherIsBetter)

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -405,18 +405,20 @@ function defaultOnResult(record: TaskResultRecord, meta: { iterations: number; p
   }
 }
 
-function resolvePlatform(): { baseUrl: string; apiKey: string } {
+function resolvePlatform(): { baseUrl: string; apiKey?: string; token?: string } {
   const root = (process.env.BENCHMARKS_PLATFORM_URL || DEFAULT_PLATFORM_URL).replace(/\/+$/, '');
   const apiKey = process.env.BENCHMARKS_PLATFORM_API_KEY;
-  if (!apiKey) {
+  const token = process.env.BENCHMARKS_PLATFORM_TOKEN;
+  if (!apiKey && !token) {
     throw new Error(
-      'An API key is required. Set BENCHMARKS_PLATFORM_API_KEY in your environment. Create an org-scoped API key at ' +
+      'A platform API key or OAuth token is required. Set BENCHMARKS_PLATFORM_API_KEY or BENCHMARKS_PLATFORM_TOKEN in your environment. Create an org-scoped API key at ' +
         `${root} in your organization settings (Settings → API keys).`
     );
   }
   return {
     baseUrl: `${root}/api/v1`,
-    apiKey,
+    ...(apiKey ? { apiKey } : {}),
+    ...(token ? { token } : {}),
   };
 }
 
@@ -533,13 +535,8 @@ export async function runBenchmark<T extends BaseParticipant>(
   const resolved = mergeConfig(config, args);
   const available = resolveParticipants(config, resolved);
 
-  let baseUrl = '';
-  let apiKey = '';
-  let client: BenchmarkClient | null = null;
-  if (!noIngest) {
-    ({ baseUrl, apiKey } = resolvePlatform());
-    client = createBenchmarkClient({ baseUrl, apiKey });
-  }
+  const { baseUrl, apiKey, token } = resolvePlatform();
+  const client = createBenchmarkClient({ baseUrl, apiKey, token });
 
   const schedule = buildSchedule(config, resolved, task);
   const totalTasks = schedule.length;
@@ -619,9 +616,9 @@ export async function runBenchmark<T extends BaseParticipant>(
 
   let participantRecords: ParticipantRecords[];
   if (resolved.groupBy === 'round') {
-    participantRecords = await runGroupedByRound(config, schedule, available, resolved, client, runId, baseUrl, apiKey, onResult, noIngest);
+    participantRecords = await runGroupedByRound(config, schedule, available, resolved, client, runId, baseUrl, apiKey, token, onResult, noIngest);
   } else {
-    participantRecords = await runGroupedByParticipant(config, schedule, available, resolved, client, runId, onResult);
+    participantRecords = await runGroupedByParticipant(config, schedule, available, resolved, client, runId, onResult, noIngest);
   }
 
   console.log(`All done. ${noIngest ? 'No platform run created.' : `View at: ${dashboardUrl}`}`);
@@ -697,6 +694,7 @@ async function runGroupedByParticipant<T extends BaseParticipant>(
   client: BenchmarkClient | null,
   runId: string,
   onResult: OnResult,
+  noIngest: boolean,
 ): Promise<ParticipantRecords[]> {
   const participantRecords: ParticipantRecords[] = [];
   for (const participant of available) {
@@ -705,7 +703,7 @@ async function runGroupedByParticipant<T extends BaseParticipant>(
     console.log('='.repeat(70));
 
     // When running without platform ingest, execute the schedule locally.
-    if (!client) {
+    if (noIngest || !client) {
       const records: TaskResultRecord[] = [];
       let rampStartMs: number | undefined;
       let nextIndex = 0;
@@ -816,7 +814,8 @@ async function runGroupedByRound<T extends BaseParticipant>(
   client: BenchmarkClient | null,
   runId: string,
   baseUrl: string,
-  apiKey: string,
+  apiKey: string | undefined,
+  token: string | undefined,
   onResult: OnResult,
   noIngest: boolean = false,
 ): Promise<ParticipantRecords[]> {
@@ -845,6 +844,7 @@ async function runGroupedByRound<T extends BaseParticipant>(
       reporter = await BenchmarkReporter.claim({
         baseUrl,
         apiKey,
+        token,
         benchmarkSlug: config.benchmarkSlug,
         runId: runId,
         participantSlug: participant.name,

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -513,7 +513,6 @@ export async function runBenchmark<T extends BaseParticipant>(
   const shaped = applyShape(fileConfig, resolveShape(fileConfig, args.shape));
   const config = applyIdentityOverrides(shaped, args);
   const resolved = mergeConfig(config, args);
-  const available = resolveParticipants(config, resolved);
 
   const auth = await resolveAuth();
   const client = createBenchmarkClient({
@@ -523,6 +522,8 @@ export async function runBenchmark<T extends BaseParticipant>(
     orgSlug: auth.orgSlug,
     orgId: auth.orgId,
   });
+
+  const available = resolveParticipants(config, resolved);
 
   const schedule = buildSchedule(config, resolved, task);
   const totalTasks = schedule.length;
@@ -602,7 +603,7 @@ export async function runBenchmark<T extends BaseParticipant>(
 
   let participantRecords: ParticipantRecords[];
   if (resolved.groupBy === 'round') {
-    participantRecords = await runGroupedByRound(config, schedule, available, resolved, client, runId, auth.apiBaseUrl, auth.apiKey, auth.token, onResult, noIngest);
+    participantRecords = await runGroupedByRound(config, schedule, available, resolved, client, runId, auth.apiBaseUrl, auth.apiKey, auth.token, auth.orgSlug, auth.orgId, onResult, noIngest);
   } else {
     participantRecords = await runGroupedByParticipant(config, schedule, available, resolved, client, runId, onResult, noIngest);
   }
@@ -802,6 +803,8 @@ async function runGroupedByRound<T extends BaseParticipant>(
   baseUrl: string,
   apiKey: string | undefined,
   token: string | undefined,
+  orgSlug: string | undefined,
+  orgId: string | undefined,
   onResult: OnResult,
   noIngest: boolean = false,
 ): Promise<ParticipantRecords[]> {
@@ -831,6 +834,8 @@ async function runGroupedByRound<T extends BaseParticipant>(
         baseUrl,
         apiKey,
         token,
+        orgSlug,
+        orgId,
         benchmarkSlug: config.benchmarkSlug,
         runId: runId,
         participantSlug: participant.name,

--- a/packages/benchsdk-worker/src/reporter.ts
+++ b/packages/benchsdk-worker/src/reporter.ts
@@ -81,8 +81,8 @@ export class BenchmarkReporter {
   }
 
   static async claim(cfg: BenchmarkReporterConfig): Promise<BenchmarkReporter | null> {
-    const client = createBenchmarkClient(cfg);
     try {
+      const client = createBenchmarkClient(cfg);
       const assignment = await client.claimWorker(cfg.benchmarkSlug, cfg.runId, cfg.participantSlug, {
         processKind: cfg.processKind,
         processKey: cfg.processKey,

--- a/packages/benchsdk/README.md
+++ b/packages/benchsdk/README.md
@@ -15,6 +15,12 @@ npm install @benchsdk/client
 > [`@benchsdk/runner`](../benchsdk-runner). This package is REST transport plus
 > the worker engine only.
 
+## Authentication
+
+`createBenchmarkClient` requires a platform API key or OAuth token. Provide
+`apiKey`/`token` directly, or set `BENCHMARKS_PLATFORM_API_KEY` or
+`BENCHMARKS_PLATFORM_TOKEN` in the environment.
+
 ## Run A Worker
 
 ```ts

--- a/packages/benchsdk/src/__tests__/client.test.ts
+++ b/packages/benchsdk/src/__tests__/client.test.ts
@@ -1,8 +1,23 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { gzipSync, gunzipSync } from 'node:zlib';
 import { createBenchmarkClient } from '../client';
 import { BenchmarkApiError, BenchmarkReporter, createSystemMetricsCollector } from '../index';
 import type { BenchmarkAssignment } from '../index';
+
+let originalApiKey: string | undefined;
+
+beforeAll(() => {
+  originalApiKey = process.env.BENCHMARKS_PLATFORM_API_KEY;
+  process.env.BENCHMARKS_PLATFORM_API_KEY = 'k';
+});
+
+afterAll(() => {
+  if (originalApiKey === undefined) {
+    delete process.env.BENCHMARKS_PLATFORM_API_KEY;
+  } else {
+    process.env.BENCHMARKS_PLATFORM_API_KEY = originalApiKey;
+  }
+});
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {

--- a/packages/benchsdk/src/__tests__/public-api.contract.test.ts
+++ b/packages/benchsdk/src/__tests__/public-api.contract.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import * as barrel from '../index';
 import {
@@ -193,6 +193,21 @@ type _PublicTypeSurface = [
 
 const BASE = 'https://platform.test/api/v1';
 const DEFAULT_BASE_URL = 'https://platform.computesdk.com/api/v1';
+
+let originalApiKey: string | undefined;
+
+beforeAll(() => {
+  originalApiKey = process.env.BENCHMARKS_PLATFORM_API_KEY;
+  process.env.BENCHMARKS_PLATFORM_API_KEY = 'k';
+});
+
+afterAll(() => {
+  if (originalApiKey === undefined) {
+    delete process.env.BENCHMARKS_PLATFORM_API_KEY;
+  } else {
+    process.env.BENCHMARKS_PLATFORM_API_KEY = originalApiKey;
+  }
+});
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {

--- a/packages/benchsdk/src/__tests__/public-api.contract.test.ts
+++ b/packages/benchsdk/src/__tests__/public-api.contract.test.ts
@@ -1352,6 +1352,23 @@ describe('BenchmarkReporter', () => {
       vi.useRealTimers();
     }
   });
+
+  it('returns null instead of rejecting when credentials are missing', async () => {
+    const prevApiKey = process.env.BENCHMARKS_PLATFORM_API_KEY;
+    const prevToken = process.env.BENCHMARKS_PLATFORM_TOKEN;
+    try {
+      delete process.env.BENCHMARKS_PLATFORM_API_KEY;
+      delete process.env.BENCHMARKS_PLATFORM_TOKEN;
+      const { fetchMock } = recordingClient(() => jsonResponse({ assignment: makeAssignment() }));
+      const reporter = await BenchmarkReporter.claim({ ...reporterConfig, fetch: fetchMock });
+      expect(reporter).toBeNull();
+    } finally {
+      if (prevApiKey === undefined) delete process.env.BENCHMARKS_PLATFORM_API_KEY;
+      else process.env.BENCHMARKS_PLATFORM_API_KEY = prevApiKey;
+      if (prevToken === undefined) delete process.env.BENCHMARKS_PLATFORM_TOKEN;
+      else process.env.BENCHMARKS_PLATFORM_TOKEN = prevToken;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Make platform authentication (API key or OAuth token) required before any CLI command, low-level client construction, or `bench run` invocation — including `--dry-run` / `--no-ingest` / `BENCHSDK_NO_INGEST=1` mode. Those flags now only skip uploading/reporting; they no longer bypass auth. OAuth device-code login (and saved credentials from `bench auth login`) work for `bench run`. Scale scripts and the `COMPUTESDK_API_KEY` fallback are left untouched as requested.

### Changes

- `packages/benchsdk-api/src/client.ts`
  - `createBenchmarkClient` now throws immediately if no `apiKey`, `token`, `BENCHMARKS_PLATFORM_API_KEY`, or `BENCHMARKS_PLATFORM_TOKEN` is available.
  - `getAuthToken` precedence is now explicit `token` > explicit `apiKey` > `BENCHMARKS_PLATFORM_TOKEN` > `BENCHMARKS_PLATFORM_API_KEY`.

- `packages/benchsdk-cli/src/client.ts`
  - `resolveAuth` now fails fast with `AuthError` whenever no credentials are present.
  - Credential precedence is now explicit `--api-key` > `BENCHMARKS_PLATFORM_TOKEN` > `BENCHMARKS_PLATFORM_API_KEY` > saved OAuth.
  - Environment credentials win over saved OAuth credentials and do not inherit the saved `baseUrl`, `orgSlug`, or `orgId`.
  - Saved OAuth credentials are still used when no environment credential is present.
  - Removed the now-unused `isNonInteractive` helper.

- `packages/benchsdk-cli/src/config.ts`
  - Added `apiKey` to the `Credentials` interface so saved API keys can be represented.

- `packages/benchsdk-cli/src/index.ts`
  - Exports `AuthError`, `resolveAuth` and `createApiClient` so the runner can reuse the CLI's credential resolution and refresh logic.

- `packages/benchsdk-worker/src/reporter.ts`
  - `BenchmarkReporter.claim` now wraps `createBenchmarkClient` in its existing try/catch, so missing credentials still return `null` instead of rejecting (preserves the claim contract).

- `packages/benchsdk-runner/src/runner.ts`
  - `runBenchmark` now calls `resolveAuth()` from `@benchsdk/cli` at the very start of every run, **before** `resolveParticipants()`.
  - `resolveAuth()` handles `BENCHMARKS_PLATFORM_API_KEY`, `BENCHMARKS_PLATFORM_TOKEN`, and saved OAuth credentials from `bench auth login`, including refresh.
  - `noIngest` still skips `upsertBenchmark`, `createRun`, `planWorkers`, and `submitRunSummary`.
  - The scoring summary submission path is guarded by `!noIngest`, so dry runs no longer attempt to submit a summary for the synthetic `no-ingest` run.
  - Round-mode runs (`runGroupedByRound`) now propagate the resolved `orgSlug`/`orgId` into `BenchmarkReporter.claim`.

- `packages/benchsdk-runner/src/__tests__/runner.test.ts`
  - Updated `no-ingest mode` tests to assert `createBenchmarkClient` is now called (auth is still resolved), while platform upload/reporting calls remain skipped.
  - Added a test verifying `submitRunSummary` is not called in dry-run when `onScore` is configured and `onComplete` still fires.
  - Added a test verifying `AuthError` is thrown before `NoAvailableParticipantsError` when no platform credentials are set.
  - Added a test verifying round-mode `BenchmarkReporter.claim` receives the resolved `orgSlug`/`orgId`.

- `packages/benchsdk-runner/src/__tests__/cli.test.ts`
  - Updated the `NoAvailableParticipantsError` test to set `BENCHMARKS_PLATFORM_API_KEY`.
  - Added a test that rejects with `AuthError` before participant checks when no platform credentials are set.

- `packages/benchsdk-cli/src/__tests__/client.test.ts`
  - Added unit tests for `resolveAuth` covering saved OAuth, env API key, env token, override API key, explicit config, both env credentials together, and the missing-credential error.

- Docs
  - `WRITING_BENCHMARKS.md`, `examples/README.md`, `packages/benchsdk-runner/README.md`, `.agents/skills/benchsdk-cli/SKILL.md`, and `packages/benchsdk/README.md` updated to document that a platform API key or OAuth token is required for every `bench run`, even with `--dry-run`.

### Verification

- `pnpm typecheck` passes.
- `pnpm -r --filter "./packages/**" build` passes.
- `pnpm --filter @benchsdk/client test`, `pnpm --filter @benchsdk/cli test`, and `pnpm --filter @benchsdk/runner test` pass.


Link to Devin session: https://app.devin.ai/sessions/af07215c3e9a4443a455e3994d54f5ea
Open in Devin Desktop: https://app.devin.ai/desktop/session/af07215c3e9a4443a455e3994d54f5ea?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->