### PR TITLE
chore(changeset): add benchsdk changesets covering auth, CLI, worker logging, metrics, and cleanup

### DIFF
--- a/.changeset/benchsdk-canonical-log-format.md
+++ b/.changeset/benchsdk-canonical-log-format.md
@@ -1,0 +1,5 @@
+---
+"@benchsdk/runner": patch
+---
+
+`bench run` now emits canonical ISO-formatted log lines with `[task N] [level]` prefixes from the runner log buffer.

--- a/.changeset/benchsdk-cli-library.md
+++ b/.changeset/benchsdk-cli-library.md
@@ -1,0 +1,12 @@
+---
+"@benchsdk/cli": minor
+"@benchsdk/api": patch
+"@benchsdk/runner": patch
+---
+
+Introduces the `@benchsdk/cli` package and unifies platform commands under the `bench` binary.
+
+- Adds `@benchsdk/cli`: a reusable library for authenticating against the benchmarks platform and querying benchmarks, runs, results, and artifacts.
+- Implements device-code OAuth login with refresh-token storage in `~/.benchsdk/credentials.json` plus `~/.benchsdk/config.json` for base URL / org / output format defaults.
+- Adds `bench auth`, `bench org`, `bench benchmarks`, `bench runs`, `bench results`, `bench artifacts`, and `bench export` subcommands.
+- Refactors `@benchsdk/runner`'s binary to delegate platform commands to the new CLI library while keeping `bench run <file.bench.ts>` as the benchmark execution path.

--- a/.changeset/benchsdk-package-refactor.md
+++ b/.changeset/benchsdk-package-refactor.md
@@ -1,0 +1,16 @@
+---
+"@benchsdk/api": minor
+"@benchsdk/worker": minor
+"@benchsdk/client": minor
+"@benchsdk/runner": minor
+---
+
+Splits the monolithic benchsdk into focused packages and migrates the runner onto them.
+
+- Adds `@benchsdk/api`: a typed REST API client plus shared platform types (previously internal to `@benchsdk/client`).
+- Adds `@benchsdk/worker`: `runWorker`, `BenchmarkReporter`, system metrics collection, and participant selection.
+- Keeps `@benchsdk/client` as a backwards-compatible umbrella that re-exports the focused packages and exposes `client.runWorker()`.
+- Migrates `@benchsdk/runner` from `@benchsdk/client` to depend directly on `@benchsdk/api` and `@benchsdk/worker`.
+- Introduces declarative `BenchmarkScoringConfig`, `scoringConfigToSpec`, and `validateBenchmarkScoringConfig`; the runner upserts `benchmark.config.scoring` and falls back to the config when `onScore` is omitted.
+- Adds `scoring.groupBy` and `config.dimensions` so task records can be grouped by a dimension key and scored separately.
+- Sends the resolved run config to the platform at run creation.

--- a/.changeset/benchsdk-require-platform-auth.md
+++ b/.changeset/benchsdk-require-platform-auth.md
@@ -1,0 +1,14 @@
+---
+"@benchsdk/api": minor
+"@benchsdk/cli": minor
+"@benchsdk/runner": minor
+"@benchsdk/worker": patch
+---
+
+`createBenchmarkClient` now requires a platform API key or OAuth token. It throws a clear error when neither `apiKey`/`token` is provided nor `BENCHMARKS_PLATFORM_API_KEY`/`BENCHMARKS_PLATFORM_TOKEN` is set, pointing users to create a key at https://platform.computesdk.com in their organization settings.
+
+`@benchsdk/cli` no longer allows commands to proceed without credentials. `resolveAuth` now fails fast with an `AuthError` in every mode, realigns auth precedence so explicit overrides and environment variables take precedence over saved OAuth, and supports saved API keys. It also exports `resolveAuth`, `createApiClient`, `AuthError`, and the `CliAuth` type.
+
+`bench run` uses the shared `resolveAuth` flow and now validates auth before participants, even with `--dry-run` / `--no-ingest` / `BENCHSDK_NO_INGEST=1` (those flags only skip uploading). Round-mode runs now propagate org headers correctly, and dry-run scoring is guarded so it only happens when a real platform run would be submitted.
+
+`BenchmarkReporter.claim` now catches the missing-credential error from `createBenchmarkClient` and returns `null` instead of rejecting, matching its existing "no work available" return contract.

--- a/.changeset/benchsdk-runner-no-ingest.md
+++ b/.changeset/benchsdk-runner-no-ingest.md
@@ -1,0 +1,7 @@
+---
+"@benchsdk/runner": minor
+---
+
+Adds `--no-ingest` / `BENCHSDK_NO_INGEST=1` dry-run mode to `bench run`.
+
+The benchmark executes locally but skips uploading results to the platform, making it possible to run without creating a platform run. Note: platform auth is still required for every `bench run` invocation (see the auth changeset).

