### PR TITLE
chore: increase Blaxel DAX root storage to 16 GiB

### DIFF
--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -103,7 +103,7 @@ const DAX_RESOURCE_OPTIONS: Record<string, Record<string, any>> = {
       {
         name: 'dax-root',
         type: 'ephemeral',
-        sizeMb: 8192,
+        sizeMb: 16384,
         mountPath: '/',                                     // Keep the writable root off RAM
       },
     ],


### PR DESCRIPTION
Update Blaxel DAX root storage from 8192 MiB to 16384 MiB. No other changes.

Submitted on behalf of Blaxel.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->