### PR TITLE
fix(sandbox-tti): remove getInfo() and sandbox metadata from create step

### DIFF
--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -85,9 +85,6 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
         'Sandbox creation timed out',
       );
       createMs = performance.now() - createStart;
-      measure({ sandboxId: s.sandboxId, createMs });
-      const info = await s.getInfo();
-      measure({ createdAt: info.createdAt.toISOString() });
       return s;
     });
     if (sandbox === undefined) {


### PR DESCRIPTION
## Summary
#404 added `sandboxId`/`createMs`/`createdAt` step metadata (via an awaited `s.getInfo()`) to the `create` step of the burst TTI benchmark for sandbox-reuse detection. That metadata was never wanted; only the `bench iterations` command from that PR was.

The `getInfo()` round-trip was excluded from `ttiMs` but still counted toward the `create` step's latency, so the platform's "Create sandbox" step showed more time than was actually scored (e.g. givemeanode: 611 ms step vs 232 ms scored `createMs`). This removes the call and the three `measure()` fields so the displayed create step latency is just `sandbox.create()` again, matching what TTI scores.

```diff
   createMs = performance.now() - createStart;
-  measure({ sandboxId: s.sandboxId, createMs });
-  const info = await s.getInfo();
-  measure({ createdAt: info.createdAt.toISOString() });
   return s;
```

Scoring (`ttiMs = createMs + first command`) is unchanged. `bench iterations` is untouched.

Link to Devin session: https://app.devin.ai/sessions/8d67817df4224446a4d60efcc298093a
Open in Devin Desktop: https://app.devin.ai/desktop/session/8d67817df4224446a4d60efcc298093a?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->