### PR TITLE
Fix Beam DAX runtime consistency

### DIFF
--- a/benchmarks/scripts/dax-benchmark.sh
+++ b/benchmarks/scripts/dax-benchmark.sh
@@ -156,10 +156,17 @@ prepare() {
   # setuptools is optional - only needed for node-gyp native module compilation,
   # not for the clone/install/typecheck benchmark. Skip the check entirely.
 
-  # Install Node.js only if it's not already available. Some sandboxes (e.g.
-  # Vercel) ship Node.js pre-installed; respect that rather than trying to
-  # override it (the symlink may not take precedence in PATH).
-  if ! command -v node >/dev/null 2>&1; then
+  # Keep the benchmark runtime consistent on glibc images. Alpine uses its
+  # native Node package because the official Node archives are not musl builds.
+  local install_node=false
+  if [[ -z "$BUN_MUSL_SUFFIX" ]] && {
+    ! command -v node >/dev/null 2>&1 ||
+      [[ "$(node --version 2>/dev/null || true)" != "v${NODE_VERSION}" ]]
+  }; then
+    install_node=true
+  fi
+
+  if [[ "$install_node" == true ]]; then
     local archive="node-v${NODE_VERSION}-${NODE_ARCH}.tar.gz"
     local prefix="/opt/node-v${NODE_VERSION}-${NODE_ARCH}"
     if ! curl -fsSL "https://nodejs.org/download/release/v${NODE_VERSION}/${archive}" -o "/tmp/${archive}"; then

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,8 +599,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@beamcloud/beam-js@1.0.17':
-    resolution: {integrity: sha512-LcgLeUDYZajTOktXXwRiWH6waE7ikWdaM5PjVv0bctjEOxwwFuUEtEc2iyj3SYAXaCJaXDiWs1LSB5frIkzBhQ==}
+  '@beamcloud/beam-js@1.0.18':
+    resolution: {integrity: sha512-G6rAd3PD/jfLvDO+WFoR+Rf7AuzbJ3rgEtTPiK+z0p4CDsTli6vxGA0zy/f8EqZ7i4OeCPlqmlp9sOeVmGE73Q==}
     peerDependencies:
       typescript: ^5.0.0
 
@@ -6058,7 +6058,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@beamcloud/beam-js@1.0.17(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@beamcloud/beam-js@1.0.18(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       axios: 1.20.0
       commander: 12.1.0
@@ -6362,7 +6362,7 @@ snapshots:
 
   '@computesdk/beam@0.3.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@beamcloud/beam-js': 1.0.17(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@beamcloud/beam-js': 1.0.18(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@computesdk/provider': 2.1.5
       computesdk: 4.1.4
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- use the benchmark-pinned Node release on glibc sandboxes instead of inheriting provider image drift
- preserve Alpine native Node handling for musl compatibility
- lock Beam JS 1.0.18 so deferred DAX commands return complete output

## Validation
- `pnpm typecheck`
- `pnpm --filter @benchsdk/runner test` (127/127)
- `bash -n benchmarks/scripts/dax-benchmark.sh`
- production DAX validation from an isolated Kubernetes pod: 7/7 phases, exit 0, 62.129 s wall time
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->