### PR TITLE
ci(ai-gateway): exclude GitHub Copilot from weekly benchmark runs

### DIFF
--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -149,6 +149,11 @@ jobs:
         run: |
           . benchmarks/scripts/load-vault-secrets.sh '^(ANTHROPIC_API_KEY|OPENAI_API_KEY|GEMINI_API_KEY|KIMI_API_KEY|GITHUB_COPILOT_API_KEY|NOVITA_API_KEY|NEON_AI_GATEWAY_BASE_URL|NEON_AI_GATEWAY_TOKEN|NGROK_AI_GATEWAY_API_KEY|LLMAPI_API_KEY|CLOUDFLARE_AI_GATEWAY_ACCOUNT_ID|CLOUDFLARE_AI_GATEWAY_GATEWAY_ID|CLOUDFLARE_AI_GATEWAY_TOKEN|LLM_GATEWAY_API_KEY|OPENROUTER_API_KEY|PYDANTIC_AI_GATEWAY_API_KEY|VERCEL_AI_GATEWAY_API_KEY|CONCENTRATE_AI_GATEWAY_API_KEY|BLAZERAIL_API_KEY|BENCHMARKS_PLATFORM_API_KEY)'
 
+          # GitHub Copilot is kept in the daily runs but excluded from the weekly run.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            unset GITHUB_COPILOT_API_KEY
+          fi
+
           if [ "${{ github.event_name }}" = "schedule" ]; then
             if [ "${{ matrix.family.slug }}" = "kimi" ]; then
               ITERATIONS="25"


### PR DESCRIPTION
## Summary

Keep GitHub Copilot in the daily OSS benchmark runs, but skip it during the weekly scheduled AI Gateway benchmark.

The weekly `ai-gateway-benchmarks.yml` workflow runs every Friday (`0 9 * * 5`). After loading vault secrets, it now unsets `GITHUB_COPILOT_API_KEY` for `schedule` events. The runner's `filterParticipantsByEnv` then skips the `github-copilot` participant because its required env var is missing, while the matrix still runs all other AI Gateway providers across all four families.

Manual `workflow_dispatch` runs (and push-triggered runs) are unaffected, so a user can still explicitly benchmark GitHub Copilot or get it from a code change.

The daily `benchmarks-daily` workflow is intentionally unchanged and continues to run GitHub Copilot.

Link to Devin session: https://app.devin.ai/sessions/44493639684a4dc5a153179999db37fa
Open in Devin Desktop: https://app.devin.ai/desktop/session/44493639684a4dc5a153179999db37fa?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->