--- a/.changeset/benchsdk-sdk-cleanup.md
+++ b/.changeset/benchsdk-sdk-cleanup.md
@@ -1,0 +1,15 @@
+---
+"@benchsdk/api": minor
+"@benchsdk/cli": patch
+"@benchsdk/runner": patch
+"@benchsdk/worker": patch
+"@benchsdk/client": minor
+---
+
+Cleans up the benchsdk public surface and legacy auth fallbacks.
+
+- Removes the legacy `COMPUTESDK_API_KEY` environment fallback from `@benchsdk/api`, `@benchsdk/cli`, and `@benchsdk/runner`; only `BENCHMARKS_PLATFORM_API_KEY` is used.
+- Removes the `COMPUTESDK_ADMIN_API_KEY` concept and related admin-key paths.
+- Tightens CLI flag validation and sanitizes scaffold names in `@benchsdk/runner`.
+- Fixes `TaskError` cross-bundle recognition so error names, codes, and data serialize correctly across the worker boundary.
+- Trims the `@benchsdk/client` umbrella exports to match the focused-package re-exports.

--- a/.changeset/benchsdk-system-metrics.md
+++ b/.changeset/benchsdk-system-metrics.md
@@ -1,0 +1,14 @@
+---
+"@benchsdk/worker": minor
+"@benchsdk/api": minor
+"@benchsdk/runner": minor
+---
+
+Adds system metrics collection to benchmark workers.
+
+- `runWorker` accepts a `metricsIntervalMs` option (default 30s, overridable via `BENCHMARK_METRICS_INTERVAL_MS`) that samples process CPU/memory, event loop lag, load average, socket counts, plus host-wide `/proc/meminfo` and `/proc/stat` metrics and cgroup v1/v2 limits.
+- Captures a baseline sample at worker claim so fast-finishing workers still record data.
+- Rejects invalid metrics sampling intervals.
+- Takes the minimum cgroup limit across ancestor levels.
+- In `groupBy: 'round'` mode, samples once per round and uploads the `system-metrics` artifact alongside the coordinator log.
+- Extends `@benchsdk/api` types to support system metric samples and artifact tagging.

--- a/.changeset/benchsdk-worker-fixes.md
+++ b/.changeset/benchsdk-worker-fixes.md
@@ -1,0 +1,9 @@
+---
+"@benchsdk/worker": patch
+"@benchsdk/runner": patch
+---
+
+Bug fixes for worker and runner result handling.
+
+- `BenchmarkReporter` now fails the worker process when the final result flush cannot send results instead of silently swallowing the error.
+- Tightens `isStepOutcome` in both the worker and runner to avoid misclassifying benchmark result objects, preserving `TaskError` domain data on failure records.

--- a/.changeset/benchsdk-worker-logging.md
+++ b/.changeset/benchsdk-worker-logging.md
@@ -1,0 +1,14 @@
+---
+"@benchsdk/worker": minor
+"@benchsdk/api": minor
+"@benchsdk/runner": patch
+"@benchsdk/client": minor
+---
+
+Improves worker logging, step capture, and artifact handling.
+
+- Adds leveled log output (`debug`, `info`, `warn`, `error`) to `runWorker`.
+- Captures named step output and buffers logs incrementally.
+- Compresses log artifacts with gzip before upload.
+- Adds worker artifact download support in `@benchsdk/api`.
+- Updates `@benchsdk/client` to re-export the new logging types and helpers.


### PR DESCRIPTION
## Summary

Since `@benchsdk/runner` and `@benchsdk/client` were last version-bumped in `709dc3b`, the benchsdk workspace has accumulated substantial user-facing changes that the existing changeset (`scoring-weight-validation.md`) did not cover. This PR adds the missing `.changeset/*.md` files so `pnpm changeset version` correctly bumps all affected packages.

## New changesets

- `benchsdk-require-platform-auth.md` — `bench run` now requires platform authentication (existing).
- `benchsdk-package-refactor.md` — `@benchsdk/api`, `@benchsdk/cli`, `@benchsdk/worker` split from the runner/client; runner migrated to the new packages; scoring configuration and default dimensions updated.
- `benchsdk-sdk-cleanup.md` — `COMPUTESDK_API_KEY` removed, `TaskError` and CLI cleanups, docs updates.
- `benchsdk-cli-library.md` — new `@benchsdk/cli` package with OAuth device-code login and `bench` platform subcommands.
- `benchsdk-runner-no-ingest.md` — `bench run --no-ingest` / `BENCHSDK_NO_INGEST` dry-run mode.
- `benchsdk-worker-logging.md` — leveled logging, step log capture, gzip-compressed artifact upload, and worker artifact downloads.
- `benchsdk-worker-fixes.md` — reporter flush failures now fail the process; `isStepOutcome` tightened to preserve `TaskError` domains.
- `benchsdk-canonical-log-format.md` — canonical ISO-formatted runner log output.
- `benchsdk-system-metrics.md` — worker system metrics collection (CPU, memory, event loop lag, load average, sockets, cgroup limits) and `groupBy: 'round'` integration.

## Result

`pnpm exec changeset status` now reports minor bumps for `@benchsdk/runner`, `@benchsdk/cli`, `@benchsdk/api`, `@benchsdk/worker`, and `@benchsdk/client`.

## What this enables

Once merged, `changeset version` will bump every benchsdk package that has meaningful changes, including first releases for the newly-extracted `@benchsdk/api`, `@benchsdk/cli`, and `@benchsdk/worker` packages, so the release workflow can publish them to npm.

Link to Devin session: https://app.devin.ai/sessions/6808d07a2d0a466f87f8421f571b88e7
Open in Devin Desktop: https://app.devin.ai/desktop/session/6808d07a2d0a466f87f8421f571b88e7?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->