### PR TITLE
fix(sandbox-tti): remove "Time to interactive" custom metric from burst TTI display

### DIFF
--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -106,12 +106,15 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
         log('node -v failed', { level: 'error', meta: { exitCode: r.exitCode, stderr: r.stderr ?? null } });
         throw new Error(`Command failed with exit code ${r.exitCode}: ${r.stderr || 'Unknown error'}`);
       }
+      if (createMs === undefined) {
+        throw new Error('create step did not produce a createMs measurement');
+      }
+      ttiMs = createMs + (performance.now() - commandStart);
       return r;
     });
-    if (createMs === undefined) {
-      throw new Error('create step did not produce a createMs measurement');
+    if (ttiMs === undefined) {
+      throw new Error('exec.task did not produce a ttiMs measurement');
     }
-    ttiMs = createMs + (performance.now() - commandStart);
     measure({ ttiMs });
     log('node -v succeeded', { level: 'info', meta: { version: result.stdout?.trim() ?? null, exitCode: result.exitCode } });
   } finally {

--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -42,9 +42,6 @@ export const config = defineBenchmarkConfig({
   concurrency: 1,
   participants: providers,
   display: {
-    metrics: [
-      { key: 'ttiMs', label: 'Time to interactive', unit: 'ms', direction: 'lower-better', decimals: 0 },
-    ],
     steps: [
       { key: 'create', label: 'Create sandbox' },
       { key: 'exec.task', label: 'Run first command' },
@@ -54,7 +51,7 @@ export const config = defineBenchmarkConfig({
   },
   scoring: {
     metrics: [
-      { key: 'ttiMs', ceiling: 10000, weights: { median: 0.60, p95: 0.25, p99: 0.15 } },
+      { key: 'ttiMs', unit: 'ms', ceiling: 10000, weights: { median: 0.60, p95: 0.25, p99: 0.15 } },
     ],
   },
   // Legacy JSON labels a burst run 'concurrent' (see merge-results /
@@ -109,13 +106,13 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
         log('node -v failed', { level: 'error', meta: { exitCode: r.exitCode, stderr: r.stderr ?? null } });
         throw new Error(`Command failed with exit code ${r.exitCode}: ${r.stderr || 'Unknown error'}`);
       }
-      if (createMs === undefined) {
-        throw new Error('create step did not produce a createMs measurement');
-      }
-      ttiMs = createMs + (performance.now() - commandStart);
-      measure({ ttiMs });
       return r;
     });
+    if (createMs === undefined) {
+      throw new Error('create step did not produce a createMs measurement');
+    }
+    ttiMs = createMs + (performance.now() - commandStart);
+    measure({ ttiMs });
     log('node -v succeeded', { level: 'info', meta: { version: result.stdout?.trim() ?? null, exitCode: result.exitCode } });
   } finally {
     if (sandbox) {


### PR DESCRIPTION
## Summary
#389 declared `ttiMs` in `display.metrics` and moved `measure({ ttiMs })` inside the `exec.task` step, which made the platform surface "Time to interactive" as a per-step custom metric. TTI has always just been the overall create → first-command task; the extra metric is redundant.

- Drop `display.metrics` from `tti.bench.ts` entirely (steps + `overview.defaultMetric: 'compositeScore'` stay).
- Record `ttiMs` at task level again (after the `exec.task` step, no longer in `step_data_json`), so it only feeds scoring / `data_json`. Scoring metric gets its `unit: 'ms'` back since display no longer provides it.
- `ttiMs` computation is unchanged (`createMs + command time`, from #404).

Audit: every other bench in this repo (and storage-concurrency / browser-concurrency) already uses `defaultMetric: 'compositeScore'`, except `sandbox/dax` (intentionally `task`) and `reliability/sandbox-opencode` (`task`, has no scoring so `compositeScore` isn't valid there).

Link to Devin session: https://app.devin.ai/sessions/8d67817df4224446a4d60efcc298093a
Open in Devin Desktop: https://app.devin.ai/desktop/session/8d67817df4224446a4d60efcc298093a?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->