### PR TITLE
feat(benchsdk): add optional display manifest to BenchmarkConfig and upload it on upsert

### DIFF
--- a/.changeset/benchsdk-display-manifest.md
+++ b/.changeset/benchsdk-display-manifest.md
@@ -1,0 +1,12 @@
+---
+"@benchsdk/runner": minor
+"create-bench": patch
+---
+
+Adds an optional `display` manifest to `BenchmarkConfig` and makes `scoring.metrics` unit metadata derive from it.
+
+- `BenchmarkConfig.display` lets authors declare metric labels, units, decimals, ranking direction, step labels, and overview defaults (`defaultMetric`, `defaultLayout`) in the same `*.bench.ts` file that defines the workload.
+- `defineBenchmarkConfig` validates the manifest shape and rejects mismatches, including `display.overview.defaultMetric` that is not declared in `display.metrics`.
+- `scoring.metrics[i].unit` is now optional; `scoringConfigToSpec` resolves each scoring metric's unit from the matching `display.metrics` entry, falling back to the scoring metric's unit or an empty string.
+- The runner uploads `display`/`scoring` into `benchmarks.config` on upsert and includes `scoring` in the run summary payload.
+- `create-bench` now scaffolds a `display` block alongside its `scoring` block.

--- a/benchmarks/ai-gateway/ai-gateway-gemini.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway-gemini.bench.ts
@@ -37,13 +37,29 @@ export const config = defineBenchmarkConfig({
   participants: providers,
   concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
+  display: {
+    description: 'AI gateway cold/warm latency and token throughput.',
+    metrics: [
+      { key: 'coldE2eMs', label: 'Cold end-to-end', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'warmTtftMs', label: 'Warm time to first token', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'outputTokensPerSec', label: 'Output tokens/s', unit: 'tok/s', direction: 'higher-better', decimals: 1 },
+      { key: 'outputTokens', label: 'Output tokens', direction: 'higher-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'dns', label: 'DNS' },
+      { key: 'tcp', label: 'TCP' },
+      { key: 'tls', label: 'TLS' },
+      { key: 'ttfb', label: 'TTFB' },
+      { key: 'ttft', label: 'TTFT' },
+    ],
+    overview: { defaultMetric: 'coldE2eMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'coldE2eMs', unit: 'ms', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
-      { key: 'warmTtftMs', unit: 'ms', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
+      { key: 'coldE2eMs', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
+      { key: 'warmTtftMs', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
       {
         key: 'outputTokensPerSec',
-        unit: 'tokens/sec',
         floor: 5,
         ceiling: 200,
         higherIsBetter: true,

--- a/benchmarks/ai-gateway/ai-gateway-kimi.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway-kimi.bench.ts
@@ -54,13 +54,29 @@ export const config = defineBenchmarkConfig({
   participants: providers,
   concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
+  display: {
+    description: 'AI gateway cold/warm latency and token throughput.',
+    metrics: [
+      { key: 'coldE2eMs', label: 'Cold end-to-end', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'warmTtftMs', label: 'Warm time to first token', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'outputTokensPerSec', label: 'Output tokens/s', unit: 'tok/s', direction: 'higher-better', decimals: 1 },
+      { key: 'outputTokens', label: 'Output tokens', direction: 'higher-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'dns', label: 'DNS' },
+      { key: 'tcp', label: 'TCP' },
+      { key: 'tls', label: 'TLS' },
+      { key: 'ttfb', label: 'TTFB' },
+      { key: 'ttft', label: 'TTFT' },
+    ],
+    overview: { defaultMetric: 'coldE2eMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'coldE2eMs', unit: 'ms', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
-      { key: 'warmTtftMs', unit: 'ms', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
+      { key: 'coldE2eMs', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
+      { key: 'warmTtftMs', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
       {
         key: 'outputTokensPerSec',
-        unit: 'tokens/sec',
         floor: 5,
         ceiling: 200,
         higherIsBetter: true,

--- a/benchmarks/ai-gateway/ai-gateway-openai.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway-openai.bench.ts
@@ -37,13 +37,29 @@ export const config = defineBenchmarkConfig({
   participants: providers,
   concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
+  display: {
+    description: 'AI gateway cold/warm latency and token throughput.',
+    metrics: [
+      { key: 'coldE2eMs', label: 'Cold end-to-end', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'warmTtftMs', label: 'Warm time to first token', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'outputTokensPerSec', label: 'Output tokens/s', unit: 'tok/s', direction: 'higher-better', decimals: 1 },
+      { key: 'outputTokens', label: 'Output tokens', direction: 'higher-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'dns', label: 'DNS' },
+      { key: 'tcp', label: 'TCP' },
+      { key: 'tls', label: 'TLS' },
+      { key: 'ttfb', label: 'TTFB' },
+      { key: 'ttft', label: 'TTFT' },
+    ],
+    overview: { defaultMetric: 'coldE2eMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'coldE2eMs', unit: 'ms', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
-      { key: 'warmTtftMs', unit: 'ms', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
+      { key: 'coldE2eMs', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
+      { key: 'warmTtftMs', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
       {
         key: 'outputTokensPerSec',
-        unit: 'tokens/sec',
         floor: 5,
         ceiling: 200,
         higherIsBetter: true,

--- a/benchmarks/ai-gateway/ai-gateway.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway.bench.ts
@@ -57,13 +57,29 @@ export const config = defineBenchmarkConfig({
   // multiplying runtime by the number of gateways.
   concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
+  display: {
+    description: 'AI gateway cold/warm latency and token throughput.',
+    metrics: [
+      { key: 'coldE2eMs', label: 'Cold end-to-end', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'warmTtftMs', label: 'Warm time to first token', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'outputTokensPerSec', label: 'Output tokens/s', unit: 'tok/s', direction: 'higher-better', decimals: 1 },
+      { key: 'outputTokens', label: 'Output tokens', direction: 'higher-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'dns', label: 'DNS' },
+      { key: 'tcp', label: 'TCP' },
+      { key: 'tls', label: 'TLS' },
+      { key: 'ttfb', label: 'TTFB' },
+      { key: 'ttft', label: 'TTFT' },
+    ],
+    overview: { defaultMetric: 'coldE2eMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'coldE2eMs', unit: 'ms', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
-      { key: 'warmTtftMs', unit: 'ms', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
+      { key: 'coldE2eMs', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
+      { key: 'warmTtftMs', ceiling: 20000, weights: { median: 0.30, p95: 0.15, p99: 0 } },
       {
         key: 'outputTokensPerSec',
-        unit: 'tokens/sec',
         floor: 5,
         ceiling: 200,
         higherIsBetter: true,

--- a/benchmarks/browser/browser-throughput.bench.ts
+++ b/benchmarks/browser/browser-throughput.bench.ts
@@ -35,6 +35,26 @@ export const config = defineBenchmarkConfig({
   iterations: 2,
   groupBy: 'round',
   participants: throughputProviders,
+  display: {
+    description: 'Browser session throughput and action rate.',
+    metrics: [
+      { key: 'actionsPerSecond', label: 'Actions/s', unit: '/s', direction: 'higher-better', decimals: 2 },
+      { key: 'actionsCompleted', label: 'Actions completed', direction: 'higher-better', decimals: 0 },
+      { key: 'taskMs', label: 'Action loop', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'screenshotMs', label: 'Screenshot', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'createMs', label: 'Session creation', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'connectMs', label: 'CDP connection', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'releaseMs', label: 'Session release', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'totalMs', label: 'Total lifecycle', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'create', label: 'Create session' },
+      { key: 'connect', label: 'Connect CDP' },
+      { key: 'actions', label: 'Actions' },
+      { key: 'release', label: 'Release session' },
+    ],
+    overview: { defaultMetric: 'actionsPerSecond', defaultLayout: 'ranking' },
+  },
   scoring: {
     // A session that dropped actions isn't comparable to one that completed
     // them all, so it counts against the success rate and its timings are
@@ -43,14 +63,13 @@ export const config = defineBenchmarkConfig({
     metrics: [
       {
         key: 'actionsPerSecond',
-        unit: 'actions/sec',
         floor: 0,
         ceiling: 10,
         higherIsBetter: true,
         weights: { median: 0.40, p95: 0, p99: 0 },
       },
-      { key: 'taskMs', unit: 'ms', ceiling: 30000, weights: { median: 0.25, p95: 0.20, p99: 0 } },
-      { key: 'screenshotMs', unit: 'ms', ceiling: 30000, weights: { median: 0.15, p95: 0, p99: 0 } },
+      { key: 'taskMs', ceiling: 30000, weights: { median: 0.25, p95: 0.20, p99: 0 } },
+      { key: 'screenshotMs', ceiling: 30000, weights: { median: 0.15, p95: 0, p99: 0 } },
     ],
   },
   onComplete: (outcome) =>

--- a/benchmarks/browser/browser.bench.ts
+++ b/benchmarks/browser/browser.bench.ts
@@ -45,8 +45,8 @@ export const config = defineBenchmarkConfig({
   },
   scoring: {
     metrics: [
-      { key: 'totalMs', unit: 'ms', ceiling: 10000, weights: { median: 0.40, p95: 0.20, p99: 0.10 } },
-      { key: 'createMs', unit: 'ms', ceiling: 10000, weights: { median: 0.30, p95: 0, p99: 0 } },
+      { key: 'totalMs', ceiling: 10000, weights: { median: 0.40, p95: 0.20, p99: 0.10 } },
+      { key: 'createMs', ceiling: 10000, weights: { median: 0.30, p95: 0, p99: 0 } },
     ],
   },
   onComplete: (outcome) =>

--- a/benchmarks/browser/browser.bench.ts
+++ b/benchmarks/browser/browser.bench.ts
@@ -26,6 +26,23 @@ export const config = defineBenchmarkConfig({
   iterations: 2,
   concurrency: 1,
   participants: browserProviders,
+  display: {
+    description: 'Browser create→connect→navigate→release lifecycle latency.',
+    metrics: [
+      { key: 'totalMs', label: 'Total lifecycle', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'createMs', label: 'Session creation', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'connectMs', label: 'CDP connection', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'navigateMs', label: 'Page navigation', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'releaseMs', label: 'Session release', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'create', label: 'Create session' },
+      { key: 'connect', label: 'Connect CDP' },
+      { key: 'navigate', label: 'Navigate page' },
+      { key: 'release', label: 'Release session' },
+    ],
+    overview: { defaultMetric: 'totalMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
       { key: 'totalMs', unit: 'ms', ceiling: 10000, weights: { median: 0.40, p95: 0.20, p99: 0.10 } },

--- a/benchmarks/reliability/sandbox-opencode.bench.ts
+++ b/benchmarks/reliability/sandbox-opencode.bench.ts
@@ -19,6 +19,15 @@ export const config = defineBenchmarkConfig({
   staggerDelayMs: 60_000,
   participants: providers,
   defaultProviders: ['tensorlake'],
+  display: {
+    description: 'Tensorlake OpenCode installation and run reliability.',
+    steps: [
+      { key: 'create', label: 'Create sandbox' },
+      { key: 'install', label: 'Install OpenCode' },
+      { key: 'run', label: 'Run OpenCode' },
+      { key: 'destroy', label: 'Destroy sandbox' },
+    ],
+  },
 });
 
 export const task = defineTask<ProviderConfig>(async (ctx) => {

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -43,6 +43,37 @@ export const config = defineBenchmarkConfig({
   groupBy: 'round',
   defaultProviders: ['e2b', 'modal', 'tensorlake'],
   participants: providers,
+  display: {
+    description: 'OpenCode build lifecycle latency per phase.',
+    metrics: [
+      { key: 'totalMs', label: 'Total build time', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'prepareMs', label: 'Prepare', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'cacheClearMs', label: 'Cache clear', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'bunDownloadMs', label: 'Bun download', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'bunUnpackMs', label: 'Bun unpack', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'cloneMs', label: 'Clone', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'installMs', label: 'Install', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'typecheckMs', label: 'Typecheck', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'phasesCompleted', label: 'Phases completed', direction: 'higher-better', decimals: 0 },
+      { key: 'phasesTotal', label: 'Phases total', direction: 'higher-better', decimals: 0 },
+      { key: 'diskAfterClone', label: 'Disk after clone', unit: 'bytes', direction: 'lower-better', decimals: 0 },
+      { key: 'diskAfterInstall', label: 'Disk after install', unit: 'bytes', direction: 'lower-better', decimals: 0 },
+      { key: 'diskAfterTypecheck', label: 'Disk after typecheck', unit: 'bytes', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'create', label: 'Create sandbox' },
+      { key: 'build', label: 'Build' },
+      { key: 'destroy', label: 'Destroy sandbox' },
+      { key: 'prepare', label: 'Prepare' },
+      { key: 'cache_clear', label: 'Cache clear' },
+      { key: 'bun_download', label: 'Bun download' },
+      { key: 'bun_unpack', label: 'Bun unpack' },
+      { key: 'clone', label: 'Clone' },
+      { key: 'install', label: 'Install' },
+      { key: 'typecheck', label: 'Typecheck' },
+    ],
+    overview: { defaultMetric: 'totalMs', defaultLayout: 'ranking' },
+  },
   onComplete: (outcome) =>
     writeDaxLegacyResults(outcome.participants, {
       resultsDir: path.resolve(__dirname, '../../results/sandbox-dax'),
@@ -222,7 +253,10 @@ function daxPhaseSteps(t: DaxTimingResult): TaskStepRecord[] {
   ];
   return phases
     .filter((entry): entry is [string, number] => typeof entry[1] === 'number')
-    .map(([name, latencyMs]) => ({ name, status: 'success', latencyMs }));
+    .map(([name, latencyMs]) => {
+      const metricKey = name.replace(/_(.)/g, (_, c) => c.toUpperCase()) + 'Ms';
+      return { name, status: 'success', latencyMs, data: { [metricKey]: latencyMs } };
+    });
 }
 
 export const task = defineTask<ProviderConfig>(async (ctx) => {
@@ -241,7 +275,17 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
 
   let timing: DaxTimingResult;
   try {
-    timing = await ctx.step('build', () => runDaxBuild(sandbox, p.name, p.timeout ?? timeout));
+    timing = await ctx.step('build', async () => {
+      const t = await runDaxBuild(sandbox, p.name, p.timeout ?? timeout);
+      const buildMetrics: JsonObject = { totalMs: t.totalMs };
+      if (t.phasesCompleted !== undefined) buildMetrics.phasesCompleted = t.phasesCompleted;
+      if (t.phasesTotal !== undefined) buildMetrics.phasesTotal = t.phasesTotal;
+      if (t.diskAfterClone !== undefined) buildMetrics.diskAfterClone = t.diskAfterClone;
+      if (t.diskAfterInstall !== undefined) buildMetrics.diskAfterInstall = t.diskAfterInstall;
+      if (t.diskAfterTypecheck !== undefined) buildMetrics.diskAfterTypecheck = t.diskAfterTypecheck;
+      ctx.measure(buildMetrics);
+      return t;
+    });
   } finally {
     await ctx
       .step('destroy', () => withTimeout(sandbox.destroy(), p.destroyTimeoutMs ?? destroyTimeoutMs, 'Destroy timeout'), {

--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -39,6 +39,18 @@ export const config = defineBenchmarkConfig({
   iterations: 2,
   concurrency: 1,
   participants: providers,
+  display: {
+    description: 'Sandbox time-to-interactive from create through first successful command.',
+    metrics: [
+      { key: 'ttiMs', label: 'Time to interactive', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'create', label: 'Create sandbox' },
+      { key: 'exec.task', label: 'Run first command' },
+      { key: 'destroy', label: 'Destroy sandbox' },
+    ],
+    overview: { defaultMetric: 'ttiMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
       { key: 'ttiMs', unit: 'ms', ceiling: 10000, weights: { median: 0.60, p95: 0.25, p99: 0.15 } },
@@ -74,6 +86,7 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
     ),
   );
 
+  let ttiMs: number | undefined;
   try {
     const result = await step('exec.task', async () => {
       const r = await withTimeout(
@@ -85,14 +98,20 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
         log('node -v failed', { level: 'error', meta: { exitCode: r.exitCode, stderr: r.stderr ?? null } });
         throw new Error(`Command failed with exit code ${r.exitCode}: ${r.stderr || 'Unknown error'}`);
       }
+      ttiMs = performance.now() - start;
+      measure({ ttiMs });
       return r;
     });
     log('node -v succeeded', { level: 'info', meta: { version: result.stdout?.trim() ?? null, exitCode: result.exitCode } });
-    measure({ ttiMs: performance.now() - start });
   } finally {
     await step('destroy', () =>
       withTimeout(sandbox.destroy(), participant.destroyTimeoutMs ?? DESTROY_TIMEOUT_MS, 'Destroy timeout'),
       { reportConcurrency: false },
     ).catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { error: formatError(err) } }));
   }
+
+  if (ttiMs === undefined) {
+    throw new Error('exec.task did not produce a ttiMs measurement');
+  }
+  return { data: { ttiMs } };
 });

--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -53,7 +53,7 @@ export const config = defineBenchmarkConfig({
   },
   scoring: {
     metrics: [
-      { key: 'ttiMs', unit: 'ms', ceiling: 10000, weights: { median: 0.60, p95: 0.25, p99: 0.15 } },
+      { key: 'ttiMs', ceiling: 10000, weights: { median: 0.60, p95: 0.25, p99: 0.15 } },
     ],
   },
   // Legacy JSON labels a burst run 'concurrent' (see merge-results /

--- a/benchmarks/storage/snapshot-fork.bench.ts
+++ b/benchmarks/storage/snapshot-fork.bench.ts
@@ -55,15 +55,33 @@ export const config = defineBenchmarkConfig({
   participants,
   customCliFlags: ['--dataset'],
   dimensions: { dataset },
+  display: {
+    description: 'Storage snapshot/fork creation and read latency.',
+    metrics: [
+      { key: 'snapshotCreateMs', label: 'Snapshot create', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'forkFromSnapshotMs', label: 'Fork from snapshot', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'forkFromLiveMs', label: 'Fork from live', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'forkFirstReadMs', label: 'Fork first read', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'seedMs', label: 'Seed', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'seed', label: 'Seed' },
+      { key: 'snapshot-create', label: 'Create snapshot' },
+      { key: 'fork-from-snapshot', label: 'Fork from snapshot' },
+      { key: 'fork-from-live', label: 'Fork from live' },
+      { key: 'fork-first-read', label: 'First read' },
+    ],
+    overview: { defaultMetric: 'forkFirstReadMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     // A fork whose read-back didn't match is not a usable fork, so its timings
     // must not be scored as if it were.
     success: { requireData: { verified: true } },
     metrics: [
-      { key: 'snapshotCreateMs', unit: 'ms', ceiling: 60000, weights: { median: 0.40, p95: 0, p99: 0 } },
-      { key: 'forkFromSnapshotMs', unit: 'ms', ceiling: 60000, weights: { median: 0.35, p95: 0, p99: 0 } },
-      { key: 'forkFromLiveMs', unit: 'ms', ceiling: 60000, weights: { median: 0.15, p95: 0, p99: 0 } },
-      { key: 'forkFirstReadMs', unit: 'ms', ceiling: 60000, weights: { median: 0.10, p95: 0, p99: 0 } },
+      { key: 'snapshotCreateMs', ceiling: 60000, weights: { median: 0.40, p95: 0, p99: 0 } },
+      { key: 'forkFromSnapshotMs', ceiling: 60000, weights: { median: 0.35, p95: 0, p99: 0 } },
+      { key: 'forkFromLiveMs', ceiling: 60000, weights: { median: 0.15, p95: 0, p99: 0 } },
+      { key: 'forkFirstReadMs', ceiling: 60000, weights: { median: 0.10, p95: 0, p99: 0 } },
     ],
   },
   onComplete: (outcome) =>

--- a/benchmarks/storage/storage.bench.ts
+++ b/benchmarks/storage/storage.bench.ts
@@ -54,12 +54,27 @@ const baseConfig = {
   concurrency: 1,
   participants: storageProviders,
   customCliFlags: ['--file-size'],
+  display: {
+    description: 'Storage upload/download lifecycle latency and throughput.',
+    metrics: [
+      { key: 'uploadMs', label: 'Upload', unit: 'ms', direction: 'lower-better' as const, decimals: 0 },
+      { key: 'downloadMs', label: 'Download', unit: 'ms', direction: 'lower-better' as const, decimals: 0 },
+      { key: 'throughputMbps', label: 'Throughput', unit: 'Mbps', direction: 'higher-better' as const, decimals: 1 },
+      { key: 'fileSizeBytes', label: 'File size', unit: 'bytes', direction: 'lower-better' as const, decimals: 0 },
+    ],
+    steps: [
+      { key: 'upload', label: 'Upload' },
+      { key: 'download', label: 'Download' },
+      { key: 'delete', label: 'Delete' },
+    ],
+    overview: { defaultMetric: 'downloadMs', defaultLayout: 'ranking' as const },
+  },
   scoring: {
     groupBy: 'file_size',
     metrics: [
-      { key: 'uploadMs', unit: 'ms', ceiling: 30000, weights: { median: 0.25, p95: 0.10, p99: 0.05 } },
-      { key: 'downloadMs', unit: 'ms', ceiling: 30000, weights: { median: 0.35, p95: 0.15, p99: 0.05 } },
-      { key: 'throughputMbps', unit: 'mbps', floor: 1, ceiling: 1000, higherIsBetter: true, weights: { median: 0.05, p95: 0, p99: 0 } },
+      { key: 'uploadMs', ceiling: 30000, weights: { median: 0.25, p95: 0.10, p99: 0.05 } },
+      { key: 'downloadMs', ceiling: 30000, weights: { median: 0.35, p95: 0.15, p99: 0.05 } },
+      { key: 'throughputMbps', floor: 1, ceiling: 1000, higherIsBetter: true, weights: { median: 0.05, p95: 0, p99: 0 } },
     ],
   },
 };

--- a/examples/01-hello.bench.ts
+++ b/examples/01-hello.bench.ts
@@ -19,9 +19,19 @@ export const config = defineBenchmarkConfig({
   iterations: 10,
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [] }],
+  display: {
+    description: 'Minimal one-step, one-metric benchmark.',
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'work', label: 'Work' },
+    ],
+    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'durationMs', unit: 'ms', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
+      { key: 'durationMs', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
     ],
   },
 });

--- a/examples/02-shapes.bench.ts
+++ b/examples/02-shapes.bench.ts
@@ -27,9 +27,19 @@ export const config = defineBenchmarkConfig({
     burst: { slug: 'shape-demo-burst', name: 'Shape Demo (Burst)' },
     staggered: { slug: 'shape-demo-staggered', name: 'Shape Demo (Staggered)', staggerDelayMs: 200 },
   },
+  display: {
+    description: 'Workload shape variants (sequential, burst, staggered).',
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'work', label: 'Work' },
+    ],
+    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'durationMs', unit: 'ms', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
+      { key: 'durationMs', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
     ],
   },
 });

--- a/examples/03-phases.bench.ts
+++ b/examples/03-phases.bench.ts
@@ -23,9 +23,20 @@ export const config = defineBenchmarkConfig({
   ],
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [], coldDelayMs: 100 }],
+  display: {
+    description: 'Cold vs. warm phase latency.',
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'cold-work', label: 'Cold work' },
+      { key: 'warm-work', label: 'Warm work' },
+    ],
+    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'durationMs', unit: 'ms', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
+      { key: 'durationMs', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
     ],
   },
 });

--- a/examples/04-round-robin.bench.ts
+++ b/examples/04-round-robin.bench.ts
@@ -25,9 +25,19 @@ export const config = defineBenchmarkConfig({
     { name: 'quick', requiredEnvVars: [], workMs: 20 },
     { name: 'slow', requiredEnvVars: [], workMs: 80 },
   ],
+  display: {
+    description: 'Round-robin participant interleaving latency.',
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'work', label: 'Work' },
+    ],
+    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'durationMs', unit: 'ms', ceiling: 500, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
+      { key: 'durationMs', ceiling: 500, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
     ],
   },
 });

--- a/examples/05-scoring.bench.ts
+++ b/examples/05-scoring.bench.ts
@@ -23,6 +23,17 @@ export const config = defineBenchmarkConfig({
   iterations: 10,
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [], payloadBytes: 1024 * 1024 }],
+  display: {
+    description: 'Hash duration, throughput, and verification success.',
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'throughputMbps', label: 'Throughput', unit: 'Mbps', direction: 'higher-better', decimals: 1 },
+    ],
+    steps: [
+      { key: 'hash', label: 'Hash payload' },
+    ],
+    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     // Records only count as successful when data.verified === true.
     success: {
@@ -32,14 +43,12 @@ export const config = defineBenchmarkConfig({
       // Duration is 50% of the composite score.
       {
         key: 'durationMs',
-        unit: 'ms',
         ceiling: 1000,
         weights: { median: 0.35, p95: 0.1, p99: 0.05 },
       },
       // Throughput is also 50% of the composite score.
       {
         key: 'throughputMbps',
-        unit: 'mbps',
         floor: 1,
         ceiling: 500,
         higherIsBetter: true,

--- a/examples/06-custom-flags.bench.ts
+++ b/examples/06-custom-flags.bench.ts
@@ -51,11 +51,21 @@ export const config = defineBenchmarkConfig({
     algorithm,
     payloadBytes,
   },
+  display: {
+    description: 'Custom CLI flags for payload size and hash algorithm.',
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
+      { key: 'hashLength', label: 'Hash length', direction: 'higher-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'hash', label: 'Hash payload' },
+    ],
+    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
       {
         key: 'durationMs',
-        unit: 'ms',
         ceiling: 1000,
         weights: { median: 0.7, p95: 0.2, p99: 0.1 },
       },

--- a/examples/07-error-handling.bench.ts
+++ b/examples/07-error-handling.bench.ts
@@ -21,9 +21,22 @@ export const config = defineBenchmarkConfig({
   iterations: 3,
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [] }],
+  display: {
+    description: 'TaskError, step timeout, and cleanup behavior.',
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'acquire-resource', label: 'Acquire resource' },
+      { key: 'risky', label: 'Risky step' },
+      { key: 'work', label: 'Work' },
+      { key: 'cleanup', label: 'Cleanup' },
+    ],
+    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'durationMs', unit: 'ms', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
+      { key: 'durationMs', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
     ],
   },
 });

--- a/examples/08-env-gated.bench.ts
+++ b/examples/08-env-gated.bench.ts
@@ -27,9 +27,20 @@ export const config = defineBenchmarkConfig({
     { name: 'local', requiredEnvVars: [] },
     { name: 'remote', requiredEnvVars: ['DEMO_API_KEY'] },
   ],
+  display: {
+    description: 'Env-gated local vs. remote participant latency.',
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'remote-auth', label: 'Remote auth' },
+      { key: 'local-work', label: 'Local work' },
+    ],
+    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'durationMs', unit: 'ms', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
+      { key: 'durationMs', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
     ],
   },
 });

--- a/examples/09-on-complete.bench.ts
+++ b/examples/09-on-complete.bench.ts
@@ -22,12 +22,21 @@ export const config = defineBenchmarkConfig({
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [] }],
   dimensions: { workload: 'sort' },
+  display: {
+    description: 'Custom onScore and onComplete demo for sorting workload.',
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'sort', label: 'Sort' },
+    ],
+    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+  },
   onScore: (lowerIsBetter) => ({
     dimensions: { workload: 'sort' },
     success: (record) => record.status === 'success' && (record.data as { sorted?: boolean }).sorted === true,
     metrics: [
       lowerIsBetter('durationMs', {
-        unit: 'ms',
         ceiling: 500,
         value: (record) => (record.data as { durationMs?: number }).durationMs ?? 0,
         weights: { median: 0.7, p95: 0.2, p99: 0.1 },

--- a/examples/10-shared-run.bench.ts
+++ b/examples/10-shared-run.bench.ts
@@ -27,9 +27,19 @@ export const config = defineBenchmarkConfig({
     { name: 'alpha', requiredEnvVars: [], workMs: 20 },
     { name: 'beta', requiredEnvVars: [], workMs: 40 },
   ],
+  display: {
+    description: 'Shared run key across multiple CI jobs.',
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'work', label: 'Work' },
+    ],
+    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'durationMs', unit: 'ms', ceiling: 500, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
+      { key: 'durationMs', ceiling: 500, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
     ],
   },
 });

--- a/examples/11-logging.bench.ts
+++ b/examples/11-logging.bench.ts
@@ -29,9 +29,22 @@ export const config = defineBenchmarkConfig({
   iterations: 3,
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [] }],
+  display: {
+    description: 'Structured logging and step output capture.',
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
+    ],
+    steps: [
+      { key: 'work', label: 'Work' },
+      { key: 'node-version', label: 'Node version' },
+      { key: 'safe-node-version', label: 'Safe node version' },
+      { key: 'parse-version', label: 'Parse version' },
+    ],
+    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+  },
   scoring: {
     metrics: [
-      { key: 'durationMs', unit: 'ms', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
+      { key: 'durationMs', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
     ],
   },
 });

--- a/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
@@ -126,6 +126,28 @@ describe('defineBenchmarkConfig', () => {
     expect(config.display?.metrics?.[0].key).toBe('throughputMbps');
   });
 
+  it('rejects a non-string display description', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: { description: 123 as any },
+      }),
+    ).toThrow('display.description must be a string');
+  });
+
+  it('rejects a non-string display metric unit', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: { metrics: [{ key: 'x', label: 'X', unit: 123 as any }] },
+      }),
+    ).toThrow('display.metrics[0].unit must be a string');
+  });
+
   it('rejects an invalid display direction', () => {
     expect(() =>
       defineBenchmarkConfig({

--- a/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
@@ -152,6 +152,62 @@ describe('defineBenchmarkConfig', () => {
       }),
     ).toThrow('duplicate');
   });
+
+  it('rejects an empty or non-string display defaultMetric', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: { overview: { defaultMetric: '' } },
+      }),
+    ).toThrow('display.overview.defaultMetric');
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: { overview: { defaultMetric: 123 as any } },
+      }),
+    ).toThrow('display.overview.defaultMetric');
+  });
+
+  it('rejects a display defaultMetric not declared in metrics', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: {
+          metrics: [{ key: 'x', label: 'X' }],
+          overview: { defaultMetric: 'y' },
+        },
+      }),
+    ).toThrow("'y' is not declared in display.metrics");
+  });
+
+  it('accepts a display defaultMetric that matches a declared metric key', () => {
+    const config = defineBenchmarkConfig({
+      benchmarkSlug: 's',
+      benchmarkName: 'n',
+      participants,
+      display: {
+        metrics: [{ key: 'x', label: 'X' }],
+        overview: { defaultMetric: 'x' },
+      },
+    });
+    expect(config.display?.overview?.defaultMetric).toBe('x');
+  });
+
+  it('allows a display defaultMetric when metrics is omitted', () => {
+    const config = defineBenchmarkConfig({
+      benchmarkSlug: 's',
+      benchmarkName: 'n',
+      participants,
+      display: { overview: { defaultMetric: 'anything' } },
+    });
+    expect(config.display?.overview?.defaultMetric).toBe('anything');
+  });
 });
 
 describe('defineTask', () => {

--- a/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
@@ -199,6 +199,37 @@ describe('defineBenchmarkConfig', () => {
     expect(config.display?.overview?.defaultMetric).toBe('x');
   });
 
+  it('accepts scoring without unit when display.metrics declares it', () => {
+    const config = defineBenchmarkConfig({
+      benchmarkSlug: 's',
+      benchmarkName: 'n',
+      participants,
+      display: {
+        metrics: [{ key: 'ttiMs', label: 'Time to interactive', unit: 'ms' }],
+      },
+      scoring: {
+        metrics: [{ key: 'ttiMs', ceiling: 10000, weights: { median: 1, p95: 0, p99: 0 } }],
+      },
+    });
+    expect(config.scoring?.metrics[0].unit).toBeUndefined();
+  });
+
+  it('rejects a scoring unit that conflicts with display.metrics', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: {
+          metrics: [{ key: 'ttiMs', label: 'Time to interactive', unit: 'ms' }],
+        },
+        scoring: {
+          metrics: [{ key: 'ttiMs', unit: 's', ceiling: 10000, weights: { median: 1, p95: 0, p99: 0 } }],
+        },
+      }),
+    ).toThrow("scoring.metrics[0].unit 's' conflicts with display.metrics[0].unit 'ms'");
+  });
+
   it('allows a display defaultMetric when metrics is omitted', () => {
     const config = defineBenchmarkConfig({
       benchmarkSlug: 's',

--- a/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
@@ -109,6 +109,49 @@ describe('defineBenchmarkConfig', () => {
       defineBenchmarkConfig({ benchmarkSlug: 's', benchmarkName: 'n', participants, shapes: { s: { slug: 'ok', staggerDelayMs: -1 } } }),
     ).toThrow('staggerDelayMs');
   });
+
+  it('carries a display manifest when valid', () => {
+    const config = defineBenchmarkConfig({
+      benchmarkSlug: 's',
+      benchmarkName: 'n',
+      participants,
+      display: {
+        description: 'A test benchmark',
+        metrics: [{ key: 'throughputMbps', label: 'Throughput', unit: 'Mbps', direction: 'higher-better' }],
+        steps: [{ key: 'create', label: 'Create sandbox' }],
+        overview: { defaultMetric: 'throughputMbps', defaultLayout: 'ranking' },
+      },
+    });
+    expect(config.display?.overview?.defaultLayout).toBe('ranking');
+    expect(config.display?.metrics?.[0].key).toBe('throughputMbps');
+  });
+
+  it('rejects an invalid display direction', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: { metrics: [{ key: 'x', label: 'X', direction: 'up' as any }] },
+      }),
+    ).toThrow('direction');
+  });
+
+  it('rejects duplicate display metric keys', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: {
+          metrics: [
+            { key: 'x', label: 'X' },
+            { key: 'x', label: 'X2' },
+          ],
+        },
+      }),
+    ).toThrow('duplicate');
+  });
 });
 
 describe('defineTask', () => {

--- a/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
@@ -230,6 +230,21 @@ describe('defineBenchmarkConfig', () => {
     ).toThrow("scoring.metrics[0].unit 's' conflicts with display.metrics[0].unit 'ms'");
   });
 
+  it('does not throw a TypeError when display.metrics is malformed', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        // @ts-expect-error intentionally malformed
+        display: { metrics: 'not-an-array' },
+        scoring: {
+          metrics: [{ key: 'ttiMs', ceiling: 10000, weights: { median: 1, p95: 0, p99: 0 } }],
+        },
+      }),
+    ).toThrow('display.metrics must be an array');
+  });
+
   it('allows a display defaultMetric when metrics is omitted', () => {
     const config = defineBenchmarkConfig({
       benchmarkSlug: 's',

--- a/packages/benchsdk-runner/src/__tests__/scoring.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/scoring.test.ts
@@ -129,6 +129,53 @@ describe('score with groupBy', () => {
   });
 });
 
+describe('scoringConfigToSpec', () => {
+  it('derives unit from display.metrics when omitted in scoring.metrics', () => {
+    const spec = scoringConfigToSpec(
+      {
+        metrics: [{ key: 'ttiMs', ceiling: 10000, weights: { median: 1, p95: 0, p99: 0 } }],
+      },
+      undefined,
+      {
+        metrics: [{ key: 'ttiMs', label: 'Time to interactive', unit: 'ms' }],
+      },
+    );
+
+    expect(spec.metrics[0].name).toBe('ttiMs');
+    expect(spec.metrics[0].unit).toBe('ms');
+  });
+
+  it('uses the scoring metric unit as a fallback when display.metrics is absent', () => {
+    const spec = scoringConfigToSpec({
+      metrics: [{ key: 'ttiMs', unit: 'ms', ceiling: 10000, weights: { median: 1, p95: 0, p99: 0 } }],
+    });
+
+    expect(spec.metrics[0].unit).toBe('ms');
+  });
+
+  it('lets display.metrics override a scoring metric unit', () => {
+    const spec = scoringConfigToSpec(
+      {
+        metrics: [{ key: 'ttiMs', unit: 's', ceiling: 10000, weights: { median: 1, p95: 0, p99: 0 } }],
+      },
+      undefined,
+      {
+        metrics: [{ key: 'ttiMs', label: 'Time to interactive', unit: 'ms' }],
+      },
+    );
+
+    expect(spec.metrics[0].unit).toBe('ms');
+  });
+
+  it('falls back to an empty unit when neither scoring nor display declares one', () => {
+    const spec = scoringConfigToSpec({
+      metrics: [{ key: 'ttiMs', ceiling: 10000, weights: { median: 1, p95: 0, p99: 0 } }],
+    });
+
+    expect(spec.metrics[0].unit).toBe('');
+  });
+});
+
 describe('scoringConfigToSpec success rule', () => {
   const spec = scoringConfigToSpec({
     success: { requireData: { verified: true } },

--- a/packages/benchsdk-runner/src/bench-config.ts
+++ b/packages/benchsdk-runner/src/bench-config.ts
@@ -483,6 +483,9 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
     if (typeof config.display !== 'object' || config.display === null || Array.isArray(config.display)) {
       throw new Error('display must be an object');
     }
+    if (config.display.description !== undefined && typeof config.display.description !== 'string') {
+      throw new Error('display.description must be a string');
+    }
     const displayMetricKeys = new Set<string>();
     if (config.display.metrics !== undefined) {
       if (!Array.isArray(config.display.metrics)) {
@@ -499,6 +502,9 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
         }
         displayMetricKeys.add(key);
         assertNonEmptyString(metric.label, `display.metrics[${i}].label`);
+        if (metric.unit !== undefined && typeof metric.unit !== 'string') {
+          throw new Error(`display.metrics[${i}].unit must be a string`);
+        }
         if (metric.direction !== undefined && metric.direction !== 'higher-better' && metric.direction !== 'lower-better') {
           throw new Error(`display.metrics[${i}].direction must be 'higher-better' or 'lower-better'`);
         }

--- a/packages/benchsdk-runner/src/bench-config.ts
+++ b/packages/benchsdk-runner/src/bench-config.ts
@@ -472,21 +472,21 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
     if (typeof config.display !== 'object' || config.display === null || Array.isArray(config.display)) {
       throw new Error('display must be an object');
     }
+    const displayMetricKeys = new Set<string>();
     if (config.display.metrics !== undefined) {
       if (!Array.isArray(config.display.metrics)) {
         throw new Error('display.metrics must be an array');
       }
-      const seenMetricKeys = new Set<string>();
       for (let i = 0; i < config.display.metrics.length; i++) {
         const metric = config.display.metrics[i];
         if (metric === null || typeof metric !== 'object' || Array.isArray(metric)) {
           throw new Error(`display.metrics[${i}] must be an object`);
         }
         const key = assertNonEmptyString(metric.key, `display.metrics[${i}].key`);
-        if (seenMetricKeys.has(key)) {
+        if (displayMetricKeys.has(key)) {
           throw new Error(`duplicate display metric key: ${key}`);
         }
-        seenMetricKeys.add(key);
+        displayMetricKeys.add(key);
         assertNonEmptyString(metric.label, `display.metrics[${i}].label`);
         if (metric.direction !== undefined && metric.direction !== 'higher-better' && metric.direction !== 'lower-better') {
           throw new Error(`display.metrics[${i}].direction must be 'higher-better' or 'lower-better'`);
@@ -524,7 +524,15 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
       if (typeof config.display.overview !== 'object' || config.display.overview === null || Array.isArray(config.display.overview)) {
         throw new Error('display.overview must be an object');
       }
-      const { defaultLayout } = config.display.overview;
+      const { defaultMetric, defaultLayout } = config.display.overview;
+      if (defaultMetric !== undefined) {
+        const metric = assertNonEmptyString(defaultMetric, 'display.overview.defaultMetric');
+        // If the manifest declares metrics, the default must reference one of them.
+        // When metrics is omitted we can't validate the key, so any non-empty string is allowed.
+        if (config.display.metrics !== undefined && !displayMetricKeys.has(metric)) {
+          throw new Error(`display.overview.defaultMetric '${metric}' is not declared in display.metrics`);
+        }
+      }
       if (defaultLayout !== undefined && !['ranking', 'cards', 'chart', 'leaderboard'].includes(defaultLayout)) {
         throw new Error("display.overview.defaultLayout must be 'ranking', 'cards', 'chart', or 'leaderboard'");
       }

--- a/packages/benchsdk-runner/src/bench-config.ts
+++ b/packages/benchsdk-runner/src/bench-config.ts
@@ -173,6 +173,55 @@ export interface ResolvedRunConfig {
   providers?: string[];
 }
 
+/** Display metadata for a single custom metric a benchmark reports via `ctx.measure`. */
+export interface BenchmarkMetricDisplay {
+  /** Stable metric key, matching the key in `ctx.measure` or `data`. */
+  key: string;
+  /** Human-readable label shown in the platform UI. */
+  label: string;
+  /** Optional unit shown after the value (e.g. `Mbps`, `/s`, `ms`). */
+  unit?: string;
+  /** Number of decimal places when formatting numeric values. Defaults to the display format. */
+  decimals?: number;
+  /** Whether higher or lower values rank better. */
+  direction?: 'higher-better' | 'lower-better';
+  /** Optional ordering hint for metric lists. */
+  order?: number;
+}
+
+/** Display metadata for a single task lifecycle step. */
+export interface BenchmarkStepDisplay {
+  /** Stable step name, matching the string passed to `ctx.step`. */
+  key: string;
+  /** Human-readable label shown in the platform UI. */
+  label: string;
+  /** Optional ordering hint for step lists. */
+  order?: number;
+}
+
+/** Display defaults for the benchmark overview page. */
+export interface BenchmarkOverviewDisplay {
+  /** Metric key to rank participants by by default (falls back to overall task latency). */
+  defaultMetric?: string;
+  /** Default overview layout. */
+  defaultLayout?: 'ranking' | 'cards' | 'chart' | 'leaderboard';
+}
+
+/**
+ * Optional platform display manifest. A `*.bench.ts` file owns not only how the
+ * benchmark runs, but how it should be rendered, without a platform code change.
+ */
+export interface BenchmarkDisplayConfig {
+  /** Optional human-readable description shown on the benchmark listing. */
+  description?: string;
+  /** Metric catalog — labels, units, and ranking direction for `ctx.measure` keys. */
+  metrics?: BenchmarkMetricDisplay[];
+  /** Step catalog — human labels for lifecycle steps reported via `ctx.step`. */
+  steps?: BenchmarkStepDisplay[];
+  /** Overview defaults. */
+  overview?: BenchmarkOverviewDisplay;
+}
+
 /**
  * Result of a benchmark run, passed to `config.onComplete`. Exposes the raw
  * per-participant records so completion hooks can write legacy local results.
@@ -266,6 +315,18 @@ export interface BenchmarkConfig<T extends BaseParticipant = BaseParticipant> {
    * from typos and report unknown flags accurately.
    */
   customCliFlags?: readonly string[];
+  /**
+   * Optional display manifest. Lets the bench author configure metric labels,
+   * step labels, and overview defaults without editing the platform.
+   */
+  display?: BenchmarkDisplayConfig;
+}
+
+function assertNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+  return value;
 }
 
 function assertPositiveInt(value: number | undefined, field: string): void {
@@ -405,6 +466,68 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
   if (config.customCliFlags !== undefined) {
     if (!Array.isArray(config.customCliFlags) || !config.customCliFlags.every((f) => typeof f === 'string' && f.startsWith('--'))) {
       throw new Error('customCliFlags must be an array of strings starting with "--"');
+    }
+  }
+  if (config.display !== undefined) {
+    if (typeof config.display !== 'object' || config.display === null || Array.isArray(config.display)) {
+      throw new Error('display must be an object');
+    }
+    if (config.display.metrics !== undefined) {
+      if (!Array.isArray(config.display.metrics)) {
+        throw new Error('display.metrics must be an array');
+      }
+      const seenMetricKeys = new Set<string>();
+      for (let i = 0; i < config.display.metrics.length; i++) {
+        const metric = config.display.metrics[i];
+        if (metric === null || typeof metric !== 'object' || Array.isArray(metric)) {
+          throw new Error(`display.metrics[${i}] must be an object`);
+        }
+        const key = assertNonEmptyString(metric.key, `display.metrics[${i}].key`);
+        if (seenMetricKeys.has(key)) {
+          throw new Error(`duplicate display metric key: ${key}`);
+        }
+        seenMetricKeys.add(key);
+        assertNonEmptyString(metric.label, `display.metrics[${i}].label`);
+        if (metric.direction !== undefined && metric.direction !== 'higher-better' && metric.direction !== 'lower-better') {
+          throw new Error(`display.metrics[${i}].direction must be 'higher-better' or 'lower-better'`);
+        }
+        if (metric.decimals !== undefined && (!Number.isInteger(metric.decimals) || metric.decimals < 0)) {
+          throw new Error(`display.metrics[${i}].decimals must be a non-negative integer`);
+        }
+        if (metric.order !== undefined && (!Number.isInteger(metric.order) || metric.order < 0)) {
+          throw new Error(`display.metrics[${i}].order must be a non-negative integer`);
+        }
+      }
+    }
+    if (config.display.steps !== undefined) {
+      if (!Array.isArray(config.display.steps)) {
+        throw new Error('display.steps must be an array');
+      }
+      const seenStepKeys = new Set<string>();
+      for (let i = 0; i < config.display.steps.length; i++) {
+        const step = config.display.steps[i];
+        if (step === null || typeof step !== 'object' || Array.isArray(step)) {
+          throw new Error(`display.steps[${i}] must be an object`);
+        }
+        const key = assertNonEmptyString(step.key, `display.steps[${i}].key`);
+        if (seenStepKeys.has(key)) {
+          throw new Error(`duplicate display step key: ${key}`);
+        }
+        seenStepKeys.add(key);
+        assertNonEmptyString(step.label, `display.steps[${i}].label`);
+        if (step.order !== undefined && (!Number.isInteger(step.order) || step.order < 0)) {
+          throw new Error(`display.steps[${i}].order must be a non-negative integer`);
+        }
+      }
+    }
+    if (config.display.overview !== undefined) {
+      if (typeof config.display.overview !== 'object' || config.display.overview === null || Array.isArray(config.display.overview)) {
+        throw new Error('display.overview must be an object');
+      }
+      const { defaultLayout } = config.display.overview;
+      if (defaultLayout !== undefined && !['ranking', 'cards', 'chart', 'leaderboard'].includes(defaultLayout)) {
+        throw new Error("display.overview.defaultLayout must be 'ranking', 'cards', 'chart', or 'leaderboard'");
+      }
     }
   }
   return config;

--- a/packages/benchsdk-runner/src/bench-config.ts
+++ b/packages/benchsdk-runner/src/bench-config.ts
@@ -381,7 +381,8 @@ function validateBenchmarkScoringConfig(scoring: BenchmarkScoringConfig, display
     seen.add(key);
     // Unit is optional; when display.metrics is also declared it is the
     // canonical source and the scoring metric's unit must not contradict it.
-    const displayMetric = display?.metrics?.find((m) => m.key === key);
+    const displayMetrics = Array.isArray(display?.metrics) ? display!.metrics : undefined;
+    const displayMetric = displayMetrics?.find((m) => m?.key === key);
     if (metric.unit !== undefined) {
       if (typeof metric.unit !== 'string') {
         throw new Error(`scoring.metrics[${i}].unit must be a string`);

--- a/packages/benchsdk-runner/src/bench-config.ts
+++ b/packages/benchsdk-runner/src/bench-config.ts
@@ -343,7 +343,7 @@ function assertFiniteNumber(value: unknown, field: string): number {
   return value;
 }
 
-function validateBenchmarkScoringConfig(scoring: BenchmarkScoringConfig): void {
+function validateBenchmarkScoringConfig(scoring: BenchmarkScoringConfig, display?: BenchmarkDisplayConfig): void {
   if (!Array.isArray(scoring.metrics) || scoring.metrics.length === 0) {
     throw new Error('scoring.metrics must be a non-empty array');
   }
@@ -379,8 +379,18 @@ function validateBenchmarkScoringConfig(scoring: BenchmarkScoringConfig): void {
       throw new Error(`duplicate scoring metric key: ${key}`);
     }
     seen.add(key);
-    if (typeof metric.unit !== 'string' || metric.unit.trim() === '') {
-      throw new Error(`scoring.metrics[${i}].unit must be a non-empty string`);
+    // Unit is optional; when display.metrics is also declared it is the
+    // canonical source and the scoring metric's unit must not contradict it.
+    const displayMetric = display?.metrics?.find((m) => m.key === key);
+    if (metric.unit !== undefined) {
+      if (typeof metric.unit !== 'string') {
+        throw new Error(`scoring.metrics[${i}].unit must be a string`);
+      }
+      if (displayMetric?.unit !== undefined && metric.unit !== displayMetric.unit) {
+        throw new Error(
+          `scoring.metrics[${i}].unit '${metric.unit}' conflicts with display.metrics[${i}].unit '${displayMetric.unit}' for key '${key}'`,
+        );
+      }
     }
     assertFiniteNumber(metric.ceiling, `scoring.metrics[${i}].ceiling`);
     if (metric.floor !== undefined) {
@@ -461,7 +471,7 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
     }
   }
   if (config.scoring !== undefined) {
-    validateBenchmarkScoringConfig(config.scoring);
+    validateBenchmarkScoringConfig(config.scoring, config.display);
   }
   if (config.customCliFlags !== undefined) {
     if (!Array.isArray(config.customCliFlags) || !config.customCliFlags.every((f) => typeof f === 'string' && f.startsWith('--'))) {

--- a/packages/benchsdk-runner/src/index.ts
+++ b/packages/benchsdk-runner/src/index.ts
@@ -10,6 +10,10 @@ export type {
   ParticipantRecords,
   ResolvedRunConfig,
   BenchmarkRunOutcome,
+  BenchmarkDisplayConfig,
+  BenchmarkMetricDisplay,
+  BenchmarkStepDisplay,
+  BenchmarkOverviewDisplay,
 } from './bench-config.js';
 export { NoAvailableParticipantsError } from './no-available-participants.js';
 export { runBenchmark, parseCliArgs, mergeConfig } from './runner.js';

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -596,9 +596,10 @@ export async function runBenchmark<T extends BaseParticipant>(
     dashboardUrl = '';
   } else {
     if (identityIsOurs) {
-      const benchmarkConfig: JsonObject = config.scoring
-        ? { scoring: config.scoring as unknown as JsonObject }
-        : {};
+      const benchmarkConfig: JsonObject = {
+        ...(config.scoring ? { scoring: config.scoring as unknown as JsonObject } : {}),
+        ...(config.display ? { display: config.display as unknown as JsonObject } : {}),
+      };
       await client!.upsertBenchmark(config.benchmarkSlug, {
         name: config.benchmarkName,
         ...(Object.keys(benchmarkConfig).length > 0 ? { config: benchmarkConfig } : {}),

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -660,7 +660,7 @@ export async function runBenchmark<T extends BaseParticipant>(
     try {
       const spec = config.onScore
         ? await config.onScore(lowerIsBetter, higherIsBetter)
-        : scoringConfigToSpec(config.scoring!, config.dimensions);
+        : scoringConfigToSpec(config.scoring!, config.dimensions, config.display);
       const scored = score(outcome, spec);
       const run = {
         gitSha: process.env.GITHUB_SHA ?? getGitSha(),

--- a/packages/benchsdk-runner/src/scoring.ts
+++ b/packages/benchsdk-runner/src/scoring.ts
@@ -6,7 +6,7 @@ export type MetricValue = string | ((record: TaskResultRecord) => number | numbe
 export interface MetricScoring {
   name: string;
   value?: MetricValue;
-  unit: string;
+  unit?: string;
   ceiling: number;
   floor?: number;
   higherIsBetter?: boolean;
@@ -23,7 +23,7 @@ export interface BenchmarkScoringWeights {
 export interface BenchmarkScoringMetric {
   key: string;
   label?: string;
-  unit: string;
+  unit?: string;
   ceiling: number;
   floor?: number;
   higherIsBetter?: boolean;
@@ -74,7 +74,7 @@ export interface BenchmarkScoreResult {
 export type LowerIsBetter = (
   name: string,
   opts: {
-    unit: string;
+    unit?: string;
     ceiling: number;
     value?: MetricValue;
     weights: { median: number; p95: number; p99: number };
@@ -85,7 +85,7 @@ export type LowerIsBetter = (
 export type HigherIsBetter = (
   name: string,
   opts: {
-    unit: string;
+    unit?: string;
     floor?: number;
     ceiling: number;
     value?: MetricValue;
@@ -253,7 +253,7 @@ function scoreGroup(
       metric.weights.p99 * scoreStat(p99, metric);
     metricScoresSum += metricScore;
 
-    metrics.push({ name: metric.name, unit: metric.unit, median, p95, p99 });
+    metrics.push({ name: metric.name, unit: metric.unit ?? '', median, p95, p99 });
   }
 
   const compositeScore = successRate === 0 ? 0 : Math.round(metricScoresSum * successRate * 100) / 100;
@@ -297,8 +297,10 @@ export function score(outcome: BenchmarkRunOutcome, spec: ScoringSpec): Benchmar
 export function scoringConfigToSpec(
   config: BenchmarkScoringConfig,
   dimensions?: Record<string, unknown>,
+  display?: { metrics?: { key: string; unit?: string }[] },
 ): ScoringSpec {
   const success = config.success;
+  const unitByMetric = new Map(display?.metrics?.map((m) => [m.key, m.unit]));
   return {
     ...(dimensions ? { dimensions: toJsonObject(dimensions) } : {}),
     ...(config.groupBy ? { groupBy: config.groupBy } : {}),
@@ -312,7 +314,7 @@ export function scoringConfigToSpec(
     metrics: config.metrics.map((metric) => ({
       name: metric.key,
       value: metric.key,
-      unit: metric.unit,
+      unit: (display?.metrics === undefined ? metric.unit : (unitByMetric.get(metric.key) ?? metric.unit)) ?? '',
       ceiling: metric.ceiling,
       floor: metric.floor,
       higherIsBetter: metric.higherIsBetter,

--- a/packages/create-bench/src/index.ts
+++ b/packages/create-bench/src/index.ts
@@ -75,9 +75,14 @@ export const config = defineBenchmarkConfig({
   iterations: 10,
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [] }],
+  display: {
+    metrics: [
+      { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better' },
+    ],
+  },
   scoring: {
     metrics: [
-      { key: 'durationMs', unit: 'ms', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
+      { key: 'durationMs', ceiling: 1000, weights: { median: 0.7, p95: 0.2, p99: 0.1 } },
     ],
   },
 });


### PR DESCRIPTION
## Summary
Makes the `*.bench.ts` file the source of truth for both display and scoring metadata. This PR adds an optional `display` manifest to `BenchmarkConfig` and also makes `scoring.metrics` unit metadata derive from `display.metrics`, removing the risk that the two config blocks drift.

### What changed
- `packages/benchsdk-runner/src/bench-config.ts`
  - Added `display?: BenchmarkDisplayConfig` to `BenchmarkConfig`.
  - `BenchmarkDisplayConfig` carries `metrics`, `steps`, and `overview` defaults.
  - `defineBenchmarkConfig` validates the manifest shape and rejects unknown metric display fields.
  - `validateBenchmarkScoringConfig` now accepts an optional `display` argument: `scoring.metrics[i].unit` is optional, and when both `scoring` and `display` declare the same key the units must match.

- `packages/benchsdk-runner/src/scoring.ts`
  - `BenchmarkScoringMetric.unit` and `MetricScoring.unit` are now optional.
  - `scoringConfigToSpec(config, dimensions, display)` resolves each scoring metric's unit from the matching `display.metrics` entry, falling back to `metric.unit`, then defaulting to an empty string.
  - `lowerIsBetter` / `higherIsBetter` accept an optional `unit` so existing `onScore` callbacks keep working.

- `packages/benchsdk-runner/src/runner.ts`
  - Passes `config.display` into `scoringConfigToSpec` so runtime scoring uses the canonical display unit.

- `packages/benchsdk-runner/src/__tests__/bench-config.test.ts` and `src/__tests__/scoring.test.ts`
  - Added tests for unit derivation, fallback, and conflict validation.

- `benchmarks/browser/browser.bench.ts`, `benchmarks/sandbox/tti.bench.ts`, `packages/create-bench/src/index.ts`
  - Removed `unit` from `scoring.metrics` and left it on `display.metrics` only.

### Why
Previously the platform had to know about each benchmark's metrics in `custom-metrics.ts` and title-cased step names. Now the author declares labels, units, sort direction, and default overview layout in the same file that defines the workload, and `scoring` can reference those metrics without duplicating unit metadata.

### Backwards compatibility
`display` is optional. Benchmarks without it continue to use existing platform-side fallbacks (`METRIC_DISPLAY` and title-cased step names). `scoring.metrics[i].unit` is still accepted when `display` is absent.

Link to Devin session: https://app.devin.ai/sessions/a45e3a08012c47e989ccfc4c055275ac
Open in Devin Desktop: https://app.devin.ai/desktop/session/a45e3a08012c47e989ccfc4c055275ac?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->