### PR TITLE
fix(workflows): align manual ai-gateway benchmark default iterations with cron

### DIFF
--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -25,7 +25,7 @@ on:
           - gemini
           - kimi
       iterations:
-        description: 'Cold + warm iterations per gateway (leave empty for family default or 30)'
+        description: 'Cold + warm iterations per gateway (leave empty for family default or 50)'
         required: false
         default: ''
       provider:
@@ -161,7 +161,7 @@ jobs:
           elif [ -n "$FAMILY_ITERATIONS" ]; then
             ITERATIONS="$FAMILY_ITERATIONS"
           else
-            ITERATIONS="30"
+            ITERATIONS="50"
           fi
 
           provider_args=()


### PR DESCRIPTION
## Summary

A manual `workflow_dispatch` run of the AI Gateway benchmark with the **Iterations** input left empty did not match the scheduled cron defaults. The workflow fell through to a hardcoded `30` iterations for families without an explicit `matrix.family.iterations` value, while cron runs `50` for those same families (Kimi stays at `25` in both cases).

## What changed

- Updated the shell fallback in `ai-gateway-benchmarks.yml` so a manual run with no explicit iteration count uses `50` instead of `30`:

  ```yaml
  else
    ITERATIONS="50"
  fi
  ```

- Updated the `iterations` input description to say "family default or 50" instead of "family default or 30".

This makes a default manual run match the cron schedule (Kimi 25, all others 50) unless the user explicitly overrides the iteration count.

Link to Devin session: https://app.devin.ai/sessions/0c860a36c6704d888ead19469152c0e1
Open in Devin Desktop: https://app.devin.ai/desktop/session/0c860a36c6704d888ead19469152c0e1?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->