### PR TITLE
chore(deps): bump @computesdk/miosa to ^1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@computesdk/lelantos": "^0.2.3",
     "@computesdk/lightning": "^1.0.3",
     "@computesdk/microsandbox": "^0.1.2",
-    "@computesdk/miosa": "^1.0.3",
+    "@computesdk/miosa": "^1.0.4",
     "@computesdk/modal": "^1.9.5",
     "@computesdk/mosaic": "^0.1.4",
     "@computesdk/namespace": "^1.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       '@computesdk/miosa':
-        specifier: ^1.0.3
-        version: 1.0.3
+        specifier: ^1.0.4
+        version: 1.0.4
       '@computesdk/modal':
         specifier: ^1.9.5
         version: 1.9.5
@@ -806,8 +806,8 @@ packages:
     resolution: {integrity: sha512-UZExZDT9I5KU9nJeuWbVL88/00HM1WKPKnCkFlNCr4K4+/SdsT2aghwVOxyizq+47ufCSjjbtXFEP9+QS1ReBQ==}
     engines: {node: '>=22'}
 
-  '@computesdk/miosa@1.0.3':
-    resolution: {integrity: sha512-htd05N0KOfdesjqnf5UPMj+liUw4RX7IgVUPpEKRG3MZsOvRQbm0pNNH3LZ8OjrgX6jvH6JeLVHtcB7eqfRxpw==}
+  '@computesdk/miosa@1.0.4':
+    resolution: {integrity: sha512-74nFk4+5Wc6px716U6/A0nLqvQcefzWJrccst2BUsp/FRZ+n9HUl7PRTe1aIagF6y9KTJV8YP87RnjaZ5dQdhQ==}
 
   '@computesdk/modal@1.9.5':
     resolution: {integrity: sha512-WTZZwN73htUFrkRTkCEtNofxS4tmYQwzPPYvdQ4MysjLwq2nZP8gYZk6awloV051o/dG1miZDPBnRHfz9gw/vA==}
@@ -6483,7 +6483,7 @@ snapshots:
       computesdk: 4.1.4
       microsandbox: 0.6.12
 
-  '@computesdk/miosa@1.0.3':
+  '@computesdk/miosa@1.0.4':
     dependencies:
       '@computesdk/provider': 2.1.5
       computesdk: 4.1.4


### PR DESCRIPTION
## Summary
Bumps `@computesdk/miosa` from `^1.0.3` to `^1.0.4` to pull in the latest miosa changes. Only `package.json` and `pnpm-lock.yaml` are affected; the provider import in `benchmarks/sandbox/providers.ts` is unchanged.

Link to Devin session: https://app.devin.ai/sessions/92f1561e5b2d452ab383453e0186055b
Open in Devin Desktop: https://app.devin.ai/desktop/session/92f1561e5b2d452ab383453e0186055b?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->