### PR TITLE
feat: add BENCHMARK_SLUG/NAME env and workflow_dispatch inputs for manual benchmark identity

### DIFF
--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -13,6 +13,14 @@ on:
     - cron: '0 9 * * 5' # Weekly on Friday at 9am UTC (4am CDT)
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       family:
         description: 'Family to run (leave as All for every target-model family)'
         required: false
@@ -64,6 +72,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -12,6 +12,14 @@ on:
     - cron: '0 10 * * 5' # Weekly on Friday at 10am UTC (5am CDT)
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       iterations:
         description: 'Iterations per provider'
         required: false
@@ -30,6 +38,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/browser-concurrent-benchmarks.yml
+++ b/.github/workflows/browser-concurrent-benchmarks.yml
@@ -13,6 +13,14 @@ on:
     - cron: '0 4 * * 1' # Weekly on Monday at 04:00 UTC (offset from other browser benchmarks)
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       dry_run:
         description: 'Run without ingesting or committing results'
         required: false
@@ -24,6 +32,10 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   setup:

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -12,6 +12,14 @@ on:
     - cron: '30 10 * * 5' # Weekly on Friday at 10:30am UTC (5:30am CDT, offset from main browser benchmark to avoid provider contention)
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       iterations:
         description: 'Iterations per provider (sessions)'
         required: false
@@ -30,6 +38,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   setup:

--- a/.github/workflows/reliability-tensorlake-opencode.yml
+++ b/.github/workflows/reliability-tensorlake-opencode.yml
@@ -5,6 +5,14 @@ on:
     - cron: '0 * * * *' # top of every hour: 60 one-minute iterations per run
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       iterations:
         description: 'Iterations per run'
         required: false
@@ -26,6 +34,10 @@ concurrency:
 permissions:
   contents: read
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-capabilities.yml
+++ b/.github/workflows/sandbox-capabilities.yml
@@ -3,6 +3,14 @@ name: Sandbox Capabilities Matrix
 on:
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       provider:
         description: 'Provider to run (leave empty for all)'
         required: false
@@ -26,6 +34,10 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-cpu-node.yml
+++ b/.github/workflows/sandbox-cpu-node.yml
@@ -14,6 +14,14 @@ on:
       - '.github/workflows/sandbox-cpu-node.yml'
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       replicas:
         description: 'Replicates per provider'
         required: false
@@ -36,6 +44,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -16,6 +16,14 @@ on:
     - cron: '30 13 * * 5' # Weekly on Friday at 1:30pm UTC (8:30am CDT, offset from TTI to avoid provider contention)
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       iterations:
         description: 'Iterations per provider'
         required: false
@@ -38,6 +46,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   dax:

--- a/.github/workflows/sandbox-disk.yml
+++ b/.github/workflows/sandbox-disk.yml
@@ -14,6 +14,14 @@ on:
       - '.github/workflows/sandbox-disk.yml'
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       replicas:
         description: 'Replicates per provider'
         required: false
@@ -36,6 +44,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-dns.yml
+++ b/.github/workflows/sandbox-dns.yml
@@ -3,6 +3,14 @@ name: Dns Benchmark
 on:
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       replicas:
         description: 'Replicates per provider'
         required: false
@@ -25,6 +33,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-download.yml
+++ b/.github/workflows/sandbox-download.yml
@@ -3,6 +3,14 @@ name: Download Benchmark
 on:
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       replicas:
         description: 'Replicates per provider'
         required: false
@@ -25,6 +33,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-latency.yml
+++ b/.github/workflows/sandbox-latency.yml
@@ -3,6 +3,14 @@ name: Latency Benchmark
 on:
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       replicas:
         description: 'Replicates per provider'
         required: false
@@ -25,6 +33,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-memory.yml
+++ b/.github/workflows/sandbox-memory.yml
@@ -14,6 +14,14 @@ on:
       - '.github/workflows/sandbox-memory.yml'
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       replicas:
         description: 'Replicates per provider'
         required: false
@@ -36,6 +44,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-network-localhost.yml
+++ b/.github/workflows/sandbox-network-localhost.yml
@@ -14,6 +14,14 @@ on:
       - '.github/workflows/sandbox-network-localhost.yml'
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       replicas:
         description: 'Replicates per provider'
         required: false
@@ -36,6 +44,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-network-wan.yml
+++ b/.github/workflows/sandbox-network-wan.yml
@@ -14,6 +14,14 @@ on:
       - '.github/workflows/sandbox-network-wan.yml'
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       replicas:
         description: 'Replicates per provider'
         required: false
@@ -36,6 +44,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-pgbench.yml
+++ b/.github/workflows/sandbox-pgbench.yml
@@ -14,6 +14,14 @@ on:
       - '.github/workflows/sandbox-pgbench.yml'
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       replicas:
         description: 'Replicates per provider'
         required: false
@@ -36,6 +44,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-realworld.yml
+++ b/.github/workflows/sandbox-realworld.yml
@@ -3,6 +3,14 @@ name: Realworld Benchmark
 on:
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       replicas:
         description: 'Replicates per provider'
         required: false
@@ -25,6 +33,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-system.yml
+++ b/.github/workflows/sandbox-system.yml
@@ -14,6 +14,14 @@ on:
       - '.github/workflows/sandbox-system.yml'
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       replicas:
         description: 'Replicates per provider'
         required: false
@@ -36,6 +44,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/sandbox-tti-benchmarks.yml
+++ b/.github/workflows/sandbox-tti-benchmarks.yml
@@ -12,6 +12,14 @@ on:
     - cron: '0 13 * * 5' # Weekly on Friday at 1pm UTC (8am CDT)
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       iterations:
         description: 'Iterations per provider'
         required: false
@@ -38,6 +46,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/snapshot-fork-benchmarks.yml
+++ b/.github/workflows/snapshot-fork-benchmarks.yml
@@ -12,6 +12,14 @@ on:
     - cron: '30 11 * * 5' # Weekly on Friday at 11:30am UTC (6:30am CDT, offset from storage to avoid racing pushes to master)
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       iterations:
         description: 'Iterations per provider'
         required: false
@@ -39,6 +47,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   snapshot-fork:

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -12,6 +12,14 @@ on:
     - cron: '0 11 * * 5' # Weekly on Friday at 11am UTC (6am CDT)
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       iterations:
         description: 'Iterations per provider, per file size'
         required: false
@@ -45,6 +53,10 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   bench:

--- a/.github/workflows/storage-concurrency-benchmarks.yml
+++ b/.github/workflows/storage-concurrency-benchmarks.yml
@@ -14,6 +14,14 @@ on:
     - cron: '0 13 * * 3' # Weekly on Wednesday at 13:00 UTC
   workflow_dispatch:
     inputs:
+      slug:
+        description: 'Optional platform benchmark slug override'
+        required: false
+        default: ''
+      name:
+        description: 'Optional platform benchmark name override'
+        required: false
+        default: ''
       provider:
         description: 'Optional provider name (for example aws-s3)'
         required: false
@@ -42,6 +50,10 @@ concurrency:
 permissions:
   contents: read
   id-token: write
+
+env:
+  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   benchmark:

--- a/.github/workflows/storage-concurrency-benchmarks.yml
+++ b/.github/workflows/storage-concurrency-benchmarks.yml
@@ -14,14 +14,6 @@ on:
     - cron: '0 13 * * 3' # Weekly on Wednesday at 13:00 UTC
   workflow_dispatch:
     inputs:
-      slug:
-        description: 'Optional platform benchmark slug override'
-        required: false
-        default: ''
-      name:
-        description: 'Optional platform benchmark name override'
-        required: false
-        default: ''
       provider:
         description: 'Optional provider name (for example aws-s3)'
         required: false
@@ -50,10 +42,6 @@ concurrency:
 permissions:
   contents: read
   id-token: write
-
-env:
-  BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
-  BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:
   benchmark:

--- a/packages/benchsdk-runner/src/cli.ts
+++ b/packages/benchsdk-runner/src/cli.ts
@@ -64,7 +64,19 @@ export async function runBenchmarkFile(argv: string[]): Promise<void> {
     throw new Error(`${file} must export a \`task\` created with defineTask.`);
   }
 
-  await runBenchmark(config as BenchmarkConfig<BaseParticipant>, task as BenchmarkTask<BaseParticipant>, flags);
+  const envFlags: string[] = [];
+  if (process.env.BENCHMARK_SLUG) {
+    envFlags.push('--benchmark', process.env.BENCHMARK_SLUG);
+  }
+  if (process.env.BENCHMARK_NAME) {
+    envFlags.push('--name', process.env.BENCHMARK_NAME);
+  }
+
+  await runBenchmark(
+    config as BenchmarkConfig<BaseParticipant>,
+    task as BenchmarkTask<BaseParticipant>,
+    [...envFlags, ...flags],
+  );
 }
 
 /** Executable entry: dispatches to benchmark execution or platform data commands. */


### PR DESCRIPTION
## Summary

Adds a manual override for the platform benchmark slug/name so `workflow_dispatch` runs can report under a distinct identity instead of being merged into an existing benchmark.

In `@benchsdk/runner`:
- `runBenchmarkFile` now reads `BENCHMARK_SLUG` / `BENCHMARK_NAME` and prepends `--benchmark <slug>` / `--name <name>` to the CLI arguments before any user-provided flags, so the override works for every `.bench.ts` entrypoint.

In all benchmark workflows:
- `workflow_dispatch` gains optional `slug` and `name` inputs.
- Top-level `env` maps them to `BENCHMARK_SLUG` / `BENCHMARK_NAME`.

Example dispatch: `slug=tti-manual` `name="Sandbox TTI Manual"` reports the run as `tti-manual` / `Sandbox TTI Manual`.

Link to Devin session: https://app.devin.ai/sessions/3994a34e31564d319acbd4f46e68f13a
Open in Devin Desktop: https://app.devin.ai/desktop/session/3994a34e31564d319acbd4f46e68f13a?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->