### PR TITLE
fix(benchsdk): resolve display review findings on benchmark config

### DIFF
--- a/.changeset/benchsdk-display-review-fixes.md
+++ b/.changeset/benchsdk-display-review-fixes.md
@@ -1,0 +1,8 @@
+---
+"@benchsdk/runner": patch
+---
+
+Resolve two Devin Review findings for `BenchmarkConfig.display` support.
+
+- `score()` now resolves a missing `ScoringSpec` metric unit from the matching `display.metrics` entry, so `onScore` callbacks that omit `unit` still produce correct units in run summaries.
+- `defineBenchmarkConfig` rejects unknown keys in `display`, `display.metrics`, `display.steps`, and `display.overview`.

--- a/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
@@ -276,6 +276,50 @@ describe('defineBenchmarkConfig', () => {
     });
     expect(config.display?.overview?.defaultMetric).toBe('anything');
   });
+
+  it('rejects unknown keys in display', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: { extra: 'value' } as any,
+      }),
+    ).toThrow("display contains unexpected key: 'extra'");
+  });
+
+  it('rejects unknown keys in display.metrics', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: { metrics: [{ key: 'x', label: 'X', extra: 1 }] as any },
+      }),
+    ).toThrow("display.metrics[0] contains unexpected key: 'extra'");
+  });
+
+  it('rejects unknown keys in display.steps', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: { steps: [{ key: 'x', label: 'X', extra: 1 }] as any },
+      }),
+    ).toThrow("display.steps[0] contains unexpected key: 'extra'");
+  });
+
+  it('rejects unknown keys in display.overview', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: { overview: { defaultMetric: 'x', extra: true } as any },
+      }),
+    ).toThrow("display.overview contains unexpected key: 'extra'");
+  });
 });
 
 describe('defineTask', () => {

--- a/packages/benchsdk-runner/src/__tests__/scoring.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/scoring.test.ts
@@ -129,6 +129,46 @@ describe('score with groupBy', () => {
   });
 });
 
