### PR TITLE
Expose per-iteration data in @benchsdk API/CLI and capture sandbox reuse metadata

### DIFF
--- a/.changeset/expose-iterations.md
+++ b/.changeset/expose-iterations.md
@@ -1,0 +1,10 @@
+---
+"@benchsdk/api": minor
+"@benchsdk/cli": minor
+---
+
+Expose per-iteration benchmark results and sandbox reuse metadata.
+
+- `@benchsdk/api` adds `getRunTaskIterations` and `getRunStepIterations` plus the `BenchmarkRunIterationInput`, `BenchmarkTaskIteration`, `BenchmarkStepIteration`, `BenchmarkRunTaskIterations`, and `BenchmarkRunStepIterations` types.
+- `@benchsdk/cli` adds `bench iterations <benchmark-slug> --run <id> [--participant <slug>] [--steps <list>] [--format json|table]`.
+- `benchmarks/sandbox/tti.bench.ts` records `sandboxId`, `createdAt`, and `createMs` in the `create` step for sandbox reuse detection.

--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -27,6 +27,7 @@ import { formatError } from '../src/util/error.js';
 import { providers } from './providers.js';
 import type { ProviderConfig } from './types.js';
 import { writeSandboxLegacyResults } from './legacy-results.js';
+import type { SandboxInterface } from 'computesdk';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -68,23 +69,25 @@ export const config = defineBenchmarkConfig({
 });
 
 /** The slice of a provider's sandbox this workload actually touches. */
