### PR TITLE
ci(sandbox): comment out Lightning AI from sandbox benchmark workflows

### DIFF
--- a/.github/workflows/sandbox-capabilities.yml
+++ b/.github/workflows/sandbox-capabilities.yml
@@ -68,7 +68,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-cpu-node.yml
+++ b/.github/workflows/sandbox-cpu-node.yml
@@ -72,7 +72,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -76,7 +76,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-disk.yml
+++ b/.github/workflows/sandbox-disk.yml
@@ -72,7 +72,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-dns.yml
+++ b/.github/workflows/sandbox-dns.yml
@@ -61,7 +61,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-download.yml
+++ b/.github/workflows/sandbox-download.yml
@@ -61,7 +61,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-latency.yml
+++ b/.github/workflows/sandbox-latency.yml
@@ -61,7 +61,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-memory.yml
+++ b/.github/workflows/sandbox-memory.yml
@@ -72,7 +72,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-network-localhost.yml
+++ b/.github/workflows/sandbox-network-localhost.yml
@@ -72,7 +72,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-network-wan.yml
+++ b/.github/workflows/sandbox-network-wan.yml
@@ -72,7 +72,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-pgbench.yml
+++ b/.github/workflows/sandbox-pgbench.yml
@@ -72,7 +72,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-realworld.yml
+++ b/.github/workflows/sandbox-realworld.yml
@@ -61,7 +61,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-system.yml
+++ b/.github/workflows/sandbox-system.yml
@@ -72,7 +72,7 @@ jobs:
           - givemeanode
           - hopx
           - isorun
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/.github/workflows/sandbox-tti-benchmarks.yml
+++ b/.github/workflows/sandbox-tti-benchmarks.yml
@@ -83,7 +83,7 @@ jobs:
           - hopx
           - isorun
           # - lelantos
-          - lightning
+          # - lightning
           - modal
           - microsandbox
           - miosa

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,49 +248,49 @@ importers:
         version: link:../benchsdk-worker
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-api:
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-cli:
@@ -300,25 +300,25 @@ importers:
         version: link:../benchsdk-api
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-runner:
@@ -334,19 +334,19 @@ importers:
         version: link:../benchsdk-worker
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-worker:
@@ -356,43 +356,43 @@ importers:
         version: link:../benchsdk-api
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/create-bench:
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
 packages:


### PR DESCRIPTION
## Summary
Comments out `- lightning` in the provider matrix of all 14 `sandbox-*.yml` workflows so Lightning AI no longer runs in the sandbox benchmarks (same approach as `# - lelantos`, `# - namespace`, etc.).

The `LIGHTNING_API_KEY` entries in the vault-secret regexes, the `sandbox-capabilities.yml` case arm, and `LIGHTNING_INSTANCE_TYPE` in the dax workflow are left in place so re-enabling is a one-line uncomment per workflow.

Also resyncs `pnpm-lock.yaml`: bot commit 477c819 rewrote the lockfile with pinned specifiers (`^20.19.43`, `^1.6.1`, ...) that no longer matched the `packages/benchsdk-*/package.json` ranges (`^20.0.0`, `^1.0.0`, ...), breaking `pnpm install --frozen-lockfile` on master. Only `specifier:` lines change; resolved versions are unchanged.

Link to Devin session: https://app.devin.ai/sessions/fe2a1840e91f4bfe8cb115d362d8618c
Open in Devin Desktop: https://app.devin.ai/desktop/session/fe2a1840e91f4bfe8cb115d362d8618c?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->