### PR TITLE
Default DAX benchmark overview to Overall task

### DIFF
--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -72,7 +72,7 @@ export const config = defineBenchmarkConfig({
       { key: 'install', label: 'Install' },
       { key: 'typecheck', label: 'Typecheck' },
     ],
-    overview: { defaultMetric: 'totalMs', defaultLayout: 'ranking' },
+    overview: { defaultMetric: 'task', defaultLayout: 'ranking' },
   },
   onComplete: (outcome) =>
     writeDaxLegacyResults(outcome.participants, {


### PR DESCRIPTION
## Summary

Sets `display.overview.defaultMetric` to `'task'` in the DAX benchmark config so that `benchmarks-platform` defaults DAX results to the Overall task view. The platform already treats the string `'task'` as the sentinel for Overall task, so rerunning the weekly and daily DAX benchmarks with this change will make both `sandbox-dax` and `sandbox-dax-daily` show Overall task by default.

This moves the source of truth for the default view into the runner config, while the existing platform override (`OVERALL_TASK_DEFAULT_SLUGS` in `benchmarks-platform`) continues to cover historical rows that still have `totalMs` in their stored config.

### Verification

- `pnpm typecheck` passed.

### Related work

- `computesdk/benchmarks-platform` already contains a slug-based platform override for `sandbox-dax` and `sandbox-dax-daily` to default those rows to Overall task while older runs are still being re-run with this config change.

Link to Devin session: https://app.devin.ai/sessions/8961061292804dc794c3250aca56d00d
Open in Devin Desktop: https://app.devin.ai/desktop/session/8961061292804dc794c3250aca56d00d?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->