### PR TITLE
fix(workflows): build workspace packages before sandbox and snapshot-fork benchmark runs

### DIFF
--- a/.github/workflows/sandbox-capabilities.yml
+++ b/.github/workflows/sandbox-capabilities.yml
@@ -90,7 +90,9 @@ jobs:
         if: env.SHOULD_RUN == 'true'
       - name: Install dependencies
         if: env.SHOULD_RUN == 'true'
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm -r --filter './packages/**' run build
       - name: Clear stale results from checkout
         if: env.SHOULD_RUN == 'true'
         run: rm -rf results/
@@ -178,7 +180,9 @@ jobs:
           cache: 'pnpm'
       - uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0.0.12
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm -r --filter './packages/**' run build
       - name: Download all results
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/sandbox-cpu-node.yml
+++ b/.github/workflows/sandbox-cpu-node.yml
@@ -90,10 +90,11 @@ jobs:
           (github.event.inputs.provider == '' || contains(format(',{0},', github.event.inputs.provider), format(',{0},', matrix.provider)))
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build bundles
         if: |
           github.event_name != 'workflow_dispatch' ||
@@ -147,10 +148,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -92,10 +92,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build E2B template with 8 vCPU / 16 GiB
         if: matrix.provider == 'e2b'
         run: |
@@ -164,10 +165,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-disk.yml
+++ b/.github/workflows/sandbox-disk.yml
@@ -90,10 +90,11 @@ jobs:
           (github.event.inputs.provider == '' || contains(format(',{0},', github.event.inputs.provider), format(',{0},', matrix.provider)))
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build bundles
         if: |
           github.event_name != 'workflow_dispatch' ||
@@ -147,10 +148,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-dns.yml
+++ b/.github/workflows/sandbox-dns.yml
@@ -79,10 +79,11 @@ jobs:
           (github.event.inputs.provider == '' || contains(format(',{0},', github.event.inputs.provider), format(',{0},', matrix.provider)))
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build bundles
         if: |
           github.event_name != 'workflow_dispatch' ||
@@ -136,10 +137,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-download.yml
+++ b/.github/workflows/sandbox-download.yml
@@ -79,10 +79,11 @@ jobs:
           (github.event.inputs.provider == '' || contains(format(',{0},', github.event.inputs.provider), format(',{0},', matrix.provider)))
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build bundles
         if: |
           github.event_name != 'workflow_dispatch' ||
@@ -136,10 +137,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-latency.yml
+++ b/.github/workflows/sandbox-latency.yml
@@ -79,10 +79,11 @@ jobs:
           (github.event.inputs.provider == '' || contains(format(',{0},', github.event.inputs.provider), format(',{0},', matrix.provider)))
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build bundles
         if: |
           github.event_name != 'workflow_dispatch' ||
@@ -136,10 +137,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-memory.yml
+++ b/.github/workflows/sandbox-memory.yml
@@ -90,10 +90,11 @@ jobs:
           (github.event.inputs.provider == '' || contains(format(',{0},', github.event.inputs.provider), format(',{0},', matrix.provider)))
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build bundles
         if: |
           github.event_name != 'workflow_dispatch' ||
@@ -147,10 +148,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-network-localhost.yml
+++ b/.github/workflows/sandbox-network-localhost.yml
@@ -90,10 +90,11 @@ jobs:
           (github.event.inputs.provider == '' || contains(format(',{0},', github.event.inputs.provider), format(',{0},', matrix.provider)))
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build bundles
         if: |
           github.event_name != 'workflow_dispatch' ||
@@ -147,10 +148,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-network-wan.yml
+++ b/.github/workflows/sandbox-network-wan.yml
@@ -90,10 +90,11 @@ jobs:
           (github.event.inputs.provider == '' || contains(format(',{0},', github.event.inputs.provider), format(',{0},', matrix.provider)))
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build bundles
         if: |
           github.event_name != 'workflow_dispatch' ||
@@ -147,10 +148,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-pgbench.yml
+++ b/.github/workflows/sandbox-pgbench.yml
@@ -90,10 +90,11 @@ jobs:
           (github.event.inputs.provider == '' || contains(format(',{0},', github.event.inputs.provider), format(',{0},', matrix.provider)))
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build bundles
         if: |
           github.event_name != 'workflow_dispatch' ||
@@ -147,10 +148,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-realworld.yml
+++ b/.github/workflows/sandbox-realworld.yml
@@ -79,10 +79,11 @@ jobs:
           (github.event.inputs.provider == '' || contains(format(',{0},', github.event.inputs.provider), format(',{0},', matrix.provider)))
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build bundles
         if: |
           github.event_name != 'workflow_dispatch' ||
@@ -136,10 +137,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-system.yml
+++ b/.github/workflows/sandbox-system.yml
@@ -90,10 +90,11 @@ jobs:
           (github.event.inputs.provider == '' || contains(format(',{0},', github.event.inputs.provider), format(',{0},', matrix.provider)))
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Build bundles
         if: |
           github.event_name != 'workflow_dispatch' ||
@@ -147,10 +148,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = 'schedule' ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sandbox-tti-benchmarks.yml
+++ b/.github/workflows/sandbox-tti-benchmarks.yml
@@ -106,10 +106,11 @@ jobs:
         if: env.SHOULD_RUN == 'true'
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Clear stale results from checkout
         if: env.SHOULD_RUN == 'true'
         run: rm -rf results/
@@ -162,10 +163,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/snapshot-fork-benchmarks.yml
+++ b/.github/workflows/snapshot-fork-benchmarks.yml
@@ -79,10 +79,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Clear stale results from checkout
         run: rm -rf results/snapshot-fork/
       - name: Run snapshot/fork test
@@ -131,10 +132,11 @@ jobs:
       - name: Install dependencies
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            pnpm update
+            pnpm -r update --ignore-scripts
           else
-            pnpm install --frozen-lockfile
+            pnpm install --frozen-lockfile --ignore-scripts
           fi
+          pnpm -r --filter './packages/**' run build
       - name: Download snapshot/fork artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

The sandbox benchmark workflows (and `snapshot-fork-benchmarks.yml`) were installing workspace dependencies without `--ignore-scripts`, which caused `prepare` scripts in the `@benchsdk/*` packages to run concurrently. Dependent packages such as `@benchsdk/client` built their DTS before `@benchsdk/worker` had produced `dist/index.d.ts`, yielding:

```
packages/benchsdk prepare: src/index.ts(87,8): error TS2307: Cannot find module '@benchsdk/worker' or its corresponding type declarations.
```

This mirrors the fix already applied to the browser, storage, and AI-gateway benchmark workflows. Each affected `Install dependencies` step now looks like:

```yaml
run: |
  if [ "${{ github.event_name }}" = "schedule" ]; then
    pnpm -r update --ignore-scripts
  else
    pnpm install --frozen-lockfile --ignore-scripts
  fi
  pnpm -r --filter './packages/**' run build
```

`--ignore-scripts` prevents the package `prepare`/`build` race, and the explicit `pnpm -r --filter './packages/**' run build` builds the workspace packages in topological order so dependents like `@benchsdk/client` can resolve `@benchsdk/worker` during their own build.

Link to Devin session: https://app.devin.ai/sessions/10a5c53f61f744468412dc6bd848bc0f
Open in Devin Desktop: https://app.devin.ai/desktop/session/10a5c53f61f744468412dc6bd848bc0f?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->