+describe('score resolves missing metric unit from display.metrics', () => {
+  function record(taskIndex: number, status: string, data: Record<string, unknown>): TaskResultRecord {
+    return { taskIndex, status, data: data as TaskResultRecord['data'] };
+  }
+
+  it('fills in the unit from display.metrics when the scoring metric omits it', () => {
+    const spec: ScoringSpec = {
+      metrics: [lowerIsBetter('durationMs', { ceiling: 500, weights: { median: 1, p95: 0, p99: 0 } })],
+    };
+    const outcome = {
+      participants: [
+        {
+          participant: 'demo',
+          records: [record(0, 'success', { durationMs: 100 })],
+        },
+      ],
+    } as unknown as BenchmarkRunOutcome;
+
+    const results = score(outcome, spec, [{ key: 'durationMs', label: 'Duration', unit: 'ms' }]);
+    expect(results[0].metrics[0]).toMatchObject({ name: 'durationMs', unit: 'ms', median: 100 });
+  });
+
+  it('prefers the unit declared in the scoring metric over display.metrics', () => {
+    const spec: ScoringSpec = {
+      metrics: [lowerIsBetter('durationMs', { ceiling: 500, unit: 's', weights: { median: 1, p95: 0, p99: 0 } })],
+    };
+    const outcome = {
+      participants: [
+        {
+          participant: 'demo',
+          records: [record(0, 'success', { durationMs: 100 })],
+        },
+      ],
+    } as unknown as BenchmarkRunOutcome;
+
+    const results = score(outcome, spec, [{ key: 'durationMs', label: 'Duration', unit: 'ms' }]);
+    expect(results[0].metrics[0].unit).toBe('s');
+  });
+});
+
 describe('scoringConfigToSpec', () => {
   it('derives unit from display.metrics when omitted in scoring.metrics', () => {
     const spec = scoringConfigToSpec(

--- a/packages/benchsdk-runner/src/__tests__/scoring.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/scoring.test.ts
@@ -151,6 +151,23 @@ describe('score resolves missing metric unit from display.metrics', () => {
     expect(results[0].metrics[0]).toMatchObject({ name: 'durationMs', unit: 'ms', median: 100 });
   });
 
+  it('resolves the unit from the aliased data key when metric.value differs from name', () => {
+    const spec: ScoringSpec = {
+      metrics: [lowerIsBetter('latency', { value: 'durationMs', ceiling: 500, weights: { median: 1, p95: 0, p99: 0 } })],
+    };
+    const outcome = {
+      participants: [
+        {
+          participant: 'demo',
+          records: [record(0, 'success', { durationMs: 100 })],
+        },
+      ],
+    } as unknown as BenchmarkRunOutcome;
+
+    const results = score(outcome, spec, [{ key: 'durationMs', label: 'Duration', unit: 'ms' }]);
+    expect(results[0].metrics[0]).toMatchObject({ name: 'latency', unit: 'ms', median: 100 });
+  });
+
   it('prefers the unit declared in the scoring metric over display.metrics', () => {
     const spec: ScoringSpec = {
       metrics: [lowerIsBetter('durationMs', { ceiling: 500, unit: 's', weights: { median: 1, p95: 0, p99: 0 } })],

--- a/packages/benchsdk-runner/src/bench-config.ts
+++ b/packages/benchsdk-runner/src/bench-config.ts
@@ -329,6 +329,14 @@ function assertNonEmptyString(value: unknown, field: string): string {
   return value;
 }
 
+function assertOnlyAllowedKeys(value: Record<string, unknown>, allowed: readonly string[], field: string): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) {
+      throw new Error(`${field} contains unexpected key: '${key}'`);
+    }
+  }
+}
+
 function assertPositiveInt(value: number | undefined, field: string): void {
   if (value === undefined) return;
   if (!Number.isInteger(value) || value < 1) {
@@ -483,6 +491,7 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
     if (typeof config.display !== 'object' || config.display === null || Array.isArray(config.display)) {
       throw new Error('display must be an object');
     }
+    assertOnlyAllowedKeys(config.display as unknown as Record<string, unknown>, ['description', 'metrics', 'steps', 'overview'], 'display');
     if (config.display.description !== undefined && typeof config.display.description !== 'string') {
       throw new Error('display.description must be a string');
     }
@@ -496,6 +505,7 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
         if (metric === null || typeof metric !== 'object' || Array.isArray(metric)) {
           throw new Error(`display.metrics[${i}] must be an object`);
         }
+        assertOnlyAllowedKeys(metric as unknown as Record<string, unknown>, ['key', 'label', 'unit', 'direction', 'decimals', 'order'], `display.metrics[${i}]`);
         const key = assertNonEmptyString(metric.key, `display.metrics[${i}].key`);
         if (displayMetricKeys.has(key)) {
           throw new Error(`duplicate display metric key: ${key}`);
@@ -526,6 +536,7 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
         if (step === null || typeof step !== 'object' || Array.isArray(step)) {
           throw new Error(`display.steps[${i}] must be an object`);
         }
+        assertOnlyAllowedKeys(step as unknown as Record<string, unknown>, ['key', 'label', 'order'], `display.steps[${i}]`);
         const key = assertNonEmptyString(step.key, `display.steps[${i}].key`);
         if (seenStepKeys.has(key)) {
           throw new Error(`duplicate display step key: ${key}`);
@@ -541,6 +552,7 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
       if (typeof config.display.overview !== 'object' || config.display.overview === null || Array.isArray(config.display.overview)) {
         throw new Error('display.overview must be an object');
       }
+      assertOnlyAllowedKeys(config.display.overview as unknown as Record<string, unknown>, ['defaultMetric', 'defaultLayout'], 'display.overview');
       const { defaultMetric, defaultLayout } = config.display.overview;
       if (defaultMetric !== undefined) {
         const metric = assertNonEmptyString(defaultMetric, 'display.overview.defaultMetric');

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -661,7 +661,7 @@ export async function runBenchmark<T extends BaseParticipant>(
       const spec = config.onScore
         ? await config.onScore(lowerIsBetter, higherIsBetter)
         : scoringConfigToSpec(config.scoring!, config.dimensions, config.display);
-      const scored = score(outcome, spec);
+      const scored = score(outcome, spec, config.display?.metrics);
       const run = {
         gitSha: process.env.GITHUB_SHA ?? getGitSha(),
         gitRef: process.env.GITHUB_REF_NAME ?? process.env.GITHUB_REF ?? getGitRef(),

--- a/packages/benchsdk-runner/src/scoring.ts
+++ b/packages/benchsdk-runner/src/scoring.ts
@@ -230,6 +230,7 @@ function scoreGroup(
   groupKey: string | undefined,
   groupValue: unknown,
   provider: string,
+  unitByMetric: Map<string, string | undefined>,
 ): BenchmarkScoreResult {
   const successFilter = spec.success ?? ((r: TaskResultRecord) => r.status === 'success');
   const passing = records.filter(successFilter);
@@ -253,7 +254,8 @@ function scoreGroup(
       metric.weights.p99 * scoreStat(p99, metric);
     metricScoresSum += metricScore;
 
-    metrics.push({ name: metric.name, unit: metric.unit ?? '', median, p95, p99 });
+    const unit = metric.unit ?? unitByMetric.get(metric.name) ?? '';
+    metrics.push({ name: metric.name, unit, median, p95, p99 });
   }
 
   const compositeScore = successRate === 0 ? 0 : Math.round(metricScoresSum * successRate * 100) / 100;
@@ -273,9 +275,14 @@ function scoreGroup(
   };
 }
 
-export function score(outcome: BenchmarkRunOutcome, spec: ScoringSpec): BenchmarkScoreResult[] {
+export function score(
+  outcome: BenchmarkRunOutcome,
+  spec: ScoringSpec,
+  displayMetrics?: { key: string; unit?: string }[],
+): BenchmarkScoreResult[] {
   validateScoringSpec(spec);
   const baseDimensions = toJsonObject(spec.dimensions ?? {});
+  const unitByMetric = new Map(displayMetrics?.map((m) => [m.key, m.unit]));
   const results: BenchmarkScoreResult[] = [];
 
   for (const { participant, records } of outcome.participants) {
@@ -286,7 +293,7 @@ export function score(outcome: BenchmarkRunOutcome, spec: ScoringSpec): Benchmar
       : [{ value: undefined, records }];
 
     for (const group of groups) {
-      results.push(scoreGroup(group.records, spec, baseDimensions, spec.groupBy, group.value, participant));
+      results.push(scoreGroup(group.records, spec, baseDimensions, spec.groupBy, group.value, participant, unitByMetric));
     }
   }
 

--- a/packages/benchsdk-runner/src/scoring.ts
+++ b/packages/benchsdk-runner/src/scoring.ts
@@ -254,7 +254,8 @@ function scoreGroup(
       metric.weights.p99 * scoreStat(p99, metric);
     metricScoresSum += metricScore;
 
-    const unit = metric.unit ?? unitByMetric.get(metric.name) ?? '';
+    const unitKey = typeof metric.value === 'string' ? metric.value : metric.name;
+    const unit = metric.unit ?? unitByMetric.get(unitKey) ?? '';
     metrics.push({ name: metric.name, unit, median, p95, p99 });
   }
 


### PR DESCRIPTION
## Summary

Fixes two Devin Review findings from `computesdk/benchmarks#389`:

1. **Callback scoring now preserves metric units** — `score()` accepts an optional `displayMetrics` lookup and fills in a missing `ScoringSpec` metric unit from `display.metrics` before returning `BenchmarkScoreResult`.

   ```ts
   // examples/09-on-complete.bench.ts no longer needs unit in lowerIsBetter()
   score(outcome, spec, config.display?.metrics)
   ```

2. **Display manifests reject unknown keys** — `defineBenchmarkConfig` now throws if `display`, `display.metrics[i]`, `display.steps[i]`, or `display.overview` contain fields outside the supported schema.

Also adds unit tests for both behaviors and a patch changeset.

Link to Devin session: https://app.devin.ai/sessions/a45e3a08012c47e989ccfc4c055275ac
Open in Devin Desktop: https://app.devin.ai/desktop/session/a45e3a08012c47e989ccfc4c055275ac?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->