### PR TITLE
feat(metrics): add system metrics collection with host/cgroup stats

### DIFF
--- a/packages/benchsdk-api/src/types.ts
+++ b/packages/benchsdk-api/src/types.ts
@@ -640,6 +640,15 @@ export interface RunWorkerOptions {
   logFlushIntervalMs?: number;
   /** Compress worker log artifacts with `gzip`. Defaults to `BENCHMARK_LOG_COMPRESSION` env or `false`. */
   logCompression?: 'gzip' | false;
+  /**
+   * Interval in ms to sample system metrics (this process's CPU/memory, event
+   * loop lag, host load average and socket counts), uploaded as a
+   * `system-metrics` artifact once at finish. `0` disables sampling entirely.
+   * Defaults to `BENCHMARK_METRICS_INTERVAL_MS` env or 30000 — unlike log
+   * flushing, this is on by default since sampling is the only way these
+   * values are ever captured.
+   */
+  metricsIntervalMs?: number;
   task: TaskFunction;
 }
 

--- a/packages/benchsdk-runner/src/__tests__/runner.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/runner.test.ts
@@ -10,6 +10,10 @@ vi.mock('@benchsdk/api', () => ({
 
 vi.mock('@benchsdk/worker', () => ({
   BenchmarkReporter: { claim: (...args: unknown[]) => reporterClaim(...args) },
+  createSystemMetricsCollector: () => ({
+    sample: () => ({ ts: new Date().toISOString() }),
+    stop: () => {},
+  }),
   filterParticipantsByEnv: (ps: any[]) => {
     const available: any[] = [];
     const skipped: { name: string; missing: string[] }[] = [];
@@ -689,6 +693,38 @@ describe('runBenchmark', () => {
     expect(runWorker).not.toHaveBeenCalled();
     expect(fakeClient.planWorkers).toHaveBeenCalledTimes(2);
     expect(calls.planWorkers[0][3]).toMatchObject({ workerCount: 1, targetConcurrency: 2 });
+  });
+
+  it('groupBy round: uploads a system-metrics artifact alongside coordinator.log', async () => {
+    const uploads: Record<string, { kind: string; body: string }[]> = { e2b: [], modal: [] };
+    reporterClaim.mockImplementation(async (cfg: any) => ({
+      taskIndexStart: 0,
+      recordResult: () => {},
+      uploadArtifact: async (input: { kind: string; body: string }) => {
+        uploads[cfg.participantSlug].push(input);
+        return {};
+      },
+      setProgress: () => {},
+      heartbeat: async () => {},
+      finish: async () => {},
+    }));
+
+    const task = vi.fn(async () => ({ data: { ok: true } }));
+
+    await runBenchmark(
+      { benchmarkSlug: 'ai-gateway-local', benchmarkName: 'AI GW', iterations: 2, groupBy: 'round', participants },
+      defineTask(task),
+      [],
+    );
+
+    for (const slug of ['e2b', 'modal']) {
+      const metrics = uploads[slug].find((u) => u.kind === 'system-metrics');
+      expect(metrics).toMatchObject({ kind: 'system-metrics', name: 'metrics.jsonl', contentType: 'application/x-ndjson' });
+      // Baseline sample at claim + one per round (2 rounds here).
+      const lines = metrics!.body.trim().split('\n');
+      expect(lines).toHaveLength(3);
+      for (const line of lines) expect(() => JSON.parse(line)).not.toThrow();
+    }
   });
 
   it('groupBy round: a task with no explicit steps records a single implicit "task" step', async () => {

--- a/packages/benchsdk-runner/src/__tests__/runner.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/runner.test.ts
@@ -695,7 +695,7 @@ describe('runBenchmark', () => {
     expect(calls.planWorkers[0][3]).toMatchObject({ workerCount: 1, targetConcurrency: 2 });
   });
 
-  it('groupBy round: uploads a system-metrics artifact alongside coordinator.log', async () => {
+  it('groupBy round: uploads a single shared system-metrics artifact (not one per participant)', async () => {
     const uploads: Record<string, { kind: string; body: string }[]> = { e2b: [], modal: [] };
     reporterClaim.mockImplementation(async (cfg: any) => ({
       taskIndexStart: 0,
@@ -717,14 +717,16 @@ describe('runBenchmark', () => {
       [],
     );
 
-    for (const slug of ['e2b', 'modal']) {
-      const metrics = uploads[slug].find((u) => u.kind === 'system-metrics');
-      expect(metrics).toMatchObject({ kind: 'system-metrics', name: 'metrics.jsonl', contentType: 'application/x-ndjson' });
-      // Baseline sample at claim + one per round (2 rounds here).
-      const lines = metrics!.body.trim().split('\n');
-      expect(lines).toHaveLength(3);
-      for (const line of lines) expect(() => JSON.parse(line)).not.toThrow();
-    }
+    // Every participant runs in this one shared process, so metrics belong to
+    // the run — a single artifact via one reporter, not a duplicate per slug.
+    const metricsUploads = [...uploads.e2b, ...uploads.modal].filter((u) => u.kind === 'system-metrics');
+    expect(metricsUploads).toHaveLength(1);
+    const metrics = metricsUploads[0];
+    expect(metrics).toMatchObject({ kind: 'system-metrics', name: 'metrics.jsonl', contentType: 'application/x-ndjson' });
+    // Baseline sample at claim + one per round (2 rounds) + one final sample.
+    const lines = metrics.body.trim().split('\n');
+    expect(lines).toHaveLength(4);
+    for (const line of lines) expect(() => JSON.parse(line)).not.toThrow();
   });
 
   it('groupBy round: a task with no explicit steps records a single implicit "task" step', async () => {

--- a/packages/benchsdk-runner/src/__tests__/runner.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/runner.test.ts
@@ -696,11 +696,11 @@ describe('runBenchmark', () => {
   });
 
   it('groupBy round: uploads a single shared system-metrics artifact (not one per participant)', async () => {
-    const uploads: Record<string, { kind: string; body: string }[]> = { e2b: [], modal: [] };
+    const uploads: Record<string, { kind: string; body: string; metadata?: Record<string, unknown> }[]> = { e2b: [], modal: [] };
     reporterClaim.mockImplementation(async (cfg: any) => ({
       taskIndexStart: 0,
       recordResult: () => {},
-      uploadArtifact: async (input: { kind: string; body: string }) => {
+      uploadArtifact: async (input: { kind: string; body: string; metadata?: Record<string, unknown> }) => {
         uploads[cfg.participantSlug].push(input);
         return {};
       },
@@ -723,6 +723,10 @@ describe('runBenchmark', () => {
     expect(metricsUploads).toHaveLength(1);
     const metrics = metricsUploads[0];
     expect(metrics).toMatchObject({ kind: 'system-metrics', name: 'metrics.jsonl', contentType: 'application/x-ndjson' });
+    // Tagged process-scoped with every participant, so it's not misread as the
+    // uploading participant's isolated usage (the SDK's only artifact API is
+    // worker-scoped, so it's necessarily filed under one reporter's worker).
+    expect(metrics.metadata).toEqual({ scope: 'shared-process', participants: ['e2b', 'modal'] });
     // Baseline sample at claim + one per round (2 rounds) + one final sample.
     const lines = metrics.body.trim().split('\n');
     expect(lines).toHaveLength(4);

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -19,10 +19,12 @@ import os from 'node:os';
 import { createBenchmarkClient } from '@benchsdk/api';
 import {
   BenchmarkReporter,
+  createSystemMetricsCollector,
   filterParticipantsByEnv,
   runWorker,
   selectParticipants,
 } from '@benchsdk/worker';
+import type { BenchmarkSystemMetricsCollector, BenchmarkSystemMetricsSample } from '@benchsdk/worker';
 import { NoAvailableParticipantsError } from './no-available-participants.js';
 import { higherIsBetter, lowerIsBetter, score, ScoringSpecError, scoringConfigToSpec } from './scoring.js';
 import type {
@@ -824,6 +826,12 @@ async function runGroupedByRound<T extends BaseParticipant>(
   const logBuffers = new Map<string, LogBuffer>();
   const failed = new Map<string, boolean>();
   const recordsByParticipant = new Map<string, TaskResultRecord[]>();
+  // One collector per participant, scoped the same way `runWorker` scopes its
+  // own (a fresh baseline at the start of that participant's execution slice),
+  // even though every participant shares this one Node process here. Created
+  // only when there's a reporter to upload to — nothing else would read it.
+  const metricsCollectors = new Map<string, BenchmarkSystemMetricsCollector>();
+  const metricsSamples = new Map<string, BenchmarkSystemMetricsSample[]>();
 
   for (const participant of available) {
     logBuffers.set(participant.name, new LogBuffer());
@@ -858,6 +866,10 @@ async function runGroupedByRound<T extends BaseParticipant>(
       console.warn(`  ${participant.name}: could not claim a platform worker — running without platform reporting.`);
     }
     reporters.set(participant.name, reporter);
+    if (reporter) {
+      metricsCollectors.set(participant.name, createSystemMetricsCollector());
+      metricsSamples.set(participant.name, [metricsCollectors.get(participant.name)!.sample()]);
+    }
   }
 
   console.log(`Interleaving ${available.length} participant(s), ${schedule.length} round(s) each.\n`);
@@ -897,6 +909,11 @@ async function runGroupedByRound<T extends BaseParticipant>(
           total: schedule.length,
         });
         await reporter.heartbeat();
+        // Sampled once per round rather than on a wall-clock timer: round mode
+        // runs everything sequentially in this one loop, so a round boundary
+        // is the natural, already-existing cadence (same one heartbeat uses).
+        const collector = metricsCollectors.get(participant.name);
+        if (collector) metricsSamples.get(participant.name)!.push(collector.sample());
       }
     }
   }
@@ -907,6 +924,19 @@ async function runGroupedByRound<T extends BaseParticipant>(
     if (reporter && !logBuffer.isEmpty()) {
       await reporter
         .uploadArtifact({ kind: 'coordinator.log', contentType: 'text/plain', name: 'worker.log', body: logBuffer.toText() })
+        .catch(() => {});
+    }
+    const collector = metricsCollectors.get(participant.name);
+    collector?.stop();
+    const samples = metricsSamples.get(participant.name);
+    if (reporter && samples && samples.length > 0) {
+      await reporter
+        .uploadArtifact({
+          kind: 'system-metrics',
+          contentType: 'application/x-ndjson',
+          name: 'metrics.jsonl',
+          body: samples.map((sample) => JSON.stringify(sample)).join('\n') + '\n',
+        })
         .catch(() => {});
     }
     await reporter?.finish(failed.get(participant.name) ?? false);

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -932,6 +932,11 @@ async function runGroupedByRound<T extends BaseParticipant>(
   // this process, so the metrics belong to the run, not to any one of them).
   if (metricsCollector) metricsSamples.push(metricsCollector.sample());
   metricsCollector?.stop();
+  // The SDK only has a worker-scoped artifact API, so this single artifact is
+  // necessarily filed under one reporter's worker. Tag it as process-scoped
+  // with the full participant list so consumers don't mistake it for that one
+  // participant's isolated usage — the metrics cover every participant that ran
+  // in this shared process, not just the reporter it happened to upload through.
   const metricsReporter = available.map((p) => reporters.get(p.name)).find((r): r is BenchmarkReporter => Boolean(r));
   if (metricsReporter && metricsSamples.length > 0) {
     await metricsReporter
@@ -939,6 +944,7 @@ async function runGroupedByRound<T extends BaseParticipant>(
         kind: 'system-metrics',
         contentType: 'application/x-ndjson',
         name: 'metrics.jsonl',
+        metadata: { scope: 'shared-process', participants: available.map((p) => p.name) },
         body: metricsSamples.map((sample) => JSON.stringify(sample)).join('\n') + '\n',
       })
       .catch(() => {});

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -826,12 +826,17 @@ async function runGroupedByRound<T extends BaseParticipant>(
   const logBuffers = new Map<string, LogBuffer>();
   const failed = new Map<string, boolean>();
   const recordsByParticipant = new Map<string, TaskResultRecord[]>();
-  // One collector per participant, scoped the same way `runWorker` scopes its
-  // own (a fresh baseline at the start of that participant's execution slice),
-  // even though every participant shares this one Node process here. Created
-  // only when there's a reporter to upload to — nothing else would read it.
-  const metricsCollectors = new Map<string, BenchmarkSystemMetricsCollector>();
-  const metricsSamples = new Map<string, BenchmarkSystemMetricsSample[]>();
+  // A single collector for the whole run: round mode interleaves every
+  // participant in this one shared Node process, so per-participant CPU/memory
+  // can't be isolated — a sample reflects the whole process, not one slice of
+  // it. We therefore sample once per round (not once per participant) and
+  // upload a single `system-metrics` artifact, rather than N duplicates that
+  // would falsely imply isolated per-participant usage. (Separate artifacts
+  // only make sense when workers genuinely run on separate VMs, one per
+  // participant, as the client `runWorker` path does.) Created only when at
+  // least one participant has a reporter to upload to — nothing else reads it.
+  let metricsCollector: BenchmarkSystemMetricsCollector | undefined;
+  const metricsSamples: BenchmarkSystemMetricsSample[] = [];
 
   for (const participant of available) {
     logBuffers.set(participant.name, new LogBuffer());
@@ -866,9 +871,12 @@ async function runGroupedByRound<T extends BaseParticipant>(
       console.warn(`  ${participant.name}: could not claim a platform worker — running without platform reporting.`);
     }
     reporters.set(participant.name, reporter);
-    if (reporter) {
-      metricsCollectors.set(participant.name, createSystemMetricsCollector());
-      metricsSamples.set(participant.name, [metricsCollectors.get(participant.name)!.sample()]);
+    // First reporter to appear starts the one shared collector, with an
+    // immediate baseline sample so a run that finishes inside one round still
+    // uploads metrics.
+    if (reporter && !metricsCollector) {
+      metricsCollector = createSystemMetricsCollector();
+      metricsSamples.push(metricsCollector.sample());
     }
   }
 
@@ -909,13 +917,31 @@ async function runGroupedByRound<T extends BaseParticipant>(
           total: schedule.length,
         });
         await reporter.heartbeat();
-        // Sampled once per round rather than on a wall-clock timer: round mode
-        // runs everything sequentially in this one loop, so a round boundary
-        // is the natural, already-existing cadence (same one heartbeat uses).
-        const collector = metricsCollectors.get(participant.name);
-        if (collector) metricsSamples.get(participant.name)!.push(collector.sample());
       }
     }
+    // Sampled once per round rather than on a wall-clock timer: round mode runs
+    // everything sequentially in this one loop, so a round boundary is the
+    // natural, already-existing cadence. Taken after the whole round (not per
+    // participant) since the sample covers the shared process, not one slice.
+    if (metricsCollector) metricsSamples.push(metricsCollector.sample());
+  }
+
+  // One shared collector for the whole process — a final sample (before stop,
+  // which disables the event-loop monitor), then upload a single
+  // `system-metrics` artifact via any one reporter (all participants ran in
+  // this process, so the metrics belong to the run, not to any one of them).
+  if (metricsCollector) metricsSamples.push(metricsCollector.sample());
+  metricsCollector?.stop();
+  const metricsReporter = available.map((p) => reporters.get(p.name)).find((r): r is BenchmarkReporter => Boolean(r));
+  if (metricsReporter && metricsSamples.length > 0) {
+    await metricsReporter
+      .uploadArtifact({
+        kind: 'system-metrics',
+        contentType: 'application/x-ndjson',
+        name: 'metrics.jsonl',
+        body: metricsSamples.map((sample) => JSON.stringify(sample)).join('\n') + '\n',
+      })
+      .catch(() => {});
   }
 
   for (const participant of available) {
@@ -924,19 +950,6 @@ async function runGroupedByRound<T extends BaseParticipant>(
     if (reporter && !logBuffer.isEmpty()) {
       await reporter
         .uploadArtifact({ kind: 'coordinator.log', contentType: 'text/plain', name: 'worker.log', body: logBuffer.toText() })
-        .catch(() => {});
-    }
-    const collector = metricsCollectors.get(participant.name);
-    collector?.stop();
-    const samples = metricsSamples.get(participant.name);
-    if (reporter && samples && samples.length > 0) {
-      await reporter
-        .uploadArtifact({
-          kind: 'system-metrics',
-          contentType: 'application/x-ndjson',
-          name: 'metrics.jsonl',
-          body: samples.map((sample) => JSON.stringify(sample)).join('\n') + '\n',
-        })
         .catch(() => {});
     }
     await reporter?.finish(failed.get(participant.name) ?? false);

--- a/packages/benchsdk-worker/src/metrics.ts
+++ b/packages/benchsdk-worker/src/metrics.ts
@@ -19,6 +19,19 @@ export interface BenchmarkSystemMetricsSample {
   loadavg15m: number;
   openFds: number | null;
   sockstat: Record<string, number> | null;
+  /** Whole-VM memory from /proc/meminfo — not this process's slice of it. Null off Linux. */
+  hostMemTotalMb: number | null;
+  hostMemAvailableMb: number | null;
+  /**
+   * Whole-VM CPU time from /proc/stat, cumulative since the collector started
+   * (same convention as cpuUserUs/cpuSystemUs). usedUs excludes idle/iowait;
+   * usedUs / totalUs is host CPU utilization since collector start.
+   */
+  hostCpuUsedUs: number | null;
+  hostCpuTotalUs: number | null;
+  /** Static for the run — the container/VM's own ceiling, not the host machine's. Null if unlimited or unreadable. */
+  cgroupMemLimitMb: number | null;
+  cgroupCpuLimitCores: number | null;
 }
 
 export interface BenchmarkSystemMetricsCollector {
@@ -54,9 +67,94 @@ function countOpenFds(): number | null {
   }
 }
 
+function readHostMemInfo(): { totalMb: number; availableMb: number } | null {
+  try {
+    const data = fs.readFileSync('/proc/meminfo', 'utf-8');
+    const total = data.match(/^MemTotal:\s+(\d+)\s*kB/m);
+    const available = data.match(/^MemAvailable:\s+(\d+)\s*kB/m);
+    if (!total || !available) return null;
+    return {
+      totalMb: Math.round(Number.parseInt(total[1], 10) / 1024),
+      availableMb: Math.round(Number.parseInt(available[1], 10) / 1024),
+    };
+  } catch {
+    return null;
+  }
+}
+
+// user nice system idle iowait irq softirq steal [guest guest_nice], in jiffies.
+function readHostCpuJiffies(): number[] | null {
+  try {
+    const data = fs.readFileSync('/proc/stat', 'utf-8');
+    const line = data.split('\n').find((l) => l.startsWith('cpu '));
+    if (!line) return null;
+    return line.trim().split(/\s+/).slice(1).map((v) => Number.parseInt(v, 10));
+  } catch {
+    return null;
+  }
+}
+
+// ponytail: hardcoded 100Hz — correct on ~every Linux distro/container, wrong
+// on the rare kernel built with a different CLK_TCK. Upgrade path: shell out
+// to `getconf CLK_TCK` once at collector creation if that ever surfaces.
+const CLK_TCK_HZ = 100;
+const US_PER_JIFFY = 1_000_000 / CLK_TCK_HZ;
+
+/** Elementwise jiffy delta since a baseline snapshot, converted to microseconds. */
+function hostCpuUsageSince(baseline: number[] | null, current: number[] | null): { usedUs: number; totalUs: number } | null {
+  if (!baseline || !current || baseline.length !== current.length) return null;
+  const deltas = current.map((v, i) => v - baseline[i]);
+  const [user, nice, system, , , irq = 0, softirq = 0, steal = 0] = deltas;
+  const usedUs = (user + nice + system + irq + softirq + steal) * US_PER_JIFFY;
+  const totalUs = deltas.reduce((sum, v) => sum + v, 0) * US_PER_JIFFY;
+  return { usedUs: Math.round(usedUs), totalUs: Math.round(totalUs) };
+}
+
+function readCgroupMemLimitMb(): number | null {
+  try {
+    const raw = fs.readFileSync('/sys/fs/cgroup/memory.max', 'utf-8').trim();
+    if (raw === 'max') return null;
+    const bytes = Number.parseInt(raw, 10);
+    return Number.isFinite(bytes) ? Math.round(bytes / 1024 / 1024) : null;
+  } catch {
+    // Not cgroup v2 (or not in a cgroup at all) — fall through to v1.
+  }
+  try {
+    const bytes = Number.parseInt(fs.readFileSync('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf-8').trim(), 10);
+    // v1 has no "unlimited" string; it reports a near-2^63 sentinel instead.
+    if (!Number.isFinite(bytes) || bytes > 1e15) return null;
+    return Math.round(bytes / 1024 / 1024);
+  } catch {
+    return null;
+  }
+}
+
+function readCgroupCpuLimitCores(): number | null {
+  try {
+    const [quotaRaw, periodRaw] = fs.readFileSync('/sys/fs/cgroup/cpu.max', 'utf-8').trim().split(/\s+/);
+    if (quotaRaw === 'max') return null;
+    const quota = Number.parseInt(quotaRaw, 10);
+    const period = Number.parseInt(periodRaw, 10);
+    return Number.isFinite(quota) && period > 0 ? quota / period : null;
+  } catch {
+    // Not cgroup v2 (or not in a cgroup at all) — fall through to v1.
+  }
+  try {
+    const quota = Number.parseInt(fs.readFileSync('/sys/fs/cgroup/cpu/cpu.cfs_quota_us', 'utf-8').trim(), 10);
+    if (!Number.isFinite(quota) || quota <= 0) return null;
+    const period = Number.parseInt(fs.readFileSync('/sys/fs/cgroup/cpu/cpu.cfs_period_us', 'utf-8').trim(), 10);
+    return period > 0 ? quota / period : null;
+  } catch {
+    return null;
+  }
+}
+
 export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector {
   const startedAt = Date.now();
   const cpuBaseline = process.cpuUsage();
+  const hostCpuBaseline = readHostCpuJiffies();
+  const cgroupMemLimitMb = readCgroupMemLimitMb();
+  const cgroupCpuLimitCores = readCgroupCpuLimitCores();
   const eventLoop = monitorEventLoopDelay({ resolution: 20 });
   eventLoop.enable();
 
@@ -65,6 +163,8 @@ export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector 
       const cpu = process.cpuUsage(cpuBaseline);
       const memory = process.memoryUsage();
       const loadavg = os.loadavg();
+      const hostMem = readHostMemInfo();
+      const hostCpu = hostCpuUsageSince(hostCpuBaseline, readHostCpuJiffies());
       const sample: BenchmarkSystemMetricsSample = {
         ts: new Date().toISOString(),
         uptimeMs: Date.now() - startedAt,
@@ -82,6 +182,12 @@ export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector 
         loadavg15m: loadavg[2],
         openFds: countOpenFds(),
         sockstat: readSockstat(),
+        hostMemTotalMb: hostMem?.totalMb ?? null,
+        hostMemAvailableMb: hostMem?.availableMb ?? null,
+        hostCpuUsedUs: hostCpu?.usedUs ?? null,
+        hostCpuTotalUs: hostCpu?.totalUs ?? null,
+        cgroupMemLimitMb,
+        cgroupCpuLimitCores,
       };
       eventLoop.reset();
       return sample;

--- a/packages/benchsdk-worker/src/metrics.ts
+++ b/packages/benchsdk-worker/src/metrics.ts
@@ -110,43 +110,114 @@ function hostCpuUsageSince(baseline: number[] | null, current: number[] | null):
   return { usedUs: Math.round(usedUs), totalUs: Math.round(totalUs) };
 }
 
+// The process's own control files aren't always at the cgroup fs root: under a
+// nested cgroup (no namespacing) they live at `<root>/<relative>/...`. Parse
+// the relative path per controller from /proc/self/cgroup, defaulting to the
+// root so hosts that *do* namespace the cgroup (relative path "/") still work.
+// A limit set on any ancestor also constrains us, so callers walk up the tree
+// and take the tightest — reading only the leaf would miss a parent's ceiling.
+function cgroupRelativePaths(): { v2: string; controllers: Map<string, string> } {
+  const controllers = new Map<string, string>();
+  let v2 = '';
+  try {
+    const data = fs.readFileSync('/proc/self/cgroup', 'utf-8');
+    for (const line of data.split('\n')) {
+      // Format: hierarchy-id:controller-list:relative-path
+      const idx = line.indexOf(':');
+      if (idx < 0) continue;
+      const rest = line.slice(idx + 1);
+      const sep = rest.indexOf(':');
+      if (sep < 0) continue;
+      const controllerList = rest.slice(0, sep);
+      const relPath = rest.slice(sep + 1);
+      if (controllerList === '') {
+        // The cgroup v2 unified hierarchy (empty controller field).
+        v2 = relPath;
+      } else {
+        for (const c of controllerList.split(',')) controllers.set(c, relPath);
+      }
+    }
+  } catch {
+    // No /proc/self/cgroup (non-Linux) — fall back to the fs root for everything.
+  }
+  return { v2, controllers };
+}
+
+// Every directory from the process's own cgroup up to (and including) the fs
+// root. The effective limit is the tightest set anywhere along this ancestry,
+// so callers read each level and take the minimum; order doesn't matter.
+function cgroupDirsToRoot(mountRoot: string, relPath: string): string[] {
+  const dirs: string[] = [mountRoot];
+  let current = mountRoot;
+  for (const seg of relPath.split('/').filter((s) => s.length > 0)) {
+    current = `${current}/${seg}`;
+    dirs.push(current);
+  }
+  return dirs;
+}
+
+// The tightest (minimum) of a and b, treating null as "no limit at this level".
+function tighter(a: number | null, b: number | null): number | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return Math.min(a, b);
+}
+
 function readCgroupMemLimitMb(): number | null {
-  try {
-    const raw = fs.readFileSync('/sys/fs/cgroup/memory.max', 'utf-8').trim();
-    if (raw === 'max') return null;
-    const bytes = Number.parseInt(raw, 10);
-    return Number.isFinite(bytes) ? Math.round(bytes / 1024 / 1024) : null;
-  } catch {
-    // Not cgroup v2 (or not in a cgroup at all) — fall through to v1.
+  const { v2, controllers } = cgroupRelativePaths();
+  let limit: number | null = null;
+  for (const dir of cgroupDirsToRoot('/sys/fs/cgroup', v2)) {
+    try {
+      const raw = fs.readFileSync(`${dir}/memory.max`, 'utf-8').trim();
+      if (raw === 'max') continue; // unlimited here — an ancestor may still cap us.
+      const bytes = Number.parseInt(raw, 10);
+      if (Number.isFinite(bytes)) limit = tighter(limit, Math.round(bytes / 1024 / 1024));
+    } catch {
+      // No memory.max at this level — try the next ancestor, then fall to v1.
+    }
   }
-  try {
-    const bytes = Number.parseInt(fs.readFileSync('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf-8').trim(), 10);
-    // v1 has no "unlimited" string; it reports a near-2^63 sentinel instead.
-    if (!Number.isFinite(bytes) || bytes > 1e15) return null;
-    return Math.round(bytes / 1024 / 1024);
-  } catch {
-    return null;
+  if (limit !== null) return limit;
+  const relPath = controllers.get('memory') ?? '';
+  for (const dir of cgroupDirsToRoot('/sys/fs/cgroup/memory', relPath)) {
+    try {
+      const bytes = Number.parseInt(fs.readFileSync(`${dir}/memory.limit_in_bytes`, 'utf-8').trim(), 10);
+      // v1 has no "unlimited" string; it reports a near-2^63 sentinel instead.
+      if (!Number.isFinite(bytes) || bytes > 1e15) continue;
+      limit = tighter(limit, Math.round(bytes / 1024 / 1024));
+    } catch {
+      // No limit file at this level — keep walking up toward the root.
+    }
   }
+  return limit;
 }
 
 function readCgroupCpuLimitCores(): number | null {
-  try {
-    const [quotaRaw, periodRaw] = fs.readFileSync('/sys/fs/cgroup/cpu.max', 'utf-8').trim().split(/\s+/);
-    if (quotaRaw === 'max') return null;
-    const quota = Number.parseInt(quotaRaw, 10);
-    const period = Number.parseInt(periodRaw, 10);
-    return Number.isFinite(quota) && period > 0 ? quota / period : null;
-  } catch {
-    // Not cgroup v2 (or not in a cgroup at all) — fall through to v1.
+  const { v2, controllers } = cgroupRelativePaths();
+  let limit: number | null = null;
+  for (const dir of cgroupDirsToRoot('/sys/fs/cgroup', v2)) {
+    try {
+      const [quotaRaw, periodRaw] = fs.readFileSync(`${dir}/cpu.max`, 'utf-8').trim().split(/\s+/);
+      if (quotaRaw === 'max') continue; // unlimited here — an ancestor may still cap us.
+      const quota = Number.parseInt(quotaRaw, 10);
+      const period = Number.parseInt(periodRaw, 10);
+      if (Number.isFinite(quota) && period > 0) limit = tighter(limit, quota / period);
+    } catch {
+      // No cpu.max at this level — try the next ancestor, then fall to v1.
+    }
   }
-  try {
-    const quota = Number.parseInt(fs.readFileSync('/sys/fs/cgroup/cpu/cpu.cfs_quota_us', 'utf-8').trim(), 10);
-    if (!Number.isFinite(quota) || quota <= 0) return null;
-    const period = Number.parseInt(fs.readFileSync('/sys/fs/cgroup/cpu/cpu.cfs_period_us', 'utf-8').trim(), 10);
-    return period > 0 ? quota / period : null;
-  } catch {
-    return null;
+  if (limit !== null) return limit;
+  const relPath = controllers.get('cpu') ?? '';
+  for (const dir of cgroupDirsToRoot('/sys/fs/cgroup/cpu', relPath)) {
+    try {
+      const quota = Number.parseInt(fs.readFileSync(`${dir}/cpu.cfs_quota_us`, 'utf-8').trim(), 10);
+      if (!Number.isFinite(quota) || quota <= 0) continue; // -1 == unlimited here.
+      const period = Number.parseInt(fs.readFileSync(`${dir}/cpu.cfs_period_us`, 'utf-8').trim(), 10);
+      if (period > 0) limit = tighter(limit, quota / period);
+    } catch {
+      // No quota file at this level — keep walking up toward the root.
+    }
   }
+  return limit;
 }
 
 export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector {

--- a/packages/benchsdk-worker/src/metrics.ts
+++ b/packages/benchsdk-worker/src/metrics.ts
@@ -146,6 +146,13 @@ function cgroupRelativePaths(): { v2: string; controllers: Map<string, string> }
 // Every directory from the process's own cgroup up to (and including) the fs
 // root. The effective limit is the tightest set anywhere along this ancestry,
 // so callers read each level and take the minimum; order doesn't matter.
+//
+// Known limitation: callers pass the conventional mount points (`/sys/fs/cgroup`
+// for v2, `/sys/fs/cgroup/<controller>` for v1) rather than discovering them
+// from /proc/self/mountinfo. Relocated, co-mounted, or subtree-mounted
+// controllers therefore read as null (unknown) — a safe degrade, never a wrong
+// number. Parsing mountinfo would generalize this but risks resolving the wrong
+// directory on a parse slip, so it's intentionally left out.
 function cgroupDirsToRoot(mountRoot: string, relPath: string): string[] {
   const dirs: string[] = [mountRoot];
   let current = mountRoot;

--- a/packages/benchsdk-worker/src/worker.ts
+++ b/packages/benchsdk-worker/src/worker.ts
@@ -154,7 +154,6 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
   if (options.metricsIntervalMs !== undefined && (!Number.isInteger(options.metricsIntervalMs) || options.metricsIntervalMs < 0)) {
     throw new Error('Benchmark metricsIntervalMs must be a non-negative integer.');
   }
-  }
 
   const logLevel: BenchmarkLogLevel = options.logLevel ?? parseLogLevel(
     typeof process !== 'undefined' ? process.env.BENCHMARK_LOG_LEVEL : undefined,

--- a/packages/benchsdk-worker/src/worker.ts
+++ b/packages/benchsdk-worker/src/worker.ts
@@ -578,6 +578,7 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
     if (logFlush) clearInterval(logFlush);
     await uploadWorkerLogArtifact(true);
     if (metricsInterval) clearInterval(metricsInterval);
+    if (systemMetricsCollector) systemMetricsSamples.push(systemMetricsCollector.sample());
     systemMetricsCollector?.stop();
     await uploadSystemMetricsArtifact();
     clearInterval(heartbeat);

--- a/packages/benchsdk-worker/src/worker.ts
+++ b/packages/benchsdk-worker/src/worker.ts
@@ -151,8 +151,9 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
   if (options.logFlushIntervalMs !== undefined && options.logFlushIntervalMs < 0) {
     throw new Error('Benchmark logFlushIntervalMs must be a non-negative integer.');
   }
-  if (options.metricsIntervalMs !== undefined && options.metricsIntervalMs < 0) {
+  if (options.metricsIntervalMs !== undefined && (!Number.isInteger(options.metricsIntervalMs) || options.metricsIntervalMs < 0)) {
     throw new Error('Benchmark metricsIntervalMs must be a non-negative integer.');
+  }
   }
 
   const logLevel: BenchmarkLogLevel = options.logLevel ?? parseLogLevel(

--- a/packages/benchsdk-worker/src/worker.ts
+++ b/packages/benchsdk-worker/src/worker.ts
@@ -2,6 +2,8 @@ import { gzip as gzipCallback } from 'node:zlib';
 import { promisify } from 'node:util';
 
 const gzip = promisify(gzipCallback);
+import { createSystemMetricsCollector } from './metrics.js';
+import type { BenchmarkSystemMetricsSample } from './metrics.js';
 import type {
   BenchmarkClient,
   BenchmarkAssignment,
@@ -26,6 +28,10 @@ const DEFAULT_READY_POLL_INTERVAL_MS = 1000;
 const DEFAULT_LOG_LEVEL: BenchmarkLogLevel = 'info';
 const DEFAULT_LOG_FLUSH_INTERVAL_MS = 0;
 const DEFAULT_MAX_LOG_LINES = 100_000;
+// On by default (unlike log flushing): this is the worker's only source of
+// system metrics, so leaving it opt-in would silently reproduce the gap
+// where no benchmark on this path collected any resource data at all.
+const DEFAULT_METRICS_INTERVAL_MS = 30_000;
 const MAX_TASK_RESULT_RECORDS = 5000;
 const MAX_TASK_RECORD_STEPS = 100;
 const MAX_HEARTBEAT_CONCURRENCY_SAMPLES = 20;
@@ -145,6 +151,9 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
   if (options.logFlushIntervalMs !== undefined && options.logFlushIntervalMs < 0) {
     throw new Error('Benchmark logFlushIntervalMs must be a non-negative integer.');
   }
+  if (options.metricsIntervalMs !== undefined && options.metricsIntervalMs < 0) {
+    throw new Error('Benchmark metricsIntervalMs must be a non-negative integer.');
+  }
 
   const logLevel: BenchmarkLogLevel = options.logLevel ?? parseLogLevel(
     typeof process !== 'undefined' ? process.env.BENCHMARK_LOG_LEVEL : undefined,
@@ -155,6 +164,11 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
   const logCompression: 'gzip' | false =
     options.logCompression ??
     (typeof process !== 'undefined' && process.env.BENCHMARK_LOG_COMPRESSION === 'gzip' ? 'gzip' : false);
+  // 0 disables, same as logFlushIntervalMs, but the default is on: unlike log
+  // flushing (a mid-run nicety for a stream that uploads in full at the end
+  // regardless), this is the only place samples are ever taken — skipping a
+  // sample at this interval loses it for good.
+  const metricsIntervalMs = options.metricsIntervalMs ?? parseEnvInt('BENCHMARK_METRICS_INTERVAL_MS', DEFAULT_METRICS_INTERVAL_MS);
 
   const assignment = await client.claimWorker(options.benchmarkSlug, options.runId, options.participantSlug, {
     processKind: options.processKind,
@@ -385,8 +399,42 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
       : undefined;
   logFlush?.unref?.();
 
+  // Sampled on an interval and uploaded once as a `system-metrics` artifact
+  // at finish, mirroring how the worker log is buffered and uploaded. Samples
+  // are this worker process's own CPU/memory plus host-wide load average and
+  // socket counts — not the sandbox/VM's total resource usage.
+  const systemMetricsCollector = metricsIntervalMs > 0 ? createSystemMetricsCollector() : undefined;
+  const systemMetricsSamples: BenchmarkSystemMetricsSample[] = [];
+  const metricsInterval =
+    systemMetricsCollector && metricsIntervalMs > 0
+      ? setInterval(() => {
+          systemMetricsSamples.push(systemMetricsCollector.sample());
+        }, metricsIntervalMs)
+      : undefined;
+  metricsInterval?.unref?.();
+
+  async function uploadSystemMetricsArtifact(): Promise<void> {
+    if (systemMetricsSamples.length === 0) return;
+    try {
+      const body = systemMetricsSamples.map((sample) => JSON.stringify(sample)).join('\n') + '\n';
+      await client.uploadWorkerArtifact(options.benchmarkSlug, options.runId, claimed.workerId, {
+        attemptId: claimed.attemptId,
+        kind: 'system-metrics',
+        contentType: 'application/x-ndjson',
+        name: 'metrics.jsonl',
+        body,
+      });
+    } catch {
+      // Metrics upload is best-effort; never fail the run over it.
+    }
+  }
+
   try {
     await sendHeartbeat().catch(() => {});
+    // An immediate baseline sample, same reasoning as the heartbeat above: a
+    // worker that finishes inside one metricsIntervalMs window would
+    // otherwise upload no metrics artifact at all.
+    if (systemMetricsCollector) systemMetricsSamples.push(systemMetricsCollector.sample());
 
     await mapPool(taskIndices, workerConcurrency, async (taskIndex) => {
       inFlightCount += 1;
@@ -528,6 +576,9 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
   } finally {
     if (logFlush) clearInterval(logFlush);
     await uploadWorkerLogArtifact(true);
+    if (metricsInterval) clearInterval(metricsInterval);
+    systemMetricsCollector?.stop();
+    await uploadSystemMetricsArtifact();
     clearInterval(heartbeat);
     clearInterval(resultFlush);
   }

--- a/packages/benchsdk/src/__tests__/public-api.contract.test.ts
+++ b/packages/benchsdk/src/__tests__/public-api.contract.test.ts
@@ -1086,8 +1086,9 @@ describe('runWorker lifecycle and task execution', () => {
     const { calls, fetchMock } = recordingClient(responder);
     const client = createBenchmarkClient({ baseUrl: BASE, apiKey: 'k', fetch: fetchMock });
     // metricsIntervalMs left at its default (30000, on by default) — the task
-    // finishes well inside that window, so only the immediate baseline
-    // sample (taken alongside the first heartbeat) should be uploaded.
+    // finishes well inside that window, so no interval sample fires. The
+    // baseline (taken alongside the first heartbeat) and the final sample (in
+    // the finish path) are still captured, so the artifact is never empty.
     await client.runWorker({
       benchmarkSlug: 'scale', runId: 'run_1', participantSlug: 'e2b',
       task: async () => ({ ok: true }),
@@ -1099,9 +1100,11 @@ describe('runWorker lifecycle and task execution', () => {
 
     const upload = calls.find((c) => c.url === 'https://upload.test/metrics' && c.method === 'PUT');
     expect(upload).toBeDefined();
-    // A single sample is valid NDJSON *and* valid JSON on its own, so
-    // parseBody's JSON.parse already turned it into an object here.
-    expect(upload!.body).toMatchObject({ loadavg1m: expect.any(Number), memRssMb: expect.any(Number) });
+    // Multiple samples make the body multi-line NDJSON (not a lone JSON object),
+    // so parseBody leaves it as a string here — parse the first line ourselves.
+    const lines = String(upload!.body).trim().split('\n');
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    expect(JSON.parse(lines[0])).toMatchObject({ loadavg1m: expect.any(Number), memRssMb: expect.any(Number) });
   });
 
 });

--- a/packages/benchsdk/src/__tests__/public-api.contract.test.ts
+++ b/packages/benchsdk/src/__tests__/public-api.contract.test.ts
@@ -890,6 +890,7 @@ describe('runWorker lifecycle and task execution', () => {
     await client.runWorker({
       benchmarkSlug: 'scale', runId: 'run_1', participantSlug: 'e2b',
       heartbeatIntervalMs: HEARTBEAT_MS,
+      metricsIntervalMs: 0, // isolates the flush interval; metrics sampling also defaults to 30000ms
       task: async () => ({ ok: true }),
     });
 
@@ -930,6 +931,7 @@ describe('runWorker lifecycle and task execution', () => {
     await client.runWorker({
       benchmarkSlug: 'scale', runId: 'run_1', participantSlug: 'e2b',
       heartbeatIntervalMs: HEARTBEAT_MS,
+      metricsIntervalMs: 0, // isolates the flush interval; metrics sampling also defaults to 30000ms
       task: async () => ({ ok: true }),
     });
 
@@ -996,7 +998,9 @@ describe('runWorker lifecycle and task execution', () => {
     const { calls, fetchMock } = recordingClient(lifecycleResponder({ taskRange: { start: 0, end: 0, count: 1 } }));
     const client = createBenchmarkClient({ baseUrl: BASE, apiKey: 'k', fetch: fetchMock });
     await client.runWorker({ benchmarkSlug: 'scale', runId: 'run_1', participantSlug: 'e2b', task: async () => ({ ok: true }) });
-    expect(calls.at(-1)!.url).toContain('/complete');
+    // Not asserted as the *last* call: the system-metrics upload (on by
+    // default) can land after /complete in the finally block.
+    expect(calls.some((c) => c.url.endsWith('/complete'))).toBe(true);
   });
 
   it('VAL-SDK-057: runs onFinish before completing/failing the worker', async () => {
@@ -1030,6 +1034,7 @@ describe('runWorker lifecycle and task execution', () => {
     const client = createBenchmarkClient({ baseUrl: BASE, apiKey: 'k', fetch: fetchMock });
     await expect(client.runWorker({
       benchmarkSlug: 'scale', runId: 'run_1', participantSlug: 'e2b',
+      metricsIntervalMs: 0, // isolates this to the heartbeat + resultFlush intervals under test
       task: async () => ({ ok: true }),
       onFinish,
     })).rejects.toBeInstanceOf(BenchmarkApiError);
@@ -1066,6 +1071,37 @@ describe('runWorker lifecycle and task execution', () => {
     const record = (calls.find((c) => c.url.endsWith('/events'))!.body as { records: TaskResultRecord[] }).records[0];
     expect(record.steps![0]).toMatchObject({ name: 'boom', status: 'error', errorCode: 'RangeError' });
     expect(record.errorCode).toBe('RangeError');
+  });
+
+  it('VAL-SDK-061: uploads a system-metrics artifact with at least a baseline sample', async () => {
+    const responder = (url: string) => {
+      if (url.endsWith('/workers/claim')) return jsonResponse({ assignment: makeAssignment({ taskRange: { start: 0, end: 0, count: 1 } }) });
+      if (url.endsWith('/events')) return jsonResponse({ accepted: 1 }, 202);
+      if (url.endsWith('/heartbeat')) return jsonResponse(lifecycleResponse());
+      if (url.endsWith('/complete')) return jsonResponse(lifecycleResponse());
+      if (url.endsWith('/workers/worker_1/artifacts')) return jsonResponse({ artifactId: 'artifact_1', uploadUrl: 'https://upload.test/metrics' });
+      if (url === 'https://upload.test/metrics') return new Response(null, { status: 200 });
+      throw new Error(`unexpected request: ${url}`);
+    };
+    const { calls, fetchMock } = recordingClient(responder);
+    const client = createBenchmarkClient({ baseUrl: BASE, apiKey: 'k', fetch: fetchMock });
+    // metricsIntervalMs left at its default (30000, on by default) — the task
+    // finishes well inside that window, so only the immediate baseline
+    // sample (taken alongside the first heartbeat) should be uploaded.
+    await client.runWorker({
+      benchmarkSlug: 'scale', runId: 'run_1', participantSlug: 'e2b',
+      task: async () => ({ ok: true }),
+    });
+
+    const create = calls.find((c) => c.url.endsWith('/workers/worker_1/artifacts') && c.method === 'POST');
+    expect(create).toBeDefined();
+    expect(create!.body).toMatchObject({ kind: 'system-metrics', name: 'metrics.jsonl', contentType: 'application/x-ndjson' });
+
+    const upload = calls.find((c) => c.url === 'https://upload.test/metrics' && c.method === 'PUT');
+    expect(upload).toBeDefined();
+    // A single sample is valid NDJSON *and* valid JSON on its own, so
+    // parseBody's JSON.parse already turned it into an object here.
+    expect(upload!.body).toMatchObject({ loadavg1m: expect.any(Number), memRssMb: expect.any(Number) });
   });
 
 });
@@ -1347,14 +1383,16 @@ describe('createSystemMetricsCollector', () => {
     'ts', 'uptimeMs', 'cpuUserUs', 'cpuSystemUs', 'memRssMb', 'memHeapUsedMb', 'memHeapTotalMb',
     'memExternalMb', 'eventLoopP50Ms', 'eventLoopP99Ms', 'eventLoopMaxMs', 'loadavg1m', 'loadavg5m',
     'loadavg15m', 'openFds', 'sockstat',
+    'hostMemTotalMb', 'hostMemAvailableMb', 'hostCpuUsedUs', 'hostCpuTotalUs',
+    'cgroupMemLimitMb', 'cgroupCpuLimitCores',
   ];
 
-  it('VAL-SDK-086: sample() returns a complete 16-field BenchmarkSystemMetricsSample', () => {
+  it('VAL-SDK-086: sample() returns a complete 22-field BenchmarkSystemMetricsSample', () => {
     const collector = createSystemMetricsCollector();
     const sample = collector.sample();
     collector.stop();
     expect(Object.keys(sample).sort()).toEqual([...SAMPLE_KEYS].sort());
-    expect(Object.keys(sample)).toHaveLength(16);
+    expect(Object.keys(sample)).toHaveLength(22);
     expect(sample.ts).toEqual(expect.any(String));
     expect(sample.memRssMb).toBeGreaterThan(0);
     expect(sample.eventLoopP99Ms).toEqual(expect.any(Number));
@@ -1377,12 +1415,18 @@ describe('createSystemMetricsCollector', () => {
     expect(typeof collector.stop).toBe('function');
   });
 
-  it('VAL-SDK-089: sockstat and openFds gracefully degrade (number|null / object|null)', () => {
+  it('VAL-SDK-089: sockstat, openFds, and the /proc- and cgroup-derived fields gracefully degrade to null off Linux', () => {
     const collector = createSystemMetricsCollector();
     const sample = collector.sample();
     collector.stop();
     expect(sample.openFds === null || typeof sample.openFds === 'number').toBe(true);
     expect(sample.sockstat === null || typeof sample.sockstat === 'object').toBe(true);
+    for (const key of [
+      'hostMemTotalMb', 'hostMemAvailableMb', 'hostCpuUsedUs', 'hostCpuTotalUs',
+      'cgroupMemLimitMb', 'cgroupCpuLimitCores',
+    ] as const) {
+      expect(sample[key] === null || typeof sample[key] === 'number').toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
Add metricsIntervalMs option to runWorker (defaults to 30s, env BENCHMARK_METRICS_INTERVAL_MS). Samples process CPU/memory, event loop lag, load average, socket counts, plus new host-wide /proc/meminfo and /proc/stat metrics and cgroup v1/v2 limits. Uploads as system-metrics artifact at finish.

Extend groupBy round mode to sample once per round and upload metrics alongside coordinator.log. Add baseline sample at claim so fast-finishing workers still capture data.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->