### PR TITLE
Use Beam JS 1.0.18 in benchmarks

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,8 +599,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@beamcloud/beam-js@1.0.17':
-    resolution: {integrity: sha512-LcgLeUDYZajTOktXXwRiWH6waE7ikWdaM5PjVv0bctjEOxwwFuUEtEc2iyj3SYAXaCJaXDiWs1LSB5frIkzBhQ==}
+  '@beamcloud/beam-js@1.0.18':
+    resolution: {integrity: sha512-G6rAd3PD/jfLvDO+WFoR+Rf7AuzbJ3rgEtTPiK+z0p4CDsTli6vxGA0zy/f8EqZ7i4OeCPlqmlp9sOeVmGE73Q==}
     peerDependencies:
       typescript: ^5.0.0
 
@@ -6058,7 +6058,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@beamcloud/beam-js@1.0.17(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+  '@beamcloud/beam-js@1.0.18(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
       axios: 1.20.0
       commander: 12.1.0
@@ -6362,7 +6362,7 @@ snapshots:
 
   '@computesdk/beam@0.3.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@beamcloud/beam-js': 1.0.17(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@beamcloud/beam-js': 1.0.18(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@computesdk/provider': 2.1.5
       computesdk: 4.1.4
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- resolve @computesdk/beam's Beam JS dependency to 1.0.18 in the benchmark lockfile
- pick up complete deferred-command output required by DAX
- keep this PR Beam-specific; the provider-neutral DAX runtime setup is split into #417

The durable source constraint lives with the Beam provider in computesdk/computesdk#779. This repository does not add a pnpm override.

## Validation
- `pnpm typecheck`
- `pnpm --filter @benchsdk/runner test` (127/127)
- combined Beam validation completed all 7/7 DAX phases

No production resources were changed.