### PR TITLE
feat(runner): record BENCH_TRIGGER_SOURCE on platform runs

### DIFF
--- a/.changeset/runner-trigger-source.md
+++ b/.changeset/runner-trigger-source.md
@@ -1,0 +1,9 @@
+---
+"@benchsdk/runner": minor
+---
+
+Record how a run was triggered.
+
+- New `BENCH_TRIGGER_SOURCE` / `BENCH_TRIGGER_REQUESTED_BY` env vars, set by workflows dispatched from the platform (`platform-retrigger`).
+- Run config now includes `trigger: { source, event?, requestedBy? }`; summary `triggeredBy` uses the same resolved source (falls back to `GITHUB_EVENT_NAME`, then `manual`).
+- Exports `resolveTriggerSource(env?)`.

--- a/.changeset/runner-trigger-source.md
+++ b/.changeset/runner-trigger-source.md
@@ -4,6 +4,6 @@
 
 Record how a run was triggered.
 
-- New `BENCH_TRIGGER_SOURCE` / `BENCH_TRIGGER_REQUESTED_BY` env vars, set by workflows dispatched from the platform (`platform-retrigger`).
-- Run config now includes `trigger: { source, event?, requestedBy? }`; summary `triggeredBy` uses the same resolved source (falls back to `GITHUB_EVENT_NAME`, then `manual`).
+- New `BENCH_TRIGGER_SOURCE` / `BENCH_TRIGGER_REQUESTED_BY` / `BENCH_TRIGGER_REQUEST_ID` env vars, set by workflows dispatched from the platform (`platform-retrigger`).
+- Run config now includes `trigger: { source, event?, requestedBy?, requestId? }`; summary `triggeredBy` uses the same resolved source (falls back to `GITHUB_EVENT_NAME`, then `manual`).
 - Exports `resolveTriggerSource(env?)`.