-interface TtiSandbox {
-  runCommand(command: string): Promise<{ exitCode: number; stdout?: string; stderr?: string }>;
-  destroy(): Promise<unknown>;
-}
+interface TtiSandbox extends SandboxInterface {}
 
 export const task = defineTask<ProviderConfig>(async (ctx) => {
   const { participant, step, measure, log } = ctx;
   const compute = participant.createCompute();
 
   const start = performance.now();
-  const sandbox = await step('create', () =>
-    withTimeout<TtiSandbox>(
+  const createStart = start;
+  const sandbox = await step('create', async () => {
+    const s = await withTimeout<TtiSandbox>(
       compute.sandbox.create(participant.sandboxOptions),
       participant.timeout ?? CREATE_TIMEOUT_MS,
       'Sandbox creation timed out',
-    ),
-  );
+    );
+    const createMs = performance.now() - createStart;
+    const info = await s.getInfo();
+    measure({ sandboxId: s.sandboxId, createdAt: info.createdAt.toISOString(), createMs });
+    return s;
+  });
 
   let ttiMs: number | undefined;
   try {

--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -75,25 +75,33 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
   const { participant, step, measure, log } = ctx;
   const compute = participant.createCompute();
 
-  const start = performance.now();
-  const createStart = start;
-  const sandbox = await step('create', async () => {
-    const s = await withTimeout<TtiSandbox>(
-      compute.sandbox.create(participant.sandboxOptions),
-      participant.timeout ?? CREATE_TIMEOUT_MS,
-      'Sandbox creation timed out',
-    );
-    const createMs = performance.now() - createStart;
-    const info = await s.getInfo();
-    measure({ sandboxId: s.sandboxId, createdAt: info.createdAt.toISOString(), createMs });
-    return s;
-  });
-
+  const createStart = performance.now();
+  let sandbox: TtiSandbox | undefined;
+  let createMs: number | undefined;
   let ttiMs: number | undefined;
+
   try {
+    sandbox = await step('create', async () => {
+      const s = await withTimeout<TtiSandbox>(
+        compute.sandbox.create(participant.sandboxOptions),
+        participant.timeout ?? CREATE_TIMEOUT_MS,
+        'Sandbox creation timed out',
+      );
+      createMs = performance.now() - createStart;
+      measure({ sandboxId: s.sandboxId, createMs });
+      const info = await s.getInfo();
+      measure({ createdAt: info.createdAt.toISOString() });
+      return s;
+    });
+    if (sandbox === undefined) {
+      throw new Error('create step did not return a sandbox');
+    }
+    const commandSandbox = sandbox;
+
+    const commandStart = performance.now();
     const result = await step('exec.task', async () => {
       const r = await withTimeout(
-        sandbox.runCommand('node -v'),
+        commandSandbox.runCommand('node -v'),
         COMMAND_TIMEOUT_MS,
         'First command execution timed out',
       );
@@ -101,16 +109,21 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
         log('node -v failed', { level: 'error', meta: { exitCode: r.exitCode, stderr: r.stderr ?? null } });
         throw new Error(`Command failed with exit code ${r.exitCode}: ${r.stderr || 'Unknown error'}`);
       }
-      ttiMs = performance.now() - start;
+      if (createMs === undefined) {
+        throw new Error('create step did not produce a createMs measurement');
+      }
+      ttiMs = createMs + (performance.now() - commandStart);
       measure({ ttiMs });
       return r;
     });
     log('node -v succeeded', { level: 'info', meta: { version: result.stdout?.trim() ?? null, exitCode: result.exitCode } });
   } finally {
-    await step('destroy', () =>
-      withTimeout(sandbox.destroy(), participant.destroyTimeoutMs ?? DESTROY_TIMEOUT_MS, 'Destroy timeout'),
-      { reportConcurrency: false },
-    ).catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { error: formatError(err) } }));
+    if (sandbox) {
+      await step('destroy', () =>
+        withTimeout(sandbox!.destroy(), participant.destroyTimeoutMs ?? DESTROY_TIMEOUT_MS, 'Destroy timeout'),
+        { reportConcurrency: false },
+      ).catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { error: formatError(err) } }));
+    }
   }
 
   if (ttiMs === undefined) {

--- a/packages/benchsdk-api/src/client.ts
+++ b/packages/benchsdk-api/src/client.ts
@@ -79,12 +79,12 @@ function queryString(input: Record<string, number | undefined>): string {
   return value ? `?${value}` : '';
 }
 
-function iterationsQueryString(input: BenchmarkRunIterationInput = {}): string {
+function iterationsExtraParams(input: BenchmarkRunIterationInput = {}): string {
   const params = new URLSearchParams();
   if (input.participant) params.set('participant', input.participant);
   if (input.steps?.length) params.set('steps', input.steps.join(','));
   const value = params.toString();
-  return value ? `?${value}` : '';
+  return value ? `&${value}` : '';
 }
 
 function getApiKey(input?: string): string | undefined {
@@ -528,14 +528,14 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
     async getRunTaskIterations(benchmarkSlug, runId, input: BenchmarkRunIterationInput = {}) {
       return request<BenchmarkRunTaskIterations>(
         'GET',
-        `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/iterations?type=tasks${iterationsQueryString(input)}`,
+        `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/iterations?type=tasks${iterationsExtraParams(input)}`,
       );
     },
 
     async getRunStepIterations(benchmarkSlug, runId, input: BenchmarkRunIterationInput = {}) {
       return request<BenchmarkRunStepIterations>(
         'GET',
-        `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/iterations?type=steps${iterationsQueryString(input)}`,
+        `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/iterations?type=steps${iterationsExtraParams(input)}`,
       );
     },
 

--- a/packages/benchsdk-api/src/client.ts
+++ b/packages/benchsdk-api/src/client.ts
@@ -18,8 +18,11 @@ import type {
   BenchmarkRunSummaryInput,
   BenchmarkRunTaskResults,
   BenchmarkRunTaskResultsInput,
+  BenchmarkRunTaskIterations,
+  BenchmarkRunStepIterations,
   BenchmarkRunTimeline,
   BenchmarkRunTimelineInput,
+  BenchmarkRunIterationInput,
   BenchmarkRunWorker,
   BenchmarkWorkerAttempt,
   CreateWorkerArtifactInput,
@@ -72,6 +75,14 @@ function queryString(input: Record<string, number | undefined>): string {
   for (const [key, value] of Object.entries(input)) {
     if (value !== undefined) params.set(key, String(value));
   }
+  const value = params.toString();
+  return value ? `?${value}` : '';
+}
+
+function iterationsQueryString(input: BenchmarkRunIterationInput = {}): string {
+  const params = new URLSearchParams();
+  if (input.participant) params.set('participant', input.participant);
+  if (input.steps?.length) params.set('steps', input.steps.join(','));
   const value = params.toString();
   return value ? `?${value}` : '';
 }
@@ -511,6 +522,20 @@ export function createBenchmarkClient(config: BenchmarkClientConfig = {}): Bench
       return request<BenchmarkRunTimeline>(
         'GET',
         `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/results/timeline${queryString({ bucketMs: input.bucketMs })}`,
+      );
+    },
+
+    async getRunTaskIterations(benchmarkSlug, runId, input: BenchmarkRunIterationInput = {}) {
+      return request<BenchmarkRunTaskIterations>(
+        'GET',
+        `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/iterations?type=tasks${iterationsQueryString(input)}`,
+      );
+    },
+
+    async getRunStepIterations(benchmarkSlug, runId, input: BenchmarkRunIterationInput = {}) {
+      return request<BenchmarkRunStepIterations>(
+        'GET',
+        `/benchmarks/${encodePath(benchmarkSlug)}/runs/${encodePath(runId)}/iterations?type=steps${iterationsQueryString(input)}`,
       );
     },
 

--- a/packages/benchsdk-api/src/types.ts
+++ b/packages/benchsdk-api/src/types.ts
@@ -434,6 +434,46 @@ export interface BenchmarkRunTimeline {
   };
 }
 
+export interface BenchmarkRunIterationInput {
+  participant?: string;
+  steps?: string[];
+}
+
+export interface BenchmarkTaskIteration {
+  participantSlug: string;
+  provider: string | null;
+  taskIndex: number;
+  status: string;
+  latencyMs: number | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  data: JsonObject;
+}
+
+export interface BenchmarkStepIteration {
+  participantSlug: string;
+  provider: string | null;
+  stepName: string;
+  taskIndex: number;
+  status: string;
+  latencyMs: number | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  data: JsonObject;
+}
+
+export interface BenchmarkRunTaskIterations {
+  run: { id: string };
+  generatedAt: string;
+  tasks: BenchmarkTaskIteration[];
+}
+
+export interface BenchmarkRunStepIterations {
+  run: { id: string };
+  generatedAt: string;
+  steps: BenchmarkStepIteration[];
+}
+
 export interface BenchmarkRunImportsSummary {
   eventBatches: number;
   persisted: number;
@@ -809,6 +849,16 @@ export interface BenchmarkClient {
     runId: string,
     input?: BenchmarkRunTimelineInput,
   ): Promise<BenchmarkRunTimeline>;
+  getRunTaskIterations(
+    benchmarkSlug: string,
+    runId: string,
+    input?: BenchmarkRunIterationInput,
+  ): Promise<BenchmarkRunTaskIterations>;
+  getRunStepIterations(
+    benchmarkSlug: string,
+    runId: string,
+    input?: BenchmarkRunIterationInput,
+  ): Promise<BenchmarkRunStepIterations>;
   getRunImports(benchmarkSlug: string, runId: string): Promise<BenchmarkRunImports>;
   submitRunSummary(benchmarkSlug: string, runId: string, input: BenchmarkRunSummaryInput): Promise<void>;
 }

--- a/packages/benchsdk-cli/src/cli.ts
+++ b/packages/benchsdk-cli/src/cli.ts
@@ -54,6 +54,8 @@ Commands:
   runs show <benchmark-slug> <runId> Show a single run
   results <benchmark-slug> [--run <id>] [--format json|table]
                                      Show benchmark or run results
+  iterations <benchmark-slug> --run <id> [--participant <slug>] [--steps <list>] [--format json|table]
+                                     Show per-iteration step latencies
   artifacts list <benchmark-slug> <runId> [--worker <id>]
                                      List run artifacts
   export <benchmark-slug> [--run <id>] [--out <dir>]
@@ -133,6 +135,8 @@ const subcommandOptionSchema = {
   limit: { type: 'number' as const },
   offset: { type: 'number' as const },
   run: { type: 'string' as const },
+  participant: { type: 'string' as const },
+  steps: { type: 'string' as const },
   worker: { type: 'string' as const },
   out: { type: 'string' as const },
 };
@@ -200,6 +204,8 @@ Subcommands:
        bench runs show <benchmark-slug> <runId>`;
     case 'results':
       return `Usage: bench results <benchmark-slug> [--run <id>] [--format json|table]`;
+    case 'iterations':
+      return `Usage: bench iterations <benchmark-slug> --run <id> [--participant <slug>] [--steps <list>] [--format json|table]`;
     case 'artifacts':
       return `Usage: bench artifacts list <benchmark-slug> <runId> [--worker <id>]`;
     case 'export':
@@ -375,6 +381,36 @@ async function handleResults(
   printData(results, { ...outputOptions, format: options.format === 'json' ? 'json' : outputOptions.format });
 }
 
+async function handleIterations(
+  benchmarkSlug: string,
+  options: { run?: string; participant?: string; steps?: string },
+  overrides: { baseUrl?: string; apiKey?: string; org?: string },
+  outputOptions: OutputOptions = {},
+): Promise<void> {
+  if (!options.run) {
+    throw new Error('Usage: bench iterations <benchmark-slug> --run <id> [--participant <slug>] [--steps <list>]');
+  }
+  const { api } = await createApiClient(overrides);
+  const steps = options.steps
+    ? options.steps.split(',').map((s) => s.trim()).filter(Boolean)
+    : undefined;
+  const { steps: rows } = await api.getRunStepIterations(benchmarkSlug, options.run, {
+    participant: options.participant,
+    steps,
+  });
+  const formatted = rows.map((row) => ({
+    participantSlug: row.participantSlug,
+    taskIndex: row.taskIndex,
+    stepName: row.stepName,
+    status: row.status,
+    latencyMs: row.latencyMs,
+    startedAt: row.startedAt,
+    completedAt: row.completedAt,
+    ...row.data,
+  }));
+  printData(formatted, outputOptions);
+}
+
 async function handleArtifactsList(
   benchmarkSlug: string,
   runId: string,
@@ -517,6 +553,13 @@ export async function run(argv: string[]): Promise<void> {
         const [slug] = subPositionals;
         if (!slug) throw new Error('Benchmark slug required: bench results <benchmark-slug>');
         await handleResults(slug, options, overrides, outputOptions);
+        break;
+      }
+      case 'iterations': {
+        const { options, positionals: subPositionals } = parseSubcommandOptions(rest);
+        const [slug] = subPositionals;
+        if (!slug) throw new Error('Benchmark slug required: bench iterations <benchmark-slug>');
+        await handleIterations(slug, options, overrides, outputOptions);
         break;
       }
       case 'artifacts': {


### PR DESCRIPTION
## Summary
Wires the new run iteration endpoint through `@benchsdk/api` and the `bench` CLI, and captures sandbox identity/timing metadata in the TTI benchmark so the CLI can detect sandbox reuse across iterations.

Changes:
- `@benchsdk/api` types: add `BenchmarkTaskIteration`, `BenchmarkStepIteration`, `BenchmarkRunTaskIterations`, `BenchmarkRunStepIterations`, and `BenchmarkRunIterationInput`.
- `@benchsdk/api` client: add `getRunTaskIterations` and `getRunStepIterations` methods that call `?type=tasks|steps` on the new endpoint.
- `@benchsdk/cli`: add `bench iterations <benchmark-slug> --run <id> [--participant <slug>] [--steps <list>] [--format json|table]`, which prints per-iteration step latencies (and spreads step `data` so sandbox reuse fields are visible).
- `benchmarks/sandbox/tti.bench.ts`: records `sandboxId`, `createdAt`, and `createMs` inside the `create` step via `measure`, so `step_data_json` carries the sandbox creation timestamp and the time spent creating.

Example:
```
bench iterations sandbox-tti --run <runId> --participant isorun --steps create,exec.task --format table
```

Link to Devin session: https://app.devin.ai/sessions/9479a5509e074d90af16ede033fcd51a
Open in Devin Desktop: https://app.devin.ai/desktop/session/9479a5509e074d90af16ede033fcd51a?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->