### PR TITLE
Remove display.description and set overview.defaultMetric to compositeScore

### DIFF
--- a/benchmarks/ai-gateway/ai-gateway-gemini.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway-gemini.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * AI Gateway benchmark — Gemini family. Same methodology, task, CLI flags,
  * and request configuration as `ai-gateway.bench.ts` (see that file and
@@ -38,7 +39,6 @@ export const config = defineBenchmarkConfig({
   concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
   display: {
-    description: 'AI gateway cold/warm latency and token throughput.',
     metrics: [
       { key: 'coldE2eMs', label: 'Cold end-to-end', unit: 'ms', direction: 'lower-better', decimals: 0 },
       { key: 'warmTtftMs', label: 'Warm time to first token', unit: 'ms', direction: 'lower-better', decimals: 0 },
@@ -52,7 +52,7 @@ export const config = defineBenchmarkConfig({
       { key: 'ttfb', label: 'TTFB' },
       { key: 'ttft', label: 'TTFT' },
     ],
-    overview: { defaultMetric: 'coldE2eMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/benchmarks/ai-gateway/ai-gateway-kimi.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway-kimi.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * AI Gateway benchmark — Kimi family. Same methodology, task, and CLI flags
  * as `ai-gateway.bench.ts` (see that file and `shared-task.ts` for the full
@@ -55,7 +56,6 @@ export const config = defineBenchmarkConfig({
   concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
   display: {
-    description: 'AI gateway cold/warm latency and token throughput.',
     metrics: [
       { key: 'coldE2eMs', label: 'Cold end-to-end', unit: 'ms', direction: 'lower-better', decimals: 0 },
       { key: 'warmTtftMs', label: 'Warm time to first token', unit: 'ms', direction: 'lower-better', decimals: 0 },
@@ -69,7 +69,7 @@ export const config = defineBenchmarkConfig({
       { key: 'ttfb', label: 'TTFB' },
       { key: 'ttft', label: 'TTFT' },
     ],
-    overview: { defaultMetric: 'coldE2eMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/benchmarks/ai-gateway/ai-gateway-openai.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway-openai.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * AI Gateway benchmark — OpenAI family. Same methodology, task, CLI flags,
  * and request configuration (`max_tokens: 200`, `temperature: 0`) as
@@ -38,7 +39,6 @@ export const config = defineBenchmarkConfig({
   concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
   display: {
-    description: 'AI gateway cold/warm latency and token throughput.',
     metrics: [
       { key: 'coldE2eMs', label: 'Cold end-to-end', unit: 'ms', direction: 'lower-better', decimals: 0 },
       { key: 'warmTtftMs', label: 'Warm time to first token', unit: 'ms', direction: 'lower-better', decimals: 0 },
@@ -52,7 +52,7 @@ export const config = defineBenchmarkConfig({
       { key: 'ttfb', label: 'TTFB' },
       { key: 'ttft', label: 'TTFT' },
     ],
-    overview: { defaultMetric: 'coldE2eMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/benchmarks/ai-gateway/ai-gateway.bench.ts
+++ b/benchmarks/ai-gateway/ai-gateway.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * AI Gateway benchmark — Anthropic family. Declarative — exports `config` +
  * `task`; `bench run` owns the entrypoint. Configured with `groupBy:
@@ -58,7 +59,6 @@ export const config = defineBenchmarkConfig({
   concurrency: providers.length,
   customCliFlags: ['--ai-gateway-iterations-cold', '--ai-gateway-iterations-warm'],
   display: {
-    description: 'AI gateway cold/warm latency and token throughput.',
     metrics: [
       { key: 'coldE2eMs', label: 'Cold end-to-end', unit: 'ms', direction: 'lower-better', decimals: 0 },
       { key: 'warmTtftMs', label: 'Warm time to first token', unit: 'ms', direction: 'lower-better', decimals: 0 },
@@ -72,7 +72,7 @@ export const config = defineBenchmarkConfig({
       { key: 'ttfb', label: 'TTFB' },
       { key: 'ttft', label: 'TTFT' },
     ],
-    overview: { defaultMetric: 'coldE2eMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/benchmarks/browser/browser-throughput.bench.ts
+++ b/benchmarks/browser/browser-throughput.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Browser throughput benchmark: each session runs a fixed action loop; sessions
  * are interleaved across providers (groupBy 'round') so every provider runs its
@@ -36,7 +37,6 @@ export const config = defineBenchmarkConfig({
   groupBy: 'round',
   participants: throughputProviders,
   display: {
-    description: 'Browser session throughput and action rate.',
     metrics: [
       { key: 'actionsPerSecond', label: 'Actions/s', unit: '/s', direction: 'higher-better', decimals: 2 },
       { key: 'actionsCompleted', label: 'Actions completed', direction: 'higher-better', decimals: 0 },
@@ -53,7 +53,7 @@ export const config = defineBenchmarkConfig({
       { key: 'actions', label: 'Actions' },
       { key: 'release', label: 'Release session' },
     ],
-    overview: { defaultMetric: 'actionsPerSecond', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     // A session that dropped actions isn't comparable to one that completed

--- a/benchmarks/browser/browser.bench.ts
+++ b/benchmarks/browser/browser.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Browser lifecycle benchmark: `iterations` create→connect→navigate→release
  * cycles per provider (concurrency 1 = sequential). Declarative — exports
@@ -27,7 +28,6 @@ export const config = defineBenchmarkConfig({
   concurrency: 1,
   participants: browserProviders,
   display: {
-    description: 'Browser create→connect→navigate→release lifecycle latency.',
     metrics: [
       { key: 'totalMs', label: 'Total lifecycle', unit: 'ms', direction: 'lower-better', decimals: 0 },
       { key: 'createMs', label: 'Session creation', unit: 'ms', direction: 'lower-better', decimals: 0 },
@@ -41,7 +41,7 @@ export const config = defineBenchmarkConfig({
       { key: 'navigate', label: 'Navigate page' },
       { key: 'release', label: 'Release session' },
     ],
-    overview: { defaultMetric: 'totalMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/benchmarks/reliability/sandbox-opencode.bench.ts
+++ b/benchmarks/reliability/sandbox-opencode.bench.ts
@@ -1,3 +1,4 @@
+
 import '../src/env.js';
 import { defineBenchmarkConfig, defineTask, TaskError } from '@benchsdk/runner';
 import { withTimeout } from '../src/util/timeout.js';
@@ -20,13 +21,14 @@ export const config = defineBenchmarkConfig({
   participants: providers,
   defaultProviders: ['tensorlake'],
   display: {
-    description: 'Tensorlake OpenCode installation and run reliability.',
     steps: [
       { key: 'create', label: 'Create sandbox' },
       { key: 'install', label: 'Install OpenCode' },
       { key: 'run', label: 'Run OpenCode' },
       { key: 'destroy', label: 'Destroy sandbox' },
     ],
+  
+    overview: { defaultMetric: 'compositeScore' },
   },
 });
 

--- a/benchmarks/reliability/sandbox-opencode.bench.ts
+++ b/benchmarks/reliability/sandbox-opencode.bench.ts
@@ -28,7 +28,7 @@ export const config = defineBenchmarkConfig({
       { key: 'destroy', label: 'Destroy sandbox' },
     ],
   
-    overview: { defaultMetric: 'compositeScore' },
+    overview: { defaultMetric: 'task' },
   },
 });
 

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Dax benchmark: runs the OpenCode build (scripts/dax-benchmark.sh) inside a
  * freshly created sandbox once per iteration and measures its build phases
@@ -44,7 +45,6 @@ export const config = defineBenchmarkConfig({
   defaultProviders: ['e2b', 'modal', 'tensorlake'],
   participants: providers,
   display: {
-    description: 'OpenCode build lifecycle latency per phase.',
     metrics: [
       { key: 'totalMs', label: 'Total build time', unit: 'ms', direction: 'lower-better', decimals: 0 },
       { key: 'prepareMs', label: 'Prepare', unit: 'ms', direction: 'lower-better', decimals: 0 },
@@ -72,7 +72,7 @@ export const config = defineBenchmarkConfig({
       { key: 'install', label: 'Install' },
       { key: 'typecheck', label: 'Typecheck' },
     ],
-    overview: { defaultMetric: 'totalMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   onComplete: (outcome) =>
     writeDaxLegacyResults(outcome.participants, {

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -72,7 +72,7 @@ export const config = defineBenchmarkConfig({
       { key: 'install', label: 'Install' },
       { key: 'typecheck', label: 'Typecheck' },
     ],
-    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'totalMs', defaultLayout: 'ranking' },
   },
   onComplete: (outcome) =>
     writeDaxLegacyResults(outcome.participants, {

--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Sandbox time-to-interactive benchmark. TTI = sandbox create through the
  * first command (`node -v`) succeeding, excluding destroy. Declarative —
@@ -40,7 +41,6 @@ export const config = defineBenchmarkConfig({
   concurrency: 1,
   participants: providers,
   display: {
-    description: 'Sandbox time-to-interactive from create through first successful command.',
     metrics: [
       { key: 'ttiMs', label: 'Time to interactive', unit: 'ms', direction: 'lower-better', decimals: 0 },
     ],
@@ -49,7 +49,7 @@ export const config = defineBenchmarkConfig({
       { key: 'exec.task', label: 'Run first command' },
       { key: 'destroy', label: 'Destroy sandbox' },
     ],
-    overview: { defaultMetric: 'ttiMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/benchmarks/storage/snapshot-fork.bench.ts
+++ b/benchmarks/storage/snapshot-fork.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Storage snapshot/fork benchmark: per-iteration seed -> snapshot -> fork ->
  * verify, per provider (concurrency 1 = sequential; each iteration creates real
@@ -56,7 +57,6 @@ export const config = defineBenchmarkConfig({
   customCliFlags: ['--dataset'],
   dimensions: { dataset },
   display: {
-    description: 'Storage snapshot/fork creation and read latency.',
     metrics: [
       { key: 'snapshotCreateMs', label: 'Snapshot create', unit: 'ms', direction: 'lower-better', decimals: 0 },
       { key: 'forkFromSnapshotMs', label: 'Fork from snapshot', unit: 'ms', direction: 'lower-better', decimals: 0 },
@@ -71,7 +71,7 @@ export const config = defineBenchmarkConfig({
       { key: 'fork-from-live', label: 'Fork from live' },
       { key: 'fork-first-read', label: 'First read' },
     ],
-    overview: { defaultMetric: 'forkFirstReadMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     // A fork whose read-back didn't match is not a usable fork, so its timings

--- a/benchmarks/storage/storage.bench.ts
+++ b/benchmarks/storage/storage.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Storage upload/download benchmark: `iterations` upload→download→delete cycles
  * per provider (concurrency 1 = sequential). Declarative — exports `config` +
@@ -55,7 +56,6 @@ const baseConfig = {
   participants: storageProviders,
   customCliFlags: ['--file-size'],
   display: {
-    description: 'Storage upload/download lifecycle latency and throughput.',
     metrics: [
       { key: 'uploadMs', label: 'Upload', unit: 'ms', direction: 'lower-better' as const, decimals: 0 },
       { key: 'downloadMs', label: 'Download', unit: 'ms', direction: 'lower-better' as const, decimals: 0 },
@@ -67,7 +67,7 @@ const baseConfig = {
       { key: 'download', label: 'Download' },
       { key: 'delete', label: 'Delete' },
     ],
-    overview: { defaultMetric: 'downloadMs', defaultLayout: 'ranking' as const },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' as const },
   },
   scoring: {
     groupBy: 'file_size',

--- a/examples/01-hello.bench.ts
+++ b/examples/01-hello.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Minimal benchmark: one participant, one step, one metric.
  *
@@ -20,14 +21,13 @@ export const config = defineBenchmarkConfig({
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [] }],
   display: {
-    description: 'Minimal one-step, one-metric benchmark.',
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
     ],
     steps: [
       { key: 'work', label: 'Work' },
     ],
-    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/examples/02-shapes.bench.ts
+++ b/examples/02-shapes.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Shapes: one benchmark file can report as sequential, burst, or staggered
  * variants by swapping slug/name and a default stagger delay.
@@ -28,14 +29,13 @@ export const config = defineBenchmarkConfig({
     staggered: { slug: 'shape-demo-staggered', name: 'Shape Demo (Staggered)', staggerDelayMs: 200 },
   },
   display: {
-    description: 'Workload shape variants (sequential, burst, staggered).',
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
     ],
     steps: [
       { key: 'work', label: 'Work' },
     ],
-    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/examples/03-phases.bench.ts
+++ b/examples/03-phases.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Phases: named run segments that let the task branch by phase.
  * Each record is automatically tagged with `data.phase`.
@@ -24,7 +25,6 @@ export const config = defineBenchmarkConfig({
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [], coldDelayMs: 100 }],
   display: {
-    description: 'Cold vs. warm phase latency.',
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
     ],
@@ -32,7 +32,7 @@ export const config = defineBenchmarkConfig({
       { key: 'cold-work', label: 'Cold work' },
       { key: 'warm-work', label: 'Warm work' },
     ],
-    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/examples/04-round-robin.bench.ts
+++ b/examples/04-round-robin.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * groupBy: 'round' interleaves participants so each round runs back-to-back.
  * This is useful for fair comparisons (e.g. every provider's Nth request under
@@ -26,14 +27,13 @@ export const config = defineBenchmarkConfig({
     { name: 'slow', requiredEnvVars: [], workMs: 80 },
   ],
   display: {
-    description: 'Round-robin participant interleaving latency.',
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
     ],
     steps: [
       { key: 'work', label: 'Work' },
     ],
-    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/examples/05-scoring.bench.ts
+++ b/examples/05-scoring.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Scoring with multiple metrics, a higher-is-better metric, and a success rule.
  *
@@ -24,7 +25,6 @@ export const config = defineBenchmarkConfig({
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [], payloadBytes: 1024 * 1024 }],
   display: {
-    description: 'Hash duration, throughput, and verification success.',
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
       { key: 'throughputMbps', label: 'Throughput', unit: 'Mbps', direction: 'higher-better', decimals: 1 },
@@ -32,7 +32,7 @@ export const config = defineBenchmarkConfig({
     steps: [
       { key: 'hash', label: 'Hash payload' },
     ],
-    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     // Records only count as successful when data.verified === true.

--- a/examples/06-custom-flags.bench.ts
+++ b/examples/06-custom-flags.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Custom CLI flags: pass benchmark-specific values through the runner without
  * it treating them as unknown options.
@@ -52,7 +53,6 @@ export const config = defineBenchmarkConfig({
     payloadBytes,
   },
   display: {
-    description: 'Custom CLI flags for payload size and hash algorithm.',
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
       { key: 'hashLength', label: 'Hash length', direction: 'higher-better', decimals: 0 },
@@ -60,7 +60,7 @@ export const config = defineBenchmarkConfig({
     steps: [
       { key: 'hash', label: 'Hash payload' },
     ],
-    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/examples/07-error-handling.bench.ts
+++ b/examples/07-error-handling.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Error handling: TaskError preserves code/data, step timeoutMs aborts long
  * steps, and try/finally cleans up resources.
@@ -22,7 +23,6 @@ export const config = defineBenchmarkConfig({
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [] }],
   display: {
-    description: 'TaskError, step timeout, and cleanup behavior.',
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
     ],
@@ -32,7 +32,7 @@ export const config = defineBenchmarkConfig({
       { key: 'work', label: 'Work' },
       { key: 'cleanup', label: 'Cleanup' },
     ],
-    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/examples/08-env-gated.bench.ts
+++ b/examples/08-env-gated.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Env-gated participants: providers with `requiredEnvVars` are automatically
  * skipped when those env vars are missing. `defaultProviders` limits the default
@@ -28,7 +29,6 @@ export const config = defineBenchmarkConfig({
     { name: 'remote', requiredEnvVars: ['DEMO_API_KEY'] },
   ],
   display: {
-    description: 'Env-gated local vs. remote participant latency.',
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
     ],
@@ -36,7 +36,7 @@ export const config = defineBenchmarkConfig({
       { key: 'remote-auth', label: 'Remote auth' },
       { key: 'local-work', label: 'Local work' },
     ],
-    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/examples/09-on-complete.bench.ts
+++ b/examples/09-on-complete.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * onScore and onComplete: define scoring with functions and write an aggregate
  * summary file after the run finishes.
@@ -23,14 +24,13 @@ export const config = defineBenchmarkConfig({
   participants: [{ name: 'local', requiredEnvVars: [] }],
   dimensions: { workload: 'sort' },
   display: {
-    description: 'Custom onScore and onComplete demo for sorting workload.',
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
     ],
     steps: [
       { key: 'sort', label: 'Sort' },
     ],
-    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   onScore: (lowerIsBetter) => ({
     dimensions: { workload: 'sort' },

--- a/examples/10-shared-run.bench.ts
+++ b/examples/10-shared-run.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Shared run key: when the same benchmark is invoked from multiple CI jobs or
  * machines, pass `--run-key <shared-key>` so every process contributes to a
@@ -28,14 +29,13 @@ export const config = defineBenchmarkConfig({
     { name: 'beta', requiredEnvVars: [], workMs: 40 },
   ],
   display: {
-    description: 'Shared run key across multiple CI jobs.',
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
     ],
     steps: [
       { key: 'work', label: 'Work' },
     ],
-    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/examples/11-logging.bench.ts
+++ b/examples/11-logging.bench.ts
@@ -1,3 +1,4 @@
+
 /**
  * Structured logging and step output capture.
  *
@@ -30,7 +31,6 @@ export const config = defineBenchmarkConfig({
   concurrency: 1,
   participants: [{ name: 'local', requiredEnvVars: [] }],
   display: {
-    description: 'Structured logging and step output capture.',
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better', decimals: 0 },
     ],
@@ -40,7 +40,7 @@ export const config = defineBenchmarkConfig({
       { key: 'safe-node-version', label: 'Safe node version' },
       { key: 'parse-version', label: 'Parse version' },
     ],
-    overview: { defaultMetric: 'durationMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'compositeScore', defaultLayout: 'ranking' },
   },
   scoring: {
     metrics: [

--- a/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
@@ -209,7 +209,7 @@ describe('defineBenchmarkConfig', () => {
     expect(config.display?.overview?.defaultMetric).toBe('x');
   });
 
-  it('accepts compositeScore and task as default metrics without declaring them', () => {
+  it('accepts compositeScore as a default metric when scoring is declared', () => {
     const composite = defineBenchmarkConfig({
       benchmarkSlug: 's',
       benchmarkName: 'n',
@@ -218,9 +218,14 @@ describe('defineBenchmarkConfig', () => {
         metrics: [{ key: 'x', label: 'X' }],
         overview: { defaultMetric: 'compositeScore' },
       },
+      scoring: {
+        metrics: [{ key: 'x', ceiling: 100, weights: { median: 1, p95: 0, p99: 0 } }],
+      },
     });
     expect(composite.display?.overview?.defaultMetric).toBe('compositeScore');
+  });
 
+  it('accepts task as a default metric without declaring it', () => {
     const task = defineBenchmarkConfig({
       benchmarkSlug: 's',
       benchmarkName: 'n',
@@ -231,6 +236,20 @@ describe('defineBenchmarkConfig', () => {
       },
     });
     expect(task.display?.overview?.defaultMetric).toBe('task');
+  });
+
+  it('rejects compositeScore as a default metric without scoring or onScore', () => {
+    expect(() =>
+      defineBenchmarkConfig({
+        benchmarkSlug: 's',
+        benchmarkName: 'n',
+        participants,
+        display: {
+          metrics: [{ key: 'x', label: 'X' }],
+          overview: { defaultMetric: 'compositeScore' },
+        },
+      }),
+    ).toThrow("compositeScore");
   });
 
   it('accepts scoring without unit when display.metrics declares it', () => {

--- a/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/bench-config.test.ts
@@ -116,7 +116,6 @@ describe('defineBenchmarkConfig', () => {
       benchmarkName: 'n',
       participants,
       display: {
-        description: 'A test benchmark',
         metrics: [{ key: 'throughputMbps', label: 'Throughput', unit: 'Mbps', direction: 'higher-better' }],
         steps: [{ key: 'create', label: 'Create sandbox' }],
         overview: { defaultMetric: 'throughputMbps', defaultLayout: 'ranking' },
@@ -124,17 +123,6 @@ describe('defineBenchmarkConfig', () => {
     });
     expect(config.display?.overview?.defaultLayout).toBe('ranking');
     expect(config.display?.metrics?.[0].key).toBe('throughputMbps');
-  });
-
-  it('rejects a non-string display description', () => {
-    expect(() =>
-      defineBenchmarkConfig({
-        benchmarkSlug: 's',
-        benchmarkName: 'n',
-        participants,
-        display: { description: 123 as any },
-      }),
-    ).toThrow('display.description must be a string');
   });
 
   it('rejects a non-string display metric unit', () => {
@@ -219,6 +207,30 @@ describe('defineBenchmarkConfig', () => {
       },
     });
     expect(config.display?.overview?.defaultMetric).toBe('x');
+  });
+
+  it('accepts compositeScore and task as default metrics without declaring them', () => {
+    const composite = defineBenchmarkConfig({
+      benchmarkSlug: 's',
+      benchmarkName: 'n',
+      participants,
+      display: {
+        metrics: [{ key: 'x', label: 'X' }],
+        overview: { defaultMetric: 'compositeScore' },
+      },
+    });
+    expect(composite.display?.overview?.defaultMetric).toBe('compositeScore');
+
+    const task = defineBenchmarkConfig({
+      benchmarkSlug: 's',
+      benchmarkName: 'n',
+      participants,
+      display: {
+        metrics: [{ key: 'x', label: 'X' }],
+        overview: { defaultMetric: 'task' },
+      },
+    });
+    expect(task.display?.overview?.defaultMetric).toBe('task');
   });
 
   it('accepts scoring without unit when display.metrics declares it', () => {

--- a/packages/benchsdk-runner/src/bench-config.ts
+++ b/packages/benchsdk-runner/src/bench-config.ts
@@ -553,6 +553,9 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
       }
     }
   }
+  if (config.display?.overview?.defaultMetric === 'compositeScore' && config.scoring === undefined && config.onScore === undefined) {
+    throw new Error("display.overview.defaultMetric cannot be 'compositeScore' without config.scoring or config.onScore");
+  }
   return config;
 }
 

--- a/packages/benchsdk-runner/src/bench-config.ts
+++ b/packages/benchsdk-runner/src/bench-config.ts
@@ -212,8 +212,6 @@ export interface BenchmarkOverviewDisplay {
  * benchmark runs, but how it should be rendered, without a platform code change.
  */
 export interface BenchmarkDisplayConfig {
-  /** Optional human-readable description shown on the benchmark listing. */
-  description?: string;
   /** Metric catalog — labels, units, and ranking direction for `ctx.measure` keys. */
   metrics?: BenchmarkMetricDisplay[];
   /** Step catalog — human labels for lifecycle steps reported via `ctx.step`. */
@@ -483,9 +481,6 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
     if (typeof config.display !== 'object' || config.display === null || Array.isArray(config.display)) {
       throw new Error('display must be an object');
     }
-    if (config.display.description !== undefined && typeof config.display.description !== 'string') {
-      throw new Error('display.description must be a string');
-    }
     const displayMetricKeys = new Set<string>();
     if (config.display.metrics !== undefined) {
       if (!Array.isArray(config.display.metrics)) {
@@ -544,10 +539,13 @@ export function defineBenchmarkConfig<T extends BaseParticipant = BaseParticipan
       const { defaultMetric, defaultLayout } = config.display.overview;
       if (defaultMetric !== undefined) {
         const metric = assertNonEmptyString(defaultMetric, 'display.overview.defaultMetric');
-        // If the manifest declares metrics, the default must reference one of them.
-        // When metrics is omitted we can't validate the key, so any non-empty string is allowed.
-        if (config.display.metrics !== undefined && !displayMetricKeys.has(metric)) {
-          throw new Error(`display.overview.defaultMetric '${metric}' is not declared in display.metrics`);
+        // The default metric can reference any declared custom metric, or the
+        // platform-level composite score / overall task latency sentinels.
+        const validDefaultMetrics = new Set(displayMetricKeys);
+        validDefaultMetrics.add('compositeScore');
+        validDefaultMetrics.add('task');
+        if (config.display.metrics !== undefined && !validDefaultMetrics.has(metric)) {
+          throw new Error(`display.overview.defaultMetric '${metric}' is not declared in display.metrics and is not a known default (compositeScore, task)`);
         }
       }
       if (defaultLayout !== undefined && !['ranking', 'cards', 'chart', 'leaderboard'].includes(defaultLayout)) {

--- a/packages/create-bench/src/index.ts
+++ b/packages/create-bench/src/index.ts
@@ -79,6 +79,7 @@ export const config = defineBenchmarkConfig({
     metrics: [
       { key: 'durationMs', label: 'Duration', unit: 'ms', direction: 'lower-better' },
     ],
+    overview: { defaultMetric: 'compositeScore' },
   },
   scoring: {
     metrics: [


### PR DESCRIPTION
## Summary

Removes the dead `display.description` field from the runner config types, validation, tests, scaffold template, and every `.bench.ts` manifest. Also updates all scored manifests so `display.overview.defaultMetric` defaults to `compositeScore`, and broadens runner validation to accept `compositeScore` and `task` as default metrics (in addition to declared custom metrics).

Two benchmarks without scoring (`benchmarks/reliability/sandbox-opencode.bench.ts` and `benchmarks/sandbox/dax.bench.ts`) now use valid defaults (`task` and `totalMs` respectively), and `defineBenchmarkConfig` now validates that `display.overview.defaultMetric: 'compositeScore'` requires `config.scoring` or `config.onScore`.

The `overview.defaultMetric` in the `.bench.ts` file is now authoritative for the initial metric shown in both the run-detail and benchmark overview views on the platform.

Link to Devin session: https://app.devin.ai/sessions/506471b73bf049adb719090fbb32e859
Open in Devin Desktop: https://app.devin.ai/desktop/session/506471b73bf049adb719090fbb32e859?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->