### PR TITLE
fix(workflows): build workspace packages before browser and storage benchmark runs

### DIFF
--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -60,10 +60,15 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+      - name: Build workspace packages
+        # The @benchsdk/* packages are built from source and dist/ is not
+        # committed. Build them in topological order so dependents like
+        # @benchsdk/client can resolve @benchsdk/worker during their own build.
+        run: pnpm -r --filter './packages/**' run build
       - name: Clear stale results from checkout
         run: rm -rf results/browser/
       - name: Run browser benchmark
@@ -109,10 +114,15 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+      - name: Build workspace packages
+        # The @benchsdk/* packages are built from source and dist/ is not
+        # committed. Build them in topological order so dependents like
+        # @benchsdk/client can resolve @benchsdk/worker during their own build.
+        run: pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/browser-concurrent-benchmarks.yml
+++ b/.github/workflows/browser-concurrent-benchmarks.yml
@@ -138,7 +138,12 @@ jobs:
           cache: 'pnpm'
       - uses: namespacelabs/nscloud-setup@v0
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build workspace packages
+        # The @benchsdk/* packages are built from source and dist/ is not
+        # committed. Build them in topological order so dependents like
+        # @benchsdk/client can resolve @benchsdk/worker during their own build.
+        run: pnpm -r --filter './packages/**' run build
       - name: Clear stale results from checkout
         run: rm -rf results/browser-concurrent/
       - name: Run browser concurrent benchmark
@@ -200,7 +205,12 @@ jobs:
           cache: 'pnpm'
       - uses: namespacelabs/nscloud-setup@v0
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build workspace packages
+        # The @benchsdk/* packages are built from source and dist/ is not
+        # committed. Build them in topological order so dependents like
+        # @benchsdk/client can resolve @benchsdk/worker during their own build.
+        run: pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -112,10 +112,15 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+      - name: Build workspace packages
+        # The @benchsdk/* packages are built from source and dist/ is not
+        # committed. Build them in topological order so dependents like
+        # @benchsdk/client can resolve @benchsdk/worker during their own build.
+        run: pnpm -r --filter './packages/**' run build
       - name: Clear stale results from checkout
         run: rm -rf results/browser-throughput/
       - name: Run browser throughput benchmark
@@ -163,10 +168,15 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+      - name: Build workspace packages
+        # The @benchsdk/* packages are built from source and dist/ is not
+        # committed. Build them in topological order so dependents like
+        # @benchsdk/client can resolve @benchsdk/worker during their own build.
+        run: pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -78,10 +78,15 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+      - name: Build workspace packages
+        # The @benchsdk/* packages are built from source and dist/ is not
+        # committed. Build them in topological order so dependents like
+        # @benchsdk/client can resolve @benchsdk/worker during their own build.
+        run: pnpm -r --filter './packages/**' run build
       - name: Clear stale results from checkout
         run: rm -rf results/storage/
       - name: Run storage benchmark
@@ -131,10 +136,15 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+      - name: Build workspace packages
+        # The @benchsdk/* packages are built from source and dist/ is not
+        # committed. Build them in topological order so dependents like
+        # @benchsdk/client can resolve @benchsdk/worker during their own build.
+        run: pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/storage-concurrency-benchmarks.yml
+++ b/.github/workflows/storage-concurrency-benchmarks.yml
@@ -60,7 +60,12 @@ jobs:
           cache: 'pnpm'
       - uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0.0.12
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build workspace packages
+        # The @benchsdk/* packages are built from source and dist/ is not
+        # committed. Build them in topological order so dependents like
+        # @benchsdk/client can resolve @benchsdk/worker during their own build.
+        run: pnpm -r --filter './packages/**' run build
       - name: Run storage concurrency benchmark
         env:
           STORAGE_CONCURRENCY_PROVIDER: ${{ inputs.provider || '' }}
@@ -106,7 +111,12 @@ jobs:
           node-version: 24
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build workspace packages
+        # The @benchsdk/* packages are built from source and dist/ is not
+        # committed. Build them in topological order so dependents like
+        # @benchsdk/client can resolve @benchsdk/worker during their own build.
+        run: pnpm -r --filter './packages/**' run build
       - name: Download combined results
         uses: actions/download-artifact@v4
         continue-on-error: true


### PR DESCRIPTION
## Summary

Scheduled benchmark runs (browser and storage) failed during `Install dependencies` because `pnpm update`/`pnpm install` triggered workspace `prepare` scripts concurrently. `packages/benchsdk` (`@benchsdk/client`) depends on `packages/benchsdk-worker` (`@benchsdk/worker`), but the worker package's `dist/` had not been built before the client's DTS build started. Since `dist/` is gitignored, this was a latent build-order bug.

Failing runs:
- Browser: https://github.com/computesdk/benchmarks/actions/runs/33862576772
- Storage: https://github.com/computesdk/benchmarks/actions/runs/33866285569/job/101001781323

The AI gateway workflow already solved this by adding `--ignore-scripts` to `pnpm update`/`pnpm install` and then explicitly building workspace packages in topological order. This PR applies the same pattern to all affected benchmark workflows:

```yaml
- name: Install dependencies
  run: |
    if [ "${{ github.event_name }}" = "schedule" ]; then
      pnpm update --ignore-scripts
    else
      pnpm install --frozen-lockfile --ignore-scripts
    fi
- name: Build workspace packages
  run: pnpm -r --filter './packages/**' run build
```

## Files changed

- `.github/workflows/browser-benchmarks.yml` — bench and collect jobs
- `.github/workflows/browser-concurrent-benchmarks.yml` — bench and collect jobs
- `.github/workflows/browser-throughput-benchmarks.yml` — bench and collect jobs
- `.github/workflows/storage-benchmarks.yml` — bench and collect jobs
- `.github/workflows/storage-concurrency-benchmarks.yml` — bench and collect jobs

These workflows all run the `packages/benchsdk-runner/dist/bin.js` binary, which does not exist until `@benchsdk/runner` is built.

Link to Devin session: https://app.devin.ai/sessions/6e7be5aa14c549e58eb9b6cfd6232223
Open in Devin Desktop: https://app.devin.ai/desktop/session/6e7be5aa14c549e58eb9b6cfd6232223?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->