--- a/packages/benchsdk-runner/src/__tests__/runner.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/runner.test.ts
@@ -417,6 +417,7 @@ describe('runBenchmark', () => {
     try {
       delete process.env.BENCH_TRIGGER_SOURCE;
       delete process.env.BENCH_TRIGGER_REQUESTED_BY;
+      delete process.env.BENCH_TRIGGER_REQUEST_ID;
       process.env.GITHUB_EVENT_NAME = 'schedule';
       await run();
       expect(calls.createRun[0][1].config.trigger).toEqual({ source: 'schedule', event: 'schedule' });
@@ -425,17 +426,20 @@ describe('runBenchmark', () => {
       process.env.GITHUB_EVENT_NAME = 'workflow_dispatch';
       process.env.BENCH_TRIGGER_SOURCE = 'platform-retrigger';
       process.env.BENCH_TRIGGER_REQUESTED_BY = 'acme';
+      process.env.BENCH_TRIGGER_REQUEST_ID = 'req-1';
       await run();
       expect(calls.createRun[1][1].config.trigger).toEqual({
         source: 'platform-retrigger',
         event: 'workflow_dispatch',
         requestedBy: 'acme',
+        requestId: 'req-1',
       });
       expect(calls.submitRunSummary[1][2].run.triggeredBy).toBe('platform-retrigger');
 
       process.env.GITHUB_EVENT_NAME = '  ';
       process.env.BENCH_TRIGGER_SOURCE = '';
       delete process.env.BENCH_TRIGGER_REQUESTED_BY;
+      process.env.BENCH_TRIGGER_REQUEST_ID = ' ';
       await run();
       expect(calls.createRun[2][1].config.trigger).toEqual({ source: 'manual' });
       expect(calls.submitRunSummary[2][2].run.triggeredBy).toBe('manual');

--- a/packages/benchsdk-runner/src/__tests__/runner.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/runner.test.ts
@@ -401,6 +401,48 @@ describe('runBenchmark', () => {
     expect(onComplete).toHaveBeenCalledWith(outcome);
   });
 
+  it('records BENCH_TRIGGER_SOURCE in the run config and summary, falling back to the GitHub event', async () => {
+    const config: BenchmarkConfig<typeof participants[number]> = {
+      benchmarkSlug: 's',
+      benchmarkName: 'n',
+      iterations: 1,
+      concurrency: 1,
+      participants: [participants[0]],
+      onScore: (lowerIsBetter) => ({
+        metrics: [lowerIsBetter('ttiMs', { unit: 'ms', ceiling: 1000, weights: { median: 1, p95: 0, p99: 0 } })],
+      }),
+    };
+    const run = () => runBenchmark(config, defineTask(async () => ({ data: { ttiMs: 100 } })), []);
+    const savedEnv = { ...process.env };
+    try {
+      delete process.env.BENCH_TRIGGER_SOURCE;
+      delete process.env.BENCH_TRIGGER_REQUESTED_BY;
+      process.env.GITHUB_EVENT_NAME = 'schedule';
+      await run();
+      expect(calls.createRun[0][1].config.trigger).toEqual({ source: 'schedule', event: 'schedule' });
+      expect(calls.submitRunSummary[0][2].run.triggeredBy).toBe('schedule');
+
+      process.env.GITHUB_EVENT_NAME = 'workflow_dispatch';
+      process.env.BENCH_TRIGGER_SOURCE = 'platform-retrigger';
+      process.env.BENCH_TRIGGER_REQUESTED_BY = 'acme';
+      await run();
+      expect(calls.createRun[1][1].config.trigger).toEqual({
+        source: 'platform-retrigger',
+        event: 'workflow_dispatch',
+        requestedBy: 'acme',
+      });
+      expect(calls.submitRunSummary[1][2].run.triggeredBy).toBe('platform-retrigger');
+
+      delete process.env.GITHUB_EVENT_NAME;
+      process.env.BENCH_TRIGGER_SOURCE = '';
+      delete process.env.BENCH_TRIGGER_REQUESTED_BY;
+      await run();
+      expect(calls.createRun[2][1].config.trigger).toEqual({ source: 'manual' });
+    } finally {
+      process.env = savedEnv;
+    }
+  });
+
   it('propagates a ScoringSpecError from a misconfigured onScore instead of swallowing it as a warning', async () => {
     // weights sum to 0.5, not 1.0 — an authoring bug in onScore, not a
     // transient submit failure, so runBenchmark must reject rather than warn

--- a/packages/benchsdk-runner/src/__tests__/runner.test.ts
+++ b/packages/benchsdk-runner/src/__tests__/runner.test.ts
@@ -433,11 +433,12 @@ describe('runBenchmark', () => {
       });
       expect(calls.submitRunSummary[1][2].run.triggeredBy).toBe('platform-retrigger');
 
-      delete process.env.GITHUB_EVENT_NAME;
+      process.env.GITHUB_EVENT_NAME = '  ';
       process.env.BENCH_TRIGGER_SOURCE = '';
       delete process.env.BENCH_TRIGGER_REQUESTED_BY;
       await run();
       expect(calls.createRun[2][1].config.trigger).toEqual({ source: 'manual' });
+      expect(calls.submitRunSummary[2][2].run.triggeredBy).toBe('manual');
     } finally {
       process.env = savedEnv;
     }

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -508,11 +508,33 @@ function resolveParticipants<T extends BaseParticipant>(config: BenchmarkConfig<
   return available;
 }
 
+/**
+ * How this run came to be, for the platform's run record. `BENCH_TRIGGER_SOURCE`
+ * (e.g. `platform-retrigger`) is set by a workflow when something other than its
+ * own schedule or a human dispatch kicked it off; otherwise the GitHub event
+ * name (`schedule`, `workflow_dispatch`) or `manual` outside of CI.
+ */
+export function resolveTriggerSource(env: NodeJS.ProcessEnv = process.env): string {
+  const source = env.BENCH_TRIGGER_SOURCE?.trim();
+  if (source) return source;
+  return env.GITHUB_EVENT_NAME ?? 'manual';
+}
+
+function triggerToJson(env: NodeJS.ProcessEnv = process.env): JsonObject {
+  const requestedBy = env.BENCH_TRIGGER_REQUESTED_BY?.trim();
+  return {
+    source: resolveTriggerSource(env),
+    ...(env.GITHUB_EVENT_NAME ? { event: env.GITHUB_EVENT_NAME } : {}),
+    ...(requestedBy ? { requestedBy } : {}),
+  };
+}
+
 /** Builds a JSON-serializable snapshot of the resolved run execution config. */
-function runConfigToJson<T extends BaseParticipant>(
+export function runConfigToJson<T extends BaseParticipant>(
   config: BenchmarkConfig<T>,
   resolved: ResolvedRunConfig,
   participants: string[],
+  env: NodeJS.ProcessEnv = process.env,
 ): JsonObject {
   const phases = config.phases?.map((phase) => ({
     name: phase.name,
@@ -530,6 +552,7 @@ function runConfigToJson<T extends BaseParticipant>(
     ...(config.dimensions ? { dimensions: config.dimensions } : {}),
     ...(config.scoring ? { scoring: config.scoring } : {}),
     participants,
+    trigger: triggerToJson(env),
   };
   return JSON.parse(JSON.stringify(runConfig)) as JsonObject;
 }
@@ -665,7 +688,7 @@ export async function runBenchmark<T extends BaseParticipant>(
       const run = {
         gitSha: process.env.GITHUB_SHA ?? getGitSha(),
         gitRef: process.env.GITHUB_REF_NAME ?? process.env.GITHUB_REF ?? getGitRef(),
-        triggeredBy: process.env.GITHUB_EVENT_NAME ?? 'manual',
+        triggeredBy: resolveTriggerSource(),
         nodeVersion: process.version,
         platform: os.platform(),
         arch: os.arch(),

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -517,14 +517,15 @@ function resolveParticipants<T extends BaseParticipant>(config: BenchmarkConfig<
 export function resolveTriggerSource(env: NodeJS.ProcessEnv = process.env): string {
   const source = env.BENCH_TRIGGER_SOURCE?.trim();
   if (source) return source;
-  return env.GITHUB_EVENT_NAME ?? 'manual';
+  return env.GITHUB_EVENT_NAME?.trim() || 'manual';
 }
 
 function triggerToJson(env: NodeJS.ProcessEnv = process.env): JsonObject {
   const requestedBy = env.BENCH_TRIGGER_REQUESTED_BY?.trim();
+  const event = env.GITHUB_EVENT_NAME?.trim();
   return {
     source: resolveTriggerSource(env),
-    ...(env.GITHUB_EVENT_NAME ? { event: env.GITHUB_EVENT_NAME } : {}),
+    ...(event ? { event } : {}),
     ...(requestedBy ? { requestedBy } : {}),
   };
 }

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -522,11 +522,13 @@ export function resolveTriggerSource(env: NodeJS.ProcessEnv = process.env): stri
 
 function triggerToJson(env: NodeJS.ProcessEnv = process.env): JsonObject {
   const requestedBy = env.BENCH_TRIGGER_REQUESTED_BY?.trim();
+  const requestId = env.BENCH_TRIGGER_REQUEST_ID?.trim();
   const event = env.GITHUB_EVENT_NAME?.trim();
   return {
     source: resolveTriggerSource(env),
     ...(event ? { event } : {}),
     ...(requestedBy ? { requestedBy } : {}),
+    ...(requestId ? { requestId } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
Lets a workflow tell the platform *why* a run happened, so dashboard re-triggers of the daily benchmarks (computesdk/benchmarks-platform#251) are distinguishable from the cron schedule and from ad-hoc `workflow_dispatch` runs.

- New env vars read by the runner: `BENCH_TRIGGER_SOURCE` (e.g. `platform-retrigger`), optional `BENCH_TRIGGER_REQUESTED_BY` (requesting org slug), and optional `BENCH_TRIGGER_REQUEST_ID` (the platform's retrigger request id, used to link the run back to the request).
- `runConfigToJson` now emits `trigger: { source, event?, requestedBy?, requestId? }` into the run config sent to `createRun`, where `source = BENCH_TRIGGER_SOURCE || GITHUB_EVENT_NAME || 'manual'` and `event` is the raw `GITHUB_EVENT_NAME` when present.
- Run summary `run.triggeredBy` uses the same `resolveTriggerSource()`; unchanged (`schedule` / `workflow_dispatch` / `manual`) when the env var is unset.

Workflows that opt in: computesdk/benchmarks-daily#34 and the browser-concurrency / storage-concurrency / ai-gateway-model-index repos. The two published-package consumers only pick this up after the next `@benchsdk/runner` release.


Link to Devin session: https://app.devin.ai/sessions/9356f1d6fbbc46cfa5db98e2be4d4987
Open in Devin Desktop: https://app.devin.ai/desktop/session/9356f1d6fbbc46cfa5db98e2be4d4987?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->