### PR TITLE
Make sure system metrics sampling is non-blocking

### DIFF
--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -906,7 +906,7 @@ async function runGroupedByRound<T extends BaseParticipant>(
     // uploads metrics.
     if (reporter && !metricsCollector) {
       metricsCollector = createSystemMetricsCollector();
-      metricsSamples.push(metricsCollector.sample());
+      metricsSamples.push(await metricsCollector.sample());
     }
   }
 
@@ -951,14 +951,14 @@ async function runGroupedByRound<T extends BaseParticipant>(
     // everything sequentially in this one loop, so a round boundary is the
     // natural, already-existing cadence. Taken after the whole round (not per
     // participant) since the sample covers the shared process, not one slice.
-    if (metricsCollector) metricsSamples.push(metricsCollector.sample());
+    if (metricsCollector) metricsSamples.push(await metricsCollector.sample());
   }
 
   // One shared collector for the whole process — a final sample (before stop,
   // which disables the event-loop monitor), then upload a single
   // `system-metrics` artifact via any one reporter (all participants ran in
   // this process, so the metrics belong to the run, not to any one of them).
-  if (metricsCollector) metricsSamples.push(metricsCollector.sample());
+  if (metricsCollector) metricsSamples.push(await metricsCollector.sample());
   metricsCollector?.stop();
   // The SDK only has a worker-scoped artifact API, so this single artifact is
   // necessarily filed under one reporter's worker. Tag it as process-scoped

--- a/packages/benchsdk-worker/src/metrics.ts
+++ b/packages/benchsdk-worker/src/metrics.ts
@@ -230,7 +230,9 @@ export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector 
   const eventLoop = monitorEventLoopDelay({ resolution: 20 });
   eventLoop.enable();
 
-  let hostCpuBaseline: number[] | null = null;
+  // Capture the host CPU baseline once at creation time so cumulative host
+  // CPU usage covers the full collector lifetime, not just from the first sample.
+  const hostCpuBaselinePromise: Promise<number[] | null> = readHostCpuJiffies().catch(() => null);
   let cgroupPaths: CgroupPaths | null = null;
   let cachedCgroupMemLimitMb: number | null | undefined;
   let cachedCgroupCpuLimitCores: number | null | undefined;
@@ -241,21 +243,15 @@ export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector 
       const memory = process.memoryUsage();
       const loadavg = os.loadavg();
 
-      const [hostMem, hostCpuJiffies, openFds, sockstat] = await Promise.all([
+      const [hostMem, hostCpuJiffies, openFds, sockstat, hostCpuBaseline] = await Promise.all([
         readHostMemInfo(),
         readHostCpuJiffies(),
         countOpenFds(),
         readSockstat(),
+        hostCpuBaselinePromise,
       ]);
 
-      let hostCpu: { usedUs: number; totalUs: number } | null = null;
-      if (hostCpuJiffies) {
-        if (hostCpuBaseline) {
-          hostCpu = hostCpuUsageSince(hostCpuBaseline, hostCpuJiffies);
-        } else {
-          hostCpuBaseline = hostCpuJiffies;
-        }
-      }
+      const hostCpu = hostCpuBaseline && hostCpuJiffies ? hostCpuUsageSince(hostCpuBaseline, hostCpuJiffies) : null;
 
       if (!cgroupPaths) {
         cgroupPaths = await cgroupRelativePaths();

--- a/packages/benchsdk-worker/src/metrics.ts
+++ b/packages/benchsdk-worker/src/metrics.ts
@@ -246,7 +246,14 @@ export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector 
       // sample read. The current read for this sample will happen after this
       // baseline read completes, so the two snapshots are still ordered.
       return readHostCpuJiffies();
-    })();
+    })().then((baseline) => {
+      // If both the creation-time and fallback reads failed, clear the cached
+      // promise so the next sample can retry establishing the baseline.
+      if (baseline === null) {
+        hostCpuBaselineInitPromise = null;
+      }
+      return baseline;
+    });
     return hostCpuBaselineInitPromise;
   }
 

--- a/packages/benchsdk-worker/src/metrics.ts
+++ b/packages/benchsdk-worker/src/metrics.ts
@@ -233,6 +233,8 @@ export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector 
   // Capture the host CPU baseline once at creation time so cumulative host
   // CPU usage covers the full collector lifetime, not just from the first sample.
   const hostCpuBaselinePromise: Promise<number[] | null> = readHostCpuJiffies().catch(() => null);
+  let hostCpuBaseline: number[] | null = null;
+  let hostCpuBaselineReady = false;
   let cgroupPaths: CgroupPaths | null = null;
   let cachedCgroupMemLimitMb: number | null | undefined;
   let cachedCgroupCpuLimitCores: number | null | undefined;
@@ -243,15 +245,34 @@ export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector 
       const memory = process.memoryUsage();
       const loadavg = os.loadavg();
 
-      const [hostMem, hostCpuJiffies, openFds, sockstat, hostCpuBaseline] = await Promise.all([
+      // On the first sample, await the creation-time baseline before reading the
+      // current /proc/stat snapshot so the two reads are correctly ordered and
+      // the first delta cannot be negative. If that creation read failed, we
+      // fall back to using the first successful sample read as the baseline and
+      // skip reporting a delta until a second ordered snapshot exists.
+      if (!hostCpuBaselineReady) {
+        hostCpuBaselineReady = true;
+        const creationBaseline = await hostCpuBaselinePromise;
+        if (creationBaseline) {
+          hostCpuBaseline = creationBaseline;
+        }
+      }
+
+      const [hostMem, hostCpuJiffies, openFds, sockstat] = await Promise.all([
         readHostMemInfo(),
         readHostCpuJiffies(),
         countOpenFds(),
         readSockstat(),
-        hostCpuBaselinePromise,
       ]);
 
-      const hostCpu = hostCpuBaseline && hostCpuJiffies ? hostCpuUsageSince(hostCpuBaseline, hostCpuJiffies) : null;
+      let hostCpu: { usedUs: number; totalUs: number } | null = null;
+      if (hostCpuBaseline) {
+        if (hostCpuJiffies) {
+          hostCpu = hostCpuUsageSince(hostCpuBaseline, hostCpuJiffies);
+        }
+      } else if (hostCpuJiffies) {
+        hostCpuBaseline = hostCpuJiffies;
+      }
 
       if (!cgroupPaths) {
         cgroupPaths = await cgroupRelativePaths();

--- a/packages/benchsdk-worker/src/metrics.ts
+++ b/packages/benchsdk-worker/src/metrics.ts
@@ -1,4 +1,4 @@
-import * as fs from 'node:fs';
+import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import { monitorEventLoopDelay } from 'node:perf_hooks';
 
@@ -35,63 +35,63 @@ export interface BenchmarkSystemMetricsSample {
 }
 
 export interface BenchmarkSystemMetricsCollector {
-  sample(): BenchmarkSystemMetricsSample;
+  sample(): Promise<BenchmarkSystemMetricsSample>;
   stop(): void;
 }
 
-function readSockstat(): Record<string, number> | null {
+async function readTextFile(path: string): Promise<string | null> {
   try {
-    const data = fs.readFileSync('/proc/net/sockstat', 'utf-8');
-    const out: Record<string, number> = {};
-    for (const line of data.split('\n')) {
-      const index = line.indexOf(':');
-      if (index < 0) continue;
-      const section = line.slice(0, index).trim().toLowerCase();
-      const parts = line.slice(index + 1).trim().split(/\s+/);
-      for (let i = 0; i + 1 < parts.length; i += 2) {
-        const value = Number.parseInt(parts[i + 1], 10);
-        if (!Number.isNaN(value)) out[`${section}_${parts[i]}`] = value;
-      }
+    return await fs.readFile(path, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+async function readSockstat(): Promise<Record<string, number> | null> {
+  const data = await readTextFile('/proc/net/sockstat');
+  if (!data) return null;
+  const out: Record<string, number> = {};
+  for (const line of data.split('\n')) {
+    const index = line.indexOf(':');
+    if (index < 0) continue;
+    const section = line.slice(0, index).trim().toLowerCase();
+    const parts = line.slice(index + 1).trim().split(/\s+/);
+    for (let i = 0; i + 1 < parts.length; i += 2) {
+      const value = Number.parseInt(parts[i + 1], 10);
+      if (!Number.isNaN(value)) out[`${section}_${parts[i]}`] = value;
     }
-    return out;
+  }
+  return out;
+}
+
+async function countOpenFds(): Promise<number | null> {
+  try {
+    const entries = await fs.readdir('/proc/self/fd');
+    return entries.length;
   } catch {
     return null;
   }
 }
 
-function countOpenFds(): number | null {
-  try {
-    return fs.readdirSync('/proc/self/fd').length;
-  } catch {
-    return null;
-  }
-}
-
-function readHostMemInfo(): { totalMb: number; availableMb: number } | null {
-  try {
-    const data = fs.readFileSync('/proc/meminfo', 'utf-8');
-    const total = data.match(/^MemTotal:\s+(\d+)\s*kB/m);
-    const available = data.match(/^MemAvailable:\s+(\d+)\s*kB/m);
-    if (!total || !available) return null;
-    return {
-      totalMb: Math.round(Number.parseInt(total[1], 10) / 1024),
-      availableMb: Math.round(Number.parseInt(available[1], 10) / 1024),
-    };
-  } catch {
-    return null;
-  }
+async function readHostMemInfo(): Promise<{ totalMb: number; availableMb: number } | null> {
+  const data = await readTextFile('/proc/meminfo');
+  if (!data) return null;
+  const total = data.match(/^MemTotal:\s+(\d+)\s*kB/m);
+  const available = data.match(/^MemAvailable:\s+(\d+)\s*kB/m);
+  if (!total || !available) return null;
+  return {
+    totalMb: Math.round(Number.parseInt(total[1], 10) / 1024),
+    availableMb: Math.round(Number.parseInt(available[1], 10) / 1024),
+  };
 }
 
 // user nice system idle iowait irq softirq steal [guest guest_nice], in jiffies.
-function readHostCpuJiffies(): number[] | null {
-  try {
-    const data = fs.readFileSync('/proc/stat', 'utf-8');
-    const line = data.split('\n').find((l) => l.startsWith('cpu '));
-    if (!line) return null;
-    return line.trim().split(/\s+/).slice(1).map((v) => Number.parseInt(v, 10));
-  } catch {
-    return null;
-  }
+async function readHostCpuJiffies(): Promise<number[] | null> {
+  const data = await readTextFile('/proc/stat');
+  if (!data) return null;
+  const line = data.split('\n').find((l) => l.startsWith('cpu '));
+  if (!line) return null;
+  return line.trim().split(/\s+/).slice(1).map((v) => Number.parseInt(v, 10));
 }
 
 // ponytail: hardcoded 100Hz — correct on ~every Linux distro/container, wrong
@@ -110,17 +110,22 @@ function hostCpuUsageSince(baseline: number[] | null, current: number[] | null):
   return { usedUs: Math.round(usedUs), totalUs: Math.round(totalUs) };
 }
 
+interface CgroupPaths {
+  v2: string;
+  controllers: Map<string, string>;
+}
+
 // The process's own control files aren't always at the cgroup fs root: under a
 // nested cgroup (no namespacing) they live at `<root>/<relative>/...`. Parse
 // the relative path per controller from /proc/self/cgroup, defaulting to the
 // root so hosts that *do* namespace the cgroup (relative path "/") still work.
 // A limit set on any ancestor also constrains us, so callers walk up the tree
 // and take the tightest — reading only the leaf would miss a parent's ceiling.
-function cgroupRelativePaths(): { v2: string; controllers: Map<string, string> } {
+async function cgroupRelativePaths(): Promise<CgroupPaths> {
   const controllers = new Map<string, string>();
   let v2 = '';
   try {
-    const data = fs.readFileSync('/proc/self/cgroup', 'utf-8');
+    const data = await fs.readFile('/proc/self/cgroup', 'utf-8');
     for (const line of data.split('\n')) {
       // Format: hierarchy-id:controller-list:relative-path
       const idx = line.indexOf(':');
@@ -170,59 +175,51 @@ function tighter(a: number | null, b: number | null): number | null {
   return Math.min(a, b);
 }
 
-function readCgroupMemLimitMb(): number | null {
-  const { v2, controllers } = cgroupRelativePaths();
+async function readCgroupMemLimitMb(paths: CgroupPaths): Promise<number | null> {
   let limit: number | null = null;
-  for (const dir of cgroupDirsToRoot('/sys/fs/cgroup', v2)) {
-    try {
-      const raw = fs.readFileSync(`${dir}/memory.max`, 'utf-8').trim();
-      if (raw === 'max') continue; // unlimited here — an ancestor may still cap us.
-      const bytes = Number.parseInt(raw, 10);
-      if (Number.isFinite(bytes)) limit = tighter(limit, Math.round(bytes / 1024 / 1024));
-    } catch {
-      // No memory.max at this level — try the next ancestor, then fall to v1.
-    }
+  for (const dir of cgroupDirsToRoot('/sys/fs/cgroup', paths.v2)) {
+    const raw = await readTextFile(`${dir}/memory.max`);
+    if (raw === null) continue;
+    const trimmed = raw.trim();
+    if (trimmed === 'max') continue; // unlimited here — an ancestor may still cap us.
+    const bytes = Number.parseInt(trimmed, 10);
+    if (Number.isFinite(bytes)) limit = tighter(limit, Math.round(bytes / 1024 / 1024));
   }
   if (limit !== null) return limit;
-  const relPath = controllers.get('memory') ?? '';
+  const relPath = paths.controllers.get('memory') ?? '';
   for (const dir of cgroupDirsToRoot('/sys/fs/cgroup/memory', relPath)) {
-    try {
-      const bytes = Number.parseInt(fs.readFileSync(`${dir}/memory.limit_in_bytes`, 'utf-8').trim(), 10);
-      // v1 has no "unlimited" string; it reports a near-2^63 sentinel instead.
-      if (!Number.isFinite(bytes) || bytes > 1e15) continue;
-      limit = tighter(limit, Math.round(bytes / 1024 / 1024));
-    } catch {
-      // No limit file at this level — keep walking up toward the root.
-    }
+    const raw = await readTextFile(`${dir}/memory.limit_in_bytes`);
+    if (raw === null) continue;
+    const bytes = Number.parseInt(raw.trim(), 10);
+    // v1 has no "unlimited" string; it reports a near-2^63 sentinel instead.
+    if (!Number.isFinite(bytes) || bytes > 1e15) continue;
+    limit = tighter(limit, Math.round(bytes / 1024 / 1024));
   }
   return limit;
 }
 
-function readCgroupCpuLimitCores(): number | null {
-  const { v2, controllers } = cgroupRelativePaths();
+async function readCgroupCpuLimitCores(paths: CgroupPaths): Promise<number | null> {
   let limit: number | null = null;
-  for (const dir of cgroupDirsToRoot('/sys/fs/cgroup', v2)) {
-    try {
-      const [quotaRaw, periodRaw] = fs.readFileSync(`${dir}/cpu.max`, 'utf-8').trim().split(/\s+/);
-      if (quotaRaw === 'max') continue; // unlimited here — an ancestor may still cap us.
-      const quota = Number.parseInt(quotaRaw, 10);
-      const period = Number.parseInt(periodRaw, 10);
-      if (Number.isFinite(quota) && period > 0) limit = tighter(limit, quota / period);
-    } catch {
-      // No cpu.max at this level — try the next ancestor, then fall to v1.
-    }
+  for (const dir of cgroupDirsToRoot('/sys/fs/cgroup', paths.v2)) {
+    const raw = await readTextFile(`${dir}/cpu.max`);
+    if (raw === null) continue;
+    const [quotaRaw, periodRaw] = raw.trim().split(/\s+/);
+    if (quotaRaw === 'max') continue; // unlimited here — an ancestor may still cap us.
+    const quota = Number.parseInt(quotaRaw, 10);
+    const period = Number.parseInt(periodRaw, 10);
+    if (Number.isFinite(quota) && period > 0) limit = tighter(limit, quota / period);
   }
   if (limit !== null) return limit;
-  const relPath = controllers.get('cpu') ?? '';
+  const relPath = paths.controllers.get('cpu') ?? '';
   for (const dir of cgroupDirsToRoot('/sys/fs/cgroup/cpu', relPath)) {
-    try {
-      const quota = Number.parseInt(fs.readFileSync(`${dir}/cpu.cfs_quota_us`, 'utf-8').trim(), 10);
-      if (!Number.isFinite(quota) || quota <= 0) continue; // -1 == unlimited here.
-      const period = Number.parseInt(fs.readFileSync(`${dir}/cpu.cfs_period_us`, 'utf-8').trim(), 10);
-      if (period > 0) limit = tighter(limit, quota / period);
-    } catch {
-      // No quota file at this level — keep walking up toward the root.
-    }
+    const quotaRaw = await readTextFile(`${dir}/cpu.cfs_quota_us`);
+    if (quotaRaw === null) continue;
+    const quota = Number.parseInt(quotaRaw.trim(), 10);
+    if (!Number.isFinite(quota) || quota <= 0) continue; // -1 == unlimited here.
+    const periodRaw = await readTextFile(`${dir}/cpu.cfs_period_us`);
+    if (periodRaw === null) continue;
+    const period = Number.parseInt(periodRaw.trim(), 10);
+    if (period > 0) limit = tighter(limit, quota / period);
   }
   return limit;
 }
@@ -230,19 +227,47 @@ function readCgroupCpuLimitCores(): number | null {
 export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector {
   const startedAt = Date.now();
   const cpuBaseline = process.cpuUsage();
-  const hostCpuBaseline = readHostCpuJiffies();
-  const cgroupMemLimitMb = readCgroupMemLimitMb();
-  const cgroupCpuLimitCores = readCgroupCpuLimitCores();
   const eventLoop = monitorEventLoopDelay({ resolution: 20 });
   eventLoop.enable();
 
+  let hostCpuBaseline: number[] | null = null;
+  let cgroupPaths: CgroupPaths | null = null;
+  let cachedCgroupMemLimitMb: number | null | undefined;
+  let cachedCgroupCpuLimitCores: number | null | undefined;
+
   return {
-    sample() {
+    async sample() {
       const cpu = process.cpuUsage(cpuBaseline);
       const memory = process.memoryUsage();
       const loadavg = os.loadavg();
-      const hostMem = readHostMemInfo();
-      const hostCpu = hostCpuUsageSince(hostCpuBaseline, readHostCpuJiffies());
+
+      const [hostMem, hostCpuJiffies, openFds, sockstat] = await Promise.all([
+        readHostMemInfo(),
+        readHostCpuJiffies(),
+        countOpenFds(),
+        readSockstat(),
+      ]);
+
+      let hostCpu: { usedUs: number; totalUs: number } | null = null;
+      if (hostCpuJiffies) {
+        if (hostCpuBaseline) {
+          hostCpu = hostCpuUsageSince(hostCpuBaseline, hostCpuJiffies);
+        } else {
+          hostCpuBaseline = hostCpuJiffies;
+        }
+      }
+
+      if (!cgroupPaths) {
+        cgroupPaths = await cgroupRelativePaths();
+      }
+
+      if (cachedCgroupMemLimitMb === undefined) {
+        cachedCgroupMemLimitMb = await readCgroupMemLimitMb(cgroupPaths);
+      }
+      if (cachedCgroupCpuLimitCores === undefined) {
+        cachedCgroupCpuLimitCores = await readCgroupCpuLimitCores(cgroupPaths);
+      }
+
       const sample: BenchmarkSystemMetricsSample = {
         ts: new Date().toISOString(),
         uptimeMs: Date.now() - startedAt,
@@ -258,14 +283,14 @@ export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector 
         loadavg1m: loadavg[0],
         loadavg5m: loadavg[1],
         loadavg15m: loadavg[2],
-        openFds: countOpenFds(),
-        sockstat: readSockstat(),
+        openFds,
+        sockstat,
         hostMemTotalMb: hostMem?.totalMb ?? null,
         hostMemAvailableMb: hostMem?.availableMb ?? null,
         hostCpuUsedUs: hostCpu?.usedUs ?? null,
         hostCpuTotalUs: hostCpu?.totalUs ?? null,
-        cgroupMemLimitMb,
-        cgroupCpuLimitCores,
+        cgroupMemLimitMb: cachedCgroupMemLimitMb ?? null,
+        cgroupCpuLimitCores: cachedCgroupCpuLimitCores ?? null,
       };
       eventLoop.reset();
       return sample;

--- a/packages/benchsdk-worker/src/metrics.ts
+++ b/packages/benchsdk-worker/src/metrics.ts
@@ -232,9 +232,24 @@ export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector 
 
   // Capture the host CPU baseline once at creation time so cumulative host
   // CPU usage covers the full collector lifetime, not just from the first sample.
-  const hostCpuBaselinePromise: Promise<number[] | null> = readHostCpuJiffies().catch(() => null);
-  let hostCpuBaseline: number[] | null = null;
-  let hostCpuBaselineReady = false;
+  // If the creation-time read fails, the first successful sample read is used as
+  // the baseline. All samples share the same init promise so overlapping calls
+  // cannot read the current CPU snapshot before the baseline is established.
+  const creationHostCpuBaselinePromise: Promise<number[] | null> = readHostCpuJiffies().catch(() => null);
+  let hostCpuBaselineInitPromise: Promise<number[] | null> | null = null;
+  function getHostCpuBaseline(): Promise<number[] | null> {
+    if (hostCpuBaselineInitPromise) return hostCpuBaselineInitPromise;
+    hostCpuBaselineInitPromise = (async () => {
+      const creationBaseline = await creationHostCpuBaselinePromise;
+      if (creationBaseline) return creationBaseline;
+      // Creation read failed; establish the baseline from the first successful
+      // sample read. The current read for this sample will happen after this
+      // baseline read completes, so the two snapshots are still ordered.
+      return readHostCpuJiffies();
+    })();
+    return hostCpuBaselineInitPromise;
+  }
+
   let cgroupPaths: CgroupPaths | null = null;
   let cachedCgroupMemLimitMb: number | null | undefined;
   let cachedCgroupCpuLimitCores: number | null | undefined;
@@ -245,18 +260,11 @@ export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector 
       const memory = process.memoryUsage();
       const loadavg = os.loadavg();
 
-      // On the first sample, await the creation-time baseline before reading the
-      // current /proc/stat snapshot so the two reads are correctly ordered and
-      // the first delta cannot be negative. If that creation read failed, we
-      // fall back to using the first successful sample read as the baseline and
-      // skip reporting a delta until a second ordered snapshot exists.
-      if (!hostCpuBaselineReady) {
-        hostCpuBaselineReady = true;
-        const creationBaseline = await hostCpuBaselinePromise;
-        if (creationBaseline) {
-          hostCpuBaseline = creationBaseline;
-        }
-      }
+      // Await the shared baseline init before reading the current CPU snapshot.
+      // This guarantees the baseline read completes first, preventing negative
+      // deltas, and lets a later successful sample recover from a transient
+      // creation-time failure.
+      const hostCpuBaseline = await getHostCpuBaseline();
 
       const [hostMem, hostCpuJiffies, openFds, sockstat] = await Promise.all([
         readHostMemInfo(),
@@ -265,14 +273,7 @@ export function createSystemMetricsCollector(): BenchmarkSystemMetricsCollector 
         readSockstat(),
       ]);
 
-      let hostCpu: { usedUs: number; totalUs: number } | null = null;
-      if (hostCpuBaseline) {
-        if (hostCpuJiffies) {
-          hostCpu = hostCpuUsageSince(hostCpuBaseline, hostCpuJiffies);
-        }
-      } else if (hostCpuJiffies) {
-        hostCpuBaseline = hostCpuJiffies;
-      }
+      const hostCpu = hostCpuBaseline && hostCpuJiffies ? hostCpuUsageSince(hostCpuBaseline, hostCpuJiffies) : null;
 
       if (!cgroupPaths) {
         cgroupPaths = await cgroupRelativePaths();

--- a/packages/benchsdk-worker/src/worker.ts
+++ b/packages/benchsdk-worker/src/worker.ts
@@ -405,14 +405,20 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
   // socket counts — not the sandbox/VM's total resource usage.
   const systemMetricsCollector = metricsIntervalMs > 0 ? createSystemMetricsCollector() : undefined;
   const systemMetricsSamples: BenchmarkSystemMetricsSample[] = [];
-  const takeSystemMetricsSample = async () => {
-    if (!systemMetricsCollector) return;
-    try {
-      systemMetricsSamples.push(await systemMetricsCollector.sample());
-    } catch {
-      // Best-effort: never fail the run over metrics collection.
-    }
-  };
+  const metricsInFlight = new Set<Promise<void>>();
+  function takeSystemMetricsSample(): Promise<void> {
+    if (!systemMetricsCollector) return Promise.resolve();
+    const promise = (async () => {
+      try {
+        systemMetricsSamples.push(await systemMetricsCollector.sample());
+      } catch {
+        // Best-effort: never fail the run over metrics collection.
+      }
+    })();
+    metricsInFlight.add(promise);
+    promise.then(() => metricsInFlight.delete(promise)).catch(() => metricsInFlight.delete(promise));
+    return promise;
+  }
   const metricsInterval =
     systemMetricsCollector && metricsIntervalMs > 0
       ? setInterval(() => {
@@ -585,6 +591,7 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
     if (logFlush) clearInterval(logFlush);
     await uploadWorkerLogArtifact(true);
     if (metricsInterval) clearInterval(metricsInterval);
+    await Promise.all([...metricsInFlight]);
     await takeSystemMetricsSample();
     systemMetricsCollector?.stop();
     await uploadSystemMetricsArtifact();

--- a/packages/benchsdk-worker/src/worker.ts
+++ b/packages/benchsdk-worker/src/worker.ts
@@ -405,10 +405,18 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
   // socket counts — not the sandbox/VM's total resource usage.
   const systemMetricsCollector = metricsIntervalMs > 0 ? createSystemMetricsCollector() : undefined;
   const systemMetricsSamples: BenchmarkSystemMetricsSample[] = [];
+  const takeSystemMetricsSample = async () => {
+    if (!systemMetricsCollector) return;
+    try {
+      systemMetricsSamples.push(await systemMetricsCollector.sample());
+    } catch {
+      // Best-effort: never fail the run over metrics collection.
+    }
+  };
   const metricsInterval =
     systemMetricsCollector && metricsIntervalMs > 0
       ? setInterval(() => {
-          systemMetricsSamples.push(systemMetricsCollector.sample());
+          void takeSystemMetricsSample();
         }, metricsIntervalMs)
       : undefined;
   metricsInterval?.unref?.();
@@ -434,7 +442,7 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
     // An immediate baseline sample, same reasoning as the heartbeat above: a
     // worker that finishes inside one metricsIntervalMs window would
     // otherwise upload no metrics artifact at all.
-    if (systemMetricsCollector) systemMetricsSamples.push(systemMetricsCollector.sample());
+    void takeSystemMetricsSample();
 
     await mapPool(taskIndices, workerConcurrency, async (taskIndex) => {
       inFlightCount += 1;
@@ -577,7 +585,7 @@ export async function runWorker(client: BenchmarkClient, options: RunWorkerOptio
     if (logFlush) clearInterval(logFlush);
     await uploadWorkerLogArtifact(true);
     if (metricsInterval) clearInterval(metricsInterval);
-    if (systemMetricsCollector) systemMetricsSamples.push(systemMetricsCollector.sample());
+    await takeSystemMetricsSample();
     systemMetricsCollector?.stop();
     await uploadSystemMetricsArtifact();
     clearInterval(heartbeat);

--- a/packages/benchsdk/README.md
+++ b/packages/benchsdk/README.md
@@ -202,7 +202,7 @@ For coordinator health artifacts, sample system metrics:
 
 ```ts
 const metrics = createSystemMetricsCollector();
-const samples = [metrics.sample()];
+const samples = [await metrics.sample()];
 metrics.stop();
 ```
 

--- a/packages/benchsdk/src/__tests__/client.test.ts
+++ b/packages/benchsdk/src/__tests__/client.test.ts
@@ -980,9 +980,9 @@ describe('createBenchmarkClient', () => {
     expect(sentSequences).toEqual([0, 0]);
   });
 
-  it('samples system metrics for coordinator artifacts', () => {
+  it('samples system metrics for coordinator artifacts', async () => {
     const collector = createSystemMetricsCollector();
-    const sample = collector.sample();
+    const sample = await collector.sample();
     collector.stop();
 
     expect(sample.ts).toEqual(expect.any(String));

--- a/packages/benchsdk/src/__tests__/client.test.ts
+++ b/packages/benchsdk/src/__tests__/client.test.ts
@@ -899,7 +899,7 @@ describe('createBenchmarkClient', () => {
     expect(artifactPost?.body).toMatchObject({ kind: 'coordinator.log', name: 'worker.log', contentType: 'application/gzip' });
 
     const upload = seen.find((entry) => entry.url === 'https://upload.test');
-    const decompressed = gunzipSync(Buffer.from(upload?.body as ArrayBufferView));
+    const decompressed = gunzipSync(Buffer.from(upload?.body as Uint8Array));
     expect(decompressed.toString()).toContain('compressed entry');
   });
 

--- a/packages/benchsdk/src/__tests__/public-api.contract.test.ts
+++ b/packages/benchsdk/src/__tests__/public-api.contract.test.ts
@@ -1422,9 +1422,9 @@ describe('createSystemMetricsCollector', () => {
     'cgroupMemLimitMb', 'cgroupCpuLimitCores',
   ];
 
-  it('VAL-SDK-086: sample() returns a complete 22-field BenchmarkSystemMetricsSample', () => {
+  it('VAL-SDK-086: sample() returns a complete 22-field BenchmarkSystemMetricsSample', async () => {
     const collector = createSystemMetricsCollector();
-    const sample = collector.sample();
+    const sample = await collector.sample();
     collector.stop();
     expect(Object.keys(sample).sort()).toEqual([...SAMPLE_KEYS].sort());
     expect(Object.keys(sample)).toHaveLength(22);
@@ -1433,26 +1433,26 @@ describe('createSystemMetricsCollector', () => {
     expect(sample.eventLoopP99Ms).toEqual(expect.any(Number));
   });
 
-  it('VAL-SDK-087: sample() can be called repeatedly (event loop counters reset per call)', () => {
+  it('VAL-SDK-087: sample() can be called repeatedly (event loop counters reset per call)', async () => {
     const collector = createSystemMetricsCollector();
-    const first = collector.sample();
-    const second = collector.sample();
+    const first = await collector.sample();
+    const second = await collector.sample();
     collector.stop();
     expect(first.eventLoopMaxMs).toEqual(expect.any(Number));
     expect(second.eventLoopMaxMs).toEqual(expect.any(Number));
     expect(second.uptimeMs).toBeGreaterThanOrEqual(first.uptimeMs);
   });
 
-  it('VAL-SDK-088: stop() disables the monitor without throwing', () => {
+  it('VAL-SDK-088: stop() disables the monitor without throwing', async () => {
     const collector = createSystemMetricsCollector();
-    collector.sample();
+    await collector.sample();
     expect(() => collector.stop()).not.toThrow();
     expect(typeof collector.stop).toBe('function');
   });
 
-  it('VAL-SDK-089: sockstat, openFds, and the /proc- and cgroup-derived fields gracefully degrade to null off Linux', () => {
+  it('VAL-SDK-089: sockstat, openFds, and the /proc- and cgroup-derived fields gracefully degrade to null off Linux', async () => {
     const collector = createSystemMetricsCollector();
-    const sample = collector.sample();
+    const sample = await collector.sample();
     collector.stop();
     expect(sample.openFds === null || typeof sample.openFds === 'number').toBe(true);
     expect(sample.sockstat === null || typeof sample.sockstat === 'object').toBe(true);


### PR DESCRIPTION
## Summary
`BenchmarkSystemMetricsCollector.sample()` was reading `/proc` and `/sys/fs/cgroup/*` files synchronously (`fs.readFileSync`/`fs.readdirSync`). Because the collector runs inside the same Node process as benchmark workers, a sample could freeze the event loop while a `performance.now()`- or `Date.now()`-based latency measurement was in flight, adding the sample cost to the measured latency. This PR removes that source of blocking.

## What changed
- `packages/benchsdk-worker/src/metrics.ts`
  - All proc/cgroup I/O is now async via `fs.promises`.
  - `BenchmarkSystemMetricsCollector.sample()` returns `Promise<BenchmarkSystemMetricsSample>`.
  - Static cgroup limits (`memory.max`, `cpu.max`) are cached per collector after the first read.
  - The host CPU baseline is captured asynchronously at `createSystemMetricsCollector()` time via a shared init promise and reused.
  - The baseline read always completes before the current `/proc/stat` snapshot is read, preventing negative deltas even when multiple samples overlap.
  - If the creation-time `/proc/stat` read fails, the first successful sample read establishes the baseline. Transient double failures clear the cached promise so a later sample retries.

- `packages/benchsdk-worker/src/worker.ts`
  - Metrics interval now fires `sample()` asynchronously (`void takeSystemMetricsSample()`); no run step is blocked waiting for the sample.
  - In-flight sample promises are tracked and awaited in `finally` before the final sample and upload, so short-lived workers still include their baseline sample.

- `packages/benchsdk-runner/src/runner.ts`
  - The three `metricsCollector.sample()` call sites in round-mode scheduling are awaited so they still capture samples but never block the timer loop.

- `packages/benchsdk/src/__tests__/public-api.contract.test.ts` and `packages/benchsdk/src/__tests__/client.test.ts`
  - Updated to `await collector.sample()`.

## Verification
- `pnpm --filter @benchsdk/worker build` passes.
- `pnpm --filter @benchsdk/runner build` passes.
- `pnpm --filter @benchsdk/client test` passes.
- `pnpm --filter @benchsdk/worker typecheck` passes.
- `pnpm --filter @benchsdk/runner typecheck` passes.
- A local micro-benchmark that sets a 50 ms timer while `sample()` runs confirms the timer now fires within expected jitter; previously it could be delayed because synchronous I/O froze the event loop.

Link to Devin session: https://app.devin.ai/sessions/98706cf463664445bd43c69262a046eb
Open in Devin Desktop: https://app.devin.ai/desktop/session/98706cf463664445bd43c69262a046eb?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->