### PR TITLE
chore(deps): bump @computesdk/archil to ^0.4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@benchsdk/runner": "workspace:*",
     "@codesandbox/sdk": "^2.4.2",
     "@computesdk/anchorbrowser": "^0.2.7",
-    "@computesdk/archil": "^0.4.9",
+    "@computesdk/archil": "^0.4.10",
     "@computesdk/arker": "^0.1.4",
     "@computesdk/beam": "^0.3.2",
     "@computesdk/blaxel": "^1.6.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^0.2.7
         version: 0.2.7(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@computesdk/archil':
-        specifier: ^0.4.9
-        version: 0.4.9
+        specifier: ^0.4.10
+        version: 0.4.10
       '@computesdk/arker':
         specifier: ^0.1.4
         version: 0.1.4(@computesdk/daytona@1.7.33(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(@computesdk/e2b@1.7.53)(@computesdk/modal@1.9.5)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -730,8 +730,8 @@ packages:
   '@computesdk/anchorbrowser@0.2.7':
     resolution: {integrity: sha512-eWZAAdk9OsDf7XKV7exCoqZvxESd4hSpgrNIGsm6cxXTGRvv1L95siWOmVMv8MLh7Xk9CoMTaFRBIW39LHldPg==}
 
-  '@computesdk/archil@0.4.9':
-    resolution: {integrity: sha512-EcwrPbLhaGa0eKo+0XZXwKmIJe9I18lfG5fODWxW5wRKUXRZW2psDL5jdqzurW567zNiQylB7nXRXr4u/e2j0g==}
+  '@computesdk/archil@0.4.10':
+    resolution: {integrity: sha512-HO5TvF7tITKwRnWC3wQZixOdzkHUsFEjSC81OSGC4t6r2ggVmrfmitdZRgo4+2XtyGnCh5YRq96Snfe8CSI7Ig==}
 
   '@computesdk/arker@0.1.4':
     resolution: {integrity: sha512-57CWI0AWy3qp9ERSpPcuDK62lst7UIN+GOI+WztsQOQUWJsgfzKn8iN6RknryLvw6o9Rxz7DTGM+Ekxqy8Ze9Q==}
@@ -6285,7 +6285,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@computesdk/archil@0.4.9':
+  '@computesdk/archil@0.4.10':
     dependencies:
       '@computesdk/provider': 2.1.5
       computesdk: 4.1.4


### PR DESCRIPTION
## Summary

Bumps `@computesdk/archil` from `^0.4.9` to `^0.4.10` and updates `pnpm-lock.yaml` accordingly. Typecheck passes.

Link to Devin session: https://app.devin.ai/sessions/8c17033ba86747aea1460da13f8a957c
Open in Devin Desktop: https://app.devin.ai/desktop/session/8c17033ba86747aea1460da13f8a957c?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->