### PR TITLE
Enable per-round concurrency and raise scheduled AI gateway iterations

### DIFF
--- a/.changeset/benchsdk-runner-round-concurrency.md
+++ b/.changeset/benchsdk-runner-round-concurrency.md
@@ -1,0 +1,9 @@
+---
+"@benchsdk/runner": minor
+---
+
+Respect `concurrency` in `groupBy: 'round'` mode.
+
+- `runGroupedByRound` now runs each round's participants concurrently up to `resolved.concurrency` instead of sequentially.
+- Added an internal `runWithConcurrency` helper to bound parallel tasks without adding a new dependency.
+- Preserves round-robin fairness: all Nth probes across gateways still start at roughly the same wall-clock time, while rounds stay sequential.

--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -109,7 +109,7 @@ jobs:
             svgScript: generate-ai-gateway-kimi-svg
             svgFile: ai-gateway-kimi.svg
             timeout: 150
-            iterations: 50
+            iterations: 25
     # Manual runs can scope to one family via the `family` input; push/schedule
     # triggers always run all four.
     timeout-minutes: ${{ matrix.family.timeout }}

--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -25,7 +25,7 @@ on:
           - gemini
           - kimi
       iterations:
-        description: 'Cold + warm iterations per gateway (leave empty for family default or 50)'
+        description: 'Cold + warm iterations per gateway (leave empty for family default or 30)'
         required: false
         default: ''
       provider:
@@ -149,13 +149,17 @@ jobs:
           . benchmarks/scripts/load-vault-secrets.sh '^(ANTHROPIC_API_KEY|OPENAI_API_KEY|GEMINI_API_KEY|KIMI_API_KEY|NOVITA_API_KEY|NEON_AI_GATEWAY_BASE_URL|NEON_AI_GATEWAY_TOKEN|NGROK_AI_GATEWAY_API_KEY|LLMAPI_API_KEY|CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID|CLOUDFLARE_AI_GATEWAY_GATEWAY_ID|CLOUDFLARE_AI_GATEWAY_TOKEN|LLM_GATEWAY_API_KEY|OPENROUTER_API_KEY|PYDANTIC_AI_GATEWAY_API_KEY|VERCEL_AI_GATEWAY_API_KEY|CONCENTRATE_AI_GATEWAY_API_KEY|BLAZERAIL_API_KEY|BENCHMARKS_PLATFORM_API_KEY)'
 
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "schedule" ]; then
-            ITERATIONS="50"
+            if [ "${{ matrix.family.slug }}" = "kimi" ]; then
+              ITERATIONS="25"
+            else
+              ITERATIONS="50"
+            fi
           elif [ -n "$INPUT_ITERATIONS" ]; then
             ITERATIONS="$INPUT_ITERATIONS"
           elif [ -n "$FAMILY_ITERATIONS" ]; then
             ITERATIONS="$FAMILY_ITERATIONS"
           else
-            ITERATIONS="50"
+            ITERATIONS="30"
           fi
 
           provider_args=()

--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -148,12 +148,14 @@ jobs:
         run: |
           . benchmarks/scripts/load-vault-secrets.sh '^(ANTHROPIC_API_KEY|OPENAI_API_KEY|GEMINI_API_KEY|KIMI_API_KEY|NOVITA_API_KEY|NEON_AI_GATEWAY_BASE_URL|NEON_AI_GATEWAY_TOKEN|NGROK_AI_GATEWAY_API_KEY|LLMAPI_API_KEY|CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID|CLOUDFLARE_AI_GATEWAY_GATEWAY_ID|CLOUDFLARE_AI_GATEWAY_TOKEN|LLM_GATEWAY_API_KEY|OPENROUTER_API_KEY|PYDANTIC_AI_GATEWAY_API_KEY|VERCEL_AI_GATEWAY_API_KEY|CONCENTRATE_AI_GATEWAY_API_KEY|BLAZERAIL_API_KEY|BENCHMARKS_PLATFORM_API_KEY)'
 
-          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "${{ github.event_name }}" = "schedule" ]; then
             if [ "${{ matrix.family.slug }}" = "kimi" ]; then
               ITERATIONS="25"
             else
               ITERATIONS="50"
             fi
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            ITERATIONS="10"
           elif [ -n "$INPUT_ITERATIONS" ]; then
             ITERATIONS="$INPUT_ITERATIONS"
           elif [ -n "$FAMILY_ITERATIONS" ]; then

--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -25,7 +25,7 @@ on:
           - gemini
           - kimi
       iterations:
-        description: 'Cold + warm iterations per gateway (leave empty for family default or 30)'
+        description: 'Cold + warm iterations per gateway (leave empty for family default or 50)'
         required: false
         default: ''
       provider:
@@ -109,7 +109,7 @@ jobs:
             svgScript: generate-ai-gateway-kimi-svg
             svgFile: ai-gateway-kimi.svg
             timeout: 150
-            iterations: 15
+            iterations: 50
     # Manual runs can scope to one family via the `family` input; push/schedule
     # triggers always run all four.
     timeout-minutes: ${{ matrix.family.timeout }}
@@ -149,13 +149,13 @@ jobs:
           . benchmarks/scripts/load-vault-secrets.sh '^(ANTHROPIC_API_KEY|OPENAI_API_KEY|GEMINI_API_KEY|KIMI_API_KEY|NOVITA_API_KEY|NEON_AI_GATEWAY_BASE_URL|NEON_AI_GATEWAY_TOKEN|NGROK_AI_GATEWAY_API_KEY|LLMAPI_API_KEY|CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID|CLOUDFLARE_AI_GATEWAY_GATEWAY_ID|CLOUDFLARE_AI_GATEWAY_TOKEN|LLM_GATEWAY_API_KEY|OPENROUTER_API_KEY|PYDANTIC_AI_GATEWAY_API_KEY|VERCEL_AI_GATEWAY_API_KEY|CONCENTRATE_AI_GATEWAY_API_KEY|BLAZERAIL_API_KEY|BENCHMARKS_PLATFORM_API_KEY)'
 
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "schedule" ]; then
-            ITERATIONS="10"
+            ITERATIONS="50"
           elif [ -n "$INPUT_ITERATIONS" ]; then
             ITERATIONS="$INPUT_ITERATIONS"
           elif [ -n "$FAMILY_ITERATIONS" ]; then
             ITERATIONS="$FAMILY_ITERATIONS"
           else
-            ITERATIONS="30"
+            ITERATIONS="50"
           fi
 
           provider_args=()

--- a/AI_GATEWAYS.md
+++ b/AI_GATEWAYS.md
@@ -174,6 +174,8 @@ round 2: openrouter → vercel-ai-gateway → cloudflare-ai-gateway → llmgatew
 
 This is purely about **execution order in time**. Instead of running all of one gateway's iterations back-to-back and then moving to the next gateway (where the last gateway tested could be unfairly affected by, say, a network blip or a provider's load spike five minutes into the run), every gateway gets its Nth iteration at roughly the same point in time as every other gateway's Nth iteration. No gateway's numbers are systematically favored by running earlier, later, or during a different network condition than the others.
 
+Within each round the gateways run concurrently up to `concurrency: providers.length`, while the rounds themselves stay sequential. This keeps the per-round fairness intact but removes the multiplicative runtime cost of the number of gateways, so iteration counts can be raised for better statistics without a proportional wall-clock increase.
+
 Round-robin only interleaves *which gateway's turn it is next*; it never affects what "warm" means for any individual gateway.
 
 ### What one warm iteration actually does

--- a/benchmarks/ai-gateway/ai-gateway-gemini.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway-gemini.bench.ts
@@ -35,6 +35,7 @@ export const config = defineBenchmarkConfig({
   phases,
   groupBy: 'round',
   participants: providers,
+  concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
   scoring: {
     metrics: [

--- a/benchmarks/ai-gateway/ai-gateway-kimi.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway-kimi.bench.ts
@@ -52,6 +52,7 @@ export const config = defineBenchmarkConfig({
   phases,
   groupBy: 'round',
   participants: providers,
+  concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
   scoring: {
     metrics: [

--- a/benchmarks/ai-gateway/ai-gateway-openai.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway-openai.bench.ts
@@ -35,6 +35,7 @@ export const config = defineBenchmarkConfig({
   phases,
   groupBy: 'round',
   participants: providers,
+  concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
   scoring: {
     metrics: [

--- a/benchmarks/ai-gateway/ai-gateway.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway.bench.ts
@@ -52,6 +52,10 @@ export const config = defineBenchmarkConfig({
   phases,
   groupBy: 'round',
   participants: providers,
+  // Run every gateway in a round concurrently while keeping rounds sequential.
+  // This preserves the per-round fairness of round-robin ordering without
+  // multiplying runtime by the number of gateways.
+  concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
   scoring: {
     metrics: [

--- a/benchmarks/ai-gateway/shared-task.ts
+++ b/benchmarks/ai-gateway/shared-task.ts
@@ -51,8 +51,8 @@ export function parseIntFlag(argv: string[], flag: string): number | undefined {
  */
 export function resolveAIGatewayPhases(argv: string[]): Array<{ name: string; iterations: number }> {
   const iterationsOverride = parseIntFlag(argv, '--iterations');
-  const iterationsCold = parseIntFlag(argv, '--ai-gateway-iterations-cold') ?? iterationsOverride ?? 50;
-  const iterationsWarm = parseIntFlag(argv, '--ai-gateway-iterations-warm') ?? iterationsOverride ?? 50;
+  const iterationsCold = parseIntFlag(argv, '--ai-gateway-iterations-cold') ?? iterationsOverride ?? 10;
+  const iterationsWarm = parseIntFlag(argv, '--ai-gateway-iterations-warm') ?? iterationsOverride ?? 10;
   return [
     { name: 'cold', iterations: iterationsCold },
     { name: 'warm', iterations: iterationsWarm },

--- a/benchmarks/ai-gateway/shared-task.ts
+++ b/benchmarks/ai-gateway/shared-task.ts
@@ -51,8 +51,8 @@ export function parseIntFlag(argv: string[], flag: string): number | undefined {
  */
 export function resolveAIGatewayPhases(argv: string[]): Array<{ name: string; iterations: number }> {
   const iterationsOverride = parseIntFlag(argv, '--iterations');
-  const iterationsCold = parseIntFlag(argv, '--ai-gateway-iterations-cold') ?? iterationsOverride ?? 10;
-  const iterationsWarm = parseIntFlag(argv, '--ai-gateway-iterations-warm') ?? iterationsOverride ?? 10;
+  const iterationsCold = parseIntFlag(argv, '--ai-gateway-iterations-cold') ?? iterationsOverride ?? 50;
+  const iterationsWarm = parseIntFlag(argv, '--ai-gateway-iterations-warm') ?? iterationsOverride ?? 50;
   return [
     { name: 'cold', iterations: iterationsCold },
     { name: 'warm', iterations: iterationsWarm },

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -82,6 +82,44 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Runs an array of async functions with a bounded concurrency limit.
+ * Results are returned in the same order as the input array.
+ */
+function runWithConcurrency<T>(fns: Array<() => Promise<T>>, limit: number): Promise<T[]> {
+  if (limit >= fns.length || fns.length === 0) {
+    return Promise.all(fns.map((fn) => fn()));
+  }
+
+  const results = new Array<T>(fns.length);
+  let running = 0;
+  let completed = 0;
+  let nextIndex = 0;
+
+  return new Promise((resolve, reject) => {
+    const runNext = () => {
+      if (completed === fns.length) {
+        resolve(results);
+        return;
+      }
+      while (running < limit && nextIndex < fns.length) {
+        const index = nextIndex++;
+        running++;
+        fns[index]().then(
+          (value) => {
+            results[index] = value;
+            running--;
+            completed++;
+            runNext();
+          },
+          (error) => reject(error),
+        );
+      }
+    };
+    runNext();
+  });
+}
+
 function getErrorCode(error: unknown): string {
   if (error instanceof Error && 'code' in error && typeof (error as { code: unknown }).code === 'string' && (error as { code: string }).code) {
     return (error as { code: string }).code;
@@ -528,7 +566,7 @@ export async function runBenchmark<T extends BaseParticipant>(
   const schedule = buildSchedule(config, resolved, task);
   const totalTasks = schedule.length;
 
-  const concurrencyLabel = resolved.groupBy === 'round' ? 'n/a (round mode)' : String(resolved.concurrency);
+  const concurrencyLabel = String(resolved.concurrency);
   console.log(`${config.benchmarkName} (self-contained)`);
   console.log(`Date: ${new Date().toISOString()}`);
   if (noIngest) {
@@ -816,6 +854,7 @@ async function runGroupedByRound<T extends BaseParticipant>(
   for (const participant of available) {
     logBuffers.set(participant.name, new LogBuffer());
     failed.set(participant.name, false);
+    recordsByParticipant.set(participant.name, []);
     if (noIngest || !client) {
       reporters.set(participant.name, null);
       continue;
@@ -859,7 +898,7 @@ async function runGroupedByRound<T extends BaseParticipant>(
     if (resolved.staggerDelayMs > 0 && i > 0) {
       await sleep(resolved.staggerDelayMs);
     }
-    for (const participant of available) {
+    const roundFns = available.map((participant) => async () => {
       const reporter = reporters.get(participant.name) ?? null;
       const logBuffer = logBuffers.get(participant.name)!;
       const record = await runTaskRecord(
@@ -873,9 +912,6 @@ async function runGroupedByRound<T extends BaseParticipant>(
       if (record.status !== 'success') failed.set(participant.name, true);
       onResult(record, { iterations: schedule.length, participant: participant.name });
       reporter?.recordResult(record);
-      if (!recordsByParticipant.has(participant.name)) {
-        recordsByParticipant.set(participant.name, []);
-      }
       const participantRecords = recordsByParticipant.get(participant.name)!;
       participantRecords.push(record);
       // Round mode drives the worker by hand, so nothing reports progress
@@ -889,7 +925,8 @@ async function runGroupedByRound<T extends BaseParticipant>(
         });
         await reporter.heartbeat();
       }
-    }
+    });
+    await runWithConcurrency(roundFns, resolved.concurrency);
   }
 
   for (const participant of available) {


### PR DESCRIPTION
Make the round-robin runner respect `concurrency` so all gateways in a round can run in parallel, then set `concurrency: providers.length` in each AI gateway family. The weekly `schedule` CI runs now use 50 cold/warm iterations per gateway (25 for Kimi) for better statistical relevance, while `push` to `master` stays at 10 per phase.

## What changed

- `packages/benchsdk-runner/src/runner.ts`
  - Added `runWithConcurrency()` helper.
  - `runGroupedByRound()` now runs each round's participants through `runWithConcurrency(roundFns, resolved.concurrency)` instead of a serial loop.
  - `runBenchmark()` no longer prints `n/a (round mode)` for concurrency; it prints the configured value.
- `benchmarks/ai-gateway/*.bench.ts`
  - Set `concurrency: providers.length` so every active gateway in a round starts at roughly the same time.
- `.github/workflows/ai-gateway-benchmarks.yml`
  - `schedule` runs now use 50 iterations per phase for Anthropic/OpenAI/Gemini and 25 per phase for Kimi.
  - `push` to `master` keeps the previous 10 iterations per phase for all families.
  - `workflow_dispatch` still respects the `iterations` input, then the per-family matrix default, then falls back to `30`.
- `AI_GATEWAYS.md`
  - Updated the round-robin explanation to note that gateways within a round are concurrent.

## Why

`groupBy: 'round'` keeps the Nth probe of every gateway at roughly the same wall-clock time, which removes time-of-day drift. Previously the runner executed those probes sequentially, so doubling the iteration count roughly multiplied runtime by the number of gateways. Running the round's participants concurrently keeps the fairness property while decoupling runtime from gateway count, making it practical to raise scheduled iterations for better statistics.

Rounds themselves remain sequential, and `staggerDelayMs` still lives between rounds, so the existing stagger behavior is unchanged.

Link to Devin session: https://app.devin.ai/sessions/0e696dd9ff374a749250e6fe2cdeb1d5
Open in Devin Desktop: https://app.devin.ai/desktop/session/0e696dd9ff374a749250e6fe2cdeb1d5?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->