### PR TITLE
fix(workflows): use recursive pnpm update for scheduled benchmark runs

### DIFF
--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update --ignore-scripts
+            pnpm -r update --ignore-scripts
           else
             pnpm install --frozen-lockfile --ignore-scripts
           fi

--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update --ignore-scripts
+            pnpm -r update --ignore-scripts
           else
             pnpm install --frozen-lockfile --ignore-scripts
           fi
@@ -114,7 +114,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update --ignore-scripts
+            pnpm -r update --ignore-scripts
           else
             pnpm install --frozen-lockfile --ignore-scripts
           fi

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update --ignore-scripts
+            pnpm -r update --ignore-scripts
           else
             pnpm install --frozen-lockfile --ignore-scripts
           fi
@@ -168,7 +168,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update --ignore-scripts
+            pnpm -r update --ignore-scripts
           else
             pnpm install --frozen-lockfile --ignore-scripts
           fi

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update --ignore-scripts
+            pnpm -r update --ignore-scripts
           else
             pnpm install --frozen-lockfile --ignore-scripts
           fi
@@ -136,7 +136,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update --ignore-scripts
+            pnpm -r update --ignore-scripts
           else
             pnpm install --frozen-lockfile --ignore-scripts
           fi


### PR DESCRIPTION
## Summary

The scheduled benchmark workflows failed during the `Build workspace packages` step because `packages/create-bench` (and other workspace packages not in the root dependency graph) had no `node_modules` and therefore no `tsup`.

The scheduled install step used `pnpm update --ignore-scripts` without `-r`. In a pnpm workspace that only installs the root package and its dependency graph, so dev dependencies of workspace packages like `create-bench`, `@benchsdk/cli`, and `@benchsdk/worker` were not installed. The following `pnpm -r --filter './packages/**' run build` then failed with `tsup: command not found`.

Change the scheduled install command to `pnpm -r update --ignore-scripts` in the affected workflows so all workspace packages are installed before the recursive build.

### Changed files

- `.github/workflows/ai-gateway-benchmarks.yml`
- `.github/workflows/browser-benchmarks.yml`
- `.github/workflows/browser-throughput-benchmarks.yml`
- `.github/workflows/storage-benchmarks.yml`

### Notes

The `Failed to create bin at node_modules/.bin/bench` warning is a side effect of `benchsdk-runner` not being built yet; once the workspace build succeeds, `dist/bin.cjs` is generated and that warning goes away.

Link to Devin session: https://app.devin.ai/sessions/5bbbb779ddee42a1a683462e97496c34
Open in Devin Desktop: https://app.devin.ai/desktop/session/5bbbb779ddee42a1a683462e97496c34?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->