### PR TITLE
feat(dax): surface failed phase and script output in error logs

### DIFF
--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -31,6 +31,56 @@ import { BENCH_SCRIPT_PATH } from './dax.js';
 import type { DaxTimingResult } from './dax.js';
 import { writeDaxLegacyResults } from './dax-legacy-results.js';
 
+/** Raw build output kept alongside the timing so failures can be diagnosed from the logs. */
+interface DaxBuildOutput {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  failedPhase?: string;
+}
+
+const OUTPUT_TAIL_LINES = 40;
+const ERROR_MAX_CHARS = 1200;
+
+/** Lines the benchmark script prints for its own bookkeeping, not diagnostics. */
+function isStructuredLine(line: string): boolean {
+  return /^BENCH_(PHASE|META|DISK|DONE|CACHE|ERROR)\t/.test(line) || /^\|/.test(line) || line.trim() === '';
+}
+
+function humanLines(output: string): string[] {
+  return output.split('\n').map((l) => l.trimEnd()).filter((l) => !isStructuredLine(l));
+}
+
+function tail(output: string, n = OUTPUT_TAIL_LINES): string {
+  return humanLines(output).slice(-n).join('\n');
+}
+
+const INTERESTING = /\b(error|fatal|failed|killed|panic|denied|not found|no space|out of memory|timed? ?out|ENOSPC|ENOMEM|EACCES|SIGKILL|E:)\b/i;
+
+/**
+ * Build a compact, human-meaningful failure summary from the script output:
+ * lines that look like real errors (from stdout and stderr, since bun/turbo/tsc
+ * print theirs to stdout) followed by the stderr tail. Structured BENCH_* lines,
+ * the result table and blank lines are dropped; the whole thing is capped so it
+ * stays usable as a single `error` string.
+ */
+function summarizeFailure(stdout: string, stderr: string): string {
+  const seen = new Set<string>();
+  const picked: string[] = [];
+  const push = (line: string) => {
+    if (seen.has(line)) return;
+    seen.add(line);
+    picked.push(line);
+  };
+  for (const line of [...humanLines(stdout), ...humanLines(stderr)]) {
+    if (INTERESTING.test(line)) push(line);
+  }
+  for (const line of humanLines(stderr).slice(-5)) push(line);
+  if (picked.length === 0) for (const line of humanLines(stdout).slice(-5)) push(line);
+  const summary = picked.slice(-12).join(' | ');
+  return summary.length > ERROR_MAX_CHARS ? summary.slice(0, ERROR_MAX_CHARS - 1) + '…' : summary;
+}
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const timeout = 600_000;
@@ -135,7 +185,11 @@ function getSandboxOptionsWithResources(providerName: string, baseOptions?: Reco
 }
 
 /** Runs the build script inside `sandbox` and parses its structured output. */
-async function runDaxBuild(sandbox: any, providerName: string, buildTimeout: number): Promise<DaxTimingResult> {
+async function runDaxBuild(
+  sandbox: any,
+  providerName: string,
+  buildTimeout: number,
+): Promise<{ timing: DaxTimingResult; output: DaxBuildOutput }> {
   // Load the benchmark script from the local filesystem rather than fetching
   // it over HTTP inside the sandbox. This eliminates a curl dependency
   // (several providers don't ship curl in their sandboxes).
@@ -155,11 +209,17 @@ async function runDaxBuild(sandbox: any, providerName: string, buildTimeout: num
     `BENCH_PROVIDER=${providerName} BENCH_REGION=unknown bash /tmp/dax-benchmark.sh`;
 
   const totalStart = Date.now();
-  const result = await withTimeout(
-    sandbox.runCommand(shellCmd, { timeout: buildTimeout }),
-    buildTimeout,
-    'Dax benchmark timed out',
-  ) as { exitCode: number; stdout?: string; stderr?: string };
+  let result: { exitCode: number; stdout?: string; stderr?: string };
+  try {
+    result = await withTimeout(
+      sandbox.runCommand(shellCmd, { timeout: buildTimeout }),
+      buildTimeout,
+      `Dax benchmark timed out after ${buildTimeout}ms`,
+    ) as { exitCode: number; stdout?: string; stderr?: string };
+  } catch (err) {
+    const elapsedMs = Date.now() - totalStart;
+    throw new Error(`runCommand failed after ${elapsedMs}ms: ${formatError(err)}`, { cause: err });
+  }
   const totalMs = Date.now() - totalStart;
 
   const stdout = result.stdout || '';
@@ -189,36 +249,44 @@ async function runDaxBuild(sandbox: any, providerName: string, buildTimeout: num
     }
   }
 
+  // The script emits BENCH_ERROR\t<phase>\t<reason> for failures it detects itself.
+  let scriptErrorPhase: string | null = null;
   for (const line of stderr.split('\n')) {
     if (line.startsWith('BENCH_ERROR\t')) {
       const parts = line.split('\t');
+      scriptErrorPhase = parts[1] ?? null;
       benchError = parts.slice(1).join(': ');
     }
-  }
-
-  if (exitCode !== 0 && !benchError) {
-    // Include last few lines of stderr for diagnostics
-    const tail = stderr.trim().split('\n').slice(-3).join(' | ');
-    benchError = 'Script exited with code ' + exitCode + (tail ? ': ' + tail : '');
   }
 
   // Count completed phases
   const phaseKeys = ['prepare', 'cache_clear', 'bun_download', 'bun_unpack', 'clone', 'install', 'typecheck'];
   const rawPhasesCompleted = phaseKeys.filter(k => phases[k] !== undefined).length;
+  const failed = exitCode !== 0 || benchError !== null || doneCommit === null;
   // The script's phase() function emits BENCH_PHASE even for the failing phase (it prints timing before checking exit code).
-  // When there's an error, the last phase that emitted a BENCH_PHASE line is the one that failed, so don't count it.
-  const phasesCompleted = benchError ? Math.max(0, rawPhasesCompleted - 1) : rawPhasesCompleted;
+  // When the run failed, the last phase that emitted a BENCH_PHASE line is the one that failed, so don't count it.
+  const phasesCompleted = failed ? Math.max(0, rawPhasesCompleted - 1) : rawPhasesCompleted;
   // Determine which phase failed so we can exclude its timing from the result.
   // The failed phase is the last one that emitted BENCH_PHASE (index rawPhasesCompleted - 1).
-  const failedPhaseKey = benchError && rawPhasesCompleted > 0 ? phaseKeys[rawPhasesCompleted - 1] : null;
+  const failedPhaseKey = failed && rawPhasesCompleted > 0 ? phaseKeys[rawPhasesCompleted - 1] : null;
+  const failedPhase = scriptErrorPhase ?? failedPhaseKey ?? undefined;
 
-  // If no phases completed, the script didn't actually run (e.g. heredoc failure)
-  if (phasesCompleted === 0 && !benchError) {
-    const tail = stderr.trim().split('\n').slice(-2).join(' | ');
-    benchError = 'No benchmark phases completed' + (tail ? ': ' + tail : '');
+  if (failed && !benchError) {
+    const detail = summarizeFailure(stdout, stderr);
+    const where = failedPhase
+      ? `${failedPhase} phase failed`
+      : rawPhasesCompleted === 0
+        ? 'no benchmark phases ran (script did not start)'
+        : 'script failed';
+    benchError = `${where} (exit code ${exitCode}, ${phasesCompleted}/${phaseKeys.length} phases completed)` + (detail ? `: ${detail}` : '');
+  } else if (benchError) {
+    const detail = summarizeFailure(stdout, stderr.split('\n').filter((l) => !l.startsWith('BENCH_ERROR\t')).join('\n'));
+    if (detail) benchError += `: ${detail}`;
   }
 
-  return {
+  const output: DaxBuildOutput = { exitCode, stdout, stderr, ...(failedPhase ? { failedPhase } : {}) };
+
+  const timing: DaxTimingResult = {
     totalMs,
     phasesCompleted,
     phasesTotal: phaseKeys.length,
@@ -242,6 +310,11 @@ async function runDaxBuild(sandbox: any, providerName: string, buildTimeout: num
     memoryKib: meta.memory_kib,
     ...(benchError ? { error: benchError } : {}),
   };
+  return { timing, output };
+}
+
+function indent(text: string): string {
+  return text.split('\n').map((l) => `    ${l}`).join('\n');
 }
 
 /** Emit each measured build phase as a pre-measured platform step. */
@@ -269,18 +342,27 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
   const compute = p.createCompute();
   const opts = getSandboxOptionsWithResources(p.name, p.sandboxOptions);
 
+  const createStart = Date.now();
   const sandbox = await ctx.step('create', () =>
     withTimeout<{ destroy(): Promise<unknown> }>(
       compute.sandbox.create(opts),
       p.timeout ?? timeout,
       'Sandbox creation timed out',
     ),
-  );
+  ).catch((err: unknown) => {
+    const message = `sandbox create failed after ${Date.now() - createStart}ms: ${formatError(err)}`;
+    log('Sandbox create failed', { level: 'error', meta: { provider: p.name, error: message } });
+    console.error(`  [${p.name}] ${message}`);
+    throw new TaskError(message, { code: 'create_failed', data: { error: message } });
+  });
 
   let timing: DaxTimingResult;
+  let output: DaxBuildOutput | undefined;
   try {
     timing = await ctx.step('build', async () => {
-      const t = await runDaxBuild(sandbox, p.name, p.timeout ?? timeout);
+      const build = await runDaxBuild(sandbox, p.name, p.timeout ?? timeout);
+      output = build.output;
+      const t = build.timing;
       const buildMetrics: JsonObject = { totalMs: t.totalMs };
       if (t.phasesCompleted !== undefined) buildMetrics.phasesCompleted = t.phasesCompleted;
       if (t.phasesTotal !== undefined) buildMetrics.phasesTotal = t.phasesTotal;
@@ -298,19 +380,33 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
       .catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { error: formatError(err) } }));
   }
 
-  const data = timing as unknown as JsonObject;
+  const data = { ...(timing as unknown as JsonObject), ...(output?.failedPhase ? { failedPhase: output.failedPhase } : {}) };
   const steps = daxPhaseSteps(timing);
 
   if (timing.error) {
+    const stdoutTail = output ? tail(output.stdout) : '';
+    const stderrTail = output ? tail(output.stderr) : '';
     log('Dax build failed', {
       level: 'error',
       meta: {
         provider: p.name,
         totalMs: timing.totalMs,
         phasesCompleted: `${timing.phasesCompleted}/${timing.phasesTotal}`,
+        ...(output?.failedPhase ? { failedPhase: output.failedPhase } : {}),
+        ...(output ? { exitCode: output.exitCode } : {}),
         error: timing.error,
+        ...(stdoutTail ? { stdoutTail } : {}),
+        ...(stderrTail ? { stderrTail } : {}),
       },
     });
+    console.error(
+      [
+        `  [${p.name}] Dax build failed${output?.failedPhase ? ` in ${output.failedPhase}` : ''}` +
+          ` (${timing.phasesCompleted}/${timing.phasesTotal} phases, exit ${output?.exitCode ?? 'n/a'}): ${timing.error}`,
+        ...(stderrTail ? ['  --- stderr (tail) ---', indent(stderrTail)] : []),
+        ...(stdoutTail ? ['  --- stdout (tail) ---', indent(stdoutTail)] : []),
+      ].join('\n'),
+    );
     throw new TaskError(timing.error, { code: 'dax_failed', data, steps });
   }
 

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -44,7 +44,7 @@ const ERROR_MAX_CHARS = 1200;
 
 /** Lines the benchmark script prints for its own bookkeeping, not diagnostics. */
 function isStructuredLine(line: string): boolean {
-  return /^BENCH_(PHASE|META|DISK|DONE|CACHE|ERROR)\t/.test(line) || /^\|/.test(line) || line.trim() === '';
+  return /^BENCH_(PHASE|META|DISK|DONE|CACHE|ERROR|FAIL)\t/.test(line) || /^\|/.test(line) || line.trim() === '';
 }
 
 function humanLines(output: string): string[] {
@@ -232,6 +232,10 @@ async function runDaxBuild(
   const disk: Record<string, number> = {};
   let benchError: string | null = null;
   let doneCommit: string | null = null;
+  // BENCH_FAIL\t<stage> is printed by the script's exit trap on any non-zero
+  // exit: the measured phase whose command failed, or `bookkeeping` when a
+  // command between phases (mkdir, version/disk probe, ...) tripped `set -e`.
+  let failStage: string | null = null;
 
   for (const line of stdout.split('\n')) {
     if (line.startsWith('BENCH_PHASE\t')) {
@@ -246,6 +250,9 @@ async function runDaxBuild(
     } else if (line.startsWith('BENCH_DONE\t')) {
       const parts = line.split('\t');
       if (parts.length >= 2) doneCommit = parts[1];
+    } else if (line.startsWith('BENCH_FAIL\t')) {
+      const parts = line.split('\t');
+      if (parts.length >= 2 && parts[1]) failStage = parts[1];
     }
   }
 
@@ -263,18 +270,28 @@ async function runDaxBuild(
   const phaseKeys = ['prepare', 'cache_clear', 'bun_download', 'bun_unpack', 'clone', 'install', 'typecheck'];
   const rawPhasesCompleted = phaseKeys.filter(k => phases[k] !== undefined).length;
   const failed = exitCode !== 0 || benchError !== null || doneCommit === null;
-  // The script's phase() function emits BENCH_PHASE even for the failing phase (it prints timing before checking exit code).
-  // When the run failed, the last phase that emitted a BENCH_PHASE line is the one that failed, so don't count it.
-  const phasesCompleted = failed ? Math.max(0, rawPhasesCompleted - 1) : rawPhasesCompleted;
-  // Determine which phase failed so we can exclude its timing from the result.
-  // The failed phase is the last one that emitted BENCH_PHASE (index rawPhasesCompleted - 1).
-  const failedPhaseKey = failed && rawPhasesCompleted > 0 ? phaseKeys[rawPhasesCompleted - 1] : null;
-  const failedPhase = scriptErrorPhase ?? failedPhaseKey ?? undefined;
+  // The measured phase whose timing must be discarded. Prefer the script's
+  // explicit stage; without it (script killed before the trap ran) fall back
+  // to the last phase that emitted BENCH_PHASE, since phase() prints timing
+  // before checking the exit code.
+  let failedPhaseKey: string | null = null;
+  if (failed) {
+    const explicit = failStage ?? scriptErrorPhase;
+    if (explicit !== null) {
+      failedPhaseKey = phaseKeys.includes(explicit) && phases[explicit] !== undefined ? explicit : null;
+    } else if (rawPhasesCompleted > 0) {
+      failedPhaseKey = phaseKeys[rawPhasesCompleted - 1];
+    }
+  }
+  const phasesCompleted = failedPhaseKey ? rawPhasesCompleted - 1 : rawPhasesCompleted;
+  const failedPhase = scriptErrorPhase ?? failStage ?? failedPhaseKey ?? undefined;
 
   if (failed && !benchError) {
     const detail = summarizeFailure(stdout, stderr);
     const where = failedPhase
-      ? `${failedPhase} phase failed`
+      ? failedPhase === 'bookkeeping'
+        ? `script failed between phases (after ${phaseKeys[rawPhasesCompleted - 1] ?? 'start'})`
+        : `${failedPhase} phase failed`
       : rawPhasesCompleted === 0
         ? 'no benchmark phases ran (script did not start)'
         : 'script failed';

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -42,42 +42,20 @@ interface DaxBuildOutput {
 const OUTPUT_TAIL_LINES = 40;
 const ERROR_MAX_CHARS = 1200;
 
-/** Lines the benchmark script prints for its own bookkeeping, not diagnostics. */
-function isStructuredLine(line: string): boolean {
-  return /^BENCH_(PHASE|META|DISK|DONE|CACHE|ERROR|FAIL)\t/.test(line) || /^\|/.test(line) || line.trim() === '';
+/** Last `n` non-empty lines of `output`, excluding the script's structured BENCH_* lines. */
+function tail(output: string, n: number): string {
+  return output
+    .split('\n')
+    .map((l) => l.trimEnd())
+    .filter((l) => l !== '' && !l.startsWith('BENCH_'))
+    .slice(-n)
+    .join('\n');
 }
 
-function humanLines(output: string): string[] {
-  return output.split('\n').map((l) => l.trimEnd()).filter((l) => !isStructuredLine(l));
-}
-
-function tail(output: string, n = OUTPUT_TAIL_LINES): string {
-  return humanLines(output).slice(-n).join('\n');
-}
-
-const INTERESTING = /\b(error|fatal|failed|killed|panic|denied|not found|no space|out of memory|timed? ?out|ENOSPC|ENOMEM|EACCES|SIGKILL|E:)\b/i;
-
-/**
- * Build a compact, human-meaningful failure summary from the script output:
- * lines that look like real errors (from stdout and stderr, since bun/turbo/tsc
- * print theirs to stdout) followed by the stderr tail. Structured BENCH_* lines,
- * the result table and blank lines are dropped; the whole thing is capped so it
- * stays usable as a single `error` string.
- */
+/** Short one-line detail for the `error` string; the full tails go to the log. */
 function summarizeFailure(stdout: string, stderr: string): string {
-  const seen = new Set<string>();
-  const picked: string[] = [];
-  const push = (line: string) => {
-    if (seen.has(line)) return;
-    seen.add(line);
-    picked.push(line);
-  };
-  for (const line of [...humanLines(stdout), ...humanLines(stderr)]) {
-    if (INTERESTING.test(line)) push(line);
-  }
-  for (const line of humanLines(stderr).slice(-5)) push(line);
-  if (picked.length === 0) for (const line of humanLines(stdout).slice(-5)) push(line);
-  const summary = picked.slice(-12).join(' | ');
+  const parts = [tail(stderr, 5), tail(stdout, 5)].filter(Boolean);
+  const summary = parts.join('\n').split('\n').join(' | ');
   return summary.length > ERROR_MAX_CHARS ? summary.slice(0, ERROR_MAX_CHARS - 1) + '…' : summary;
 }
 
@@ -232,10 +210,8 @@ async function runDaxBuild(
   const disk: Record<string, number> = {};
   let benchError: string | null = null;
   let doneCommit: string | null = null;
-  // BENCH_FAIL\t<stage> is printed by the script's exit trap on any non-zero
-  // exit: the measured phase whose command failed, or `bookkeeping` when a
-  // command between phases (mkdir, version/disk probe, ...) tripped `set -e`.
-  let failStage: string | null = null;
+  // BENCH_FAIL\t<phase> is printed by phase() when the measured command fails.
+  let failedPhase: string | null = null;
 
   for (const line of stdout.split('\n')) {
     if (line.startsWith('BENCH_PHASE\t')) {
@@ -252,16 +228,14 @@ async function runDaxBuild(
       if (parts.length >= 2) doneCommit = parts[1];
     } else if (line.startsWith('BENCH_FAIL\t')) {
       const parts = line.split('\t');
-      if (parts.length >= 2 && parts[1]) failStage = parts[1];
+      if (parts.length >= 2 && parts[1]) failedPhase = parts[1];
     }
   }
 
-  // The script emits BENCH_ERROR\t<phase>\t<reason> for failures it detects itself.
-  let scriptErrorPhase: string | null = null;
   for (const line of stderr.split('\n')) {
     if (line.startsWith('BENCH_ERROR\t')) {
       const parts = line.split('\t');
-      scriptErrorPhase = parts[1] ?? null;
+      if (!failedPhase && parts[1]) failedPhase = parts[1];
       benchError = parts.slice(1).join(': ');
     }
   }
@@ -270,35 +244,20 @@ async function runDaxBuild(
   const phaseKeys = ['prepare', 'cache_clear', 'bun_download', 'bun_unpack', 'clone', 'install', 'typecheck'];
   const rawPhasesCompleted = phaseKeys.filter(k => phases[k] !== undefined).length;
   const failed = exitCode !== 0 || benchError !== null || doneCommit === null;
-  // The measured phase whose timing must be discarded. Prefer the script's
-  // explicit stage; without it (script killed before the trap ran) fall back
-  // to the last phase that emitted BENCH_PHASE, since phase() prints timing
-  // before checking the exit code.
-  let failedPhaseKey: string | null = null;
-  if (failed) {
-    const explicit = failStage ?? scriptErrorPhase;
-    if (explicit !== null) {
-      failedPhaseKey = phaseKeys.includes(explicit) && phases[explicit] !== undefined ? explicit : null;
-    } else if (rawPhasesCompleted > 0) {
-      failedPhaseKey = phaseKeys[rawPhasesCompleted - 1];
-    }
-  }
+  // phase() prints BENCH_PHASE (timing) before BENCH_FAIL, so the failed phase's
+  // timing must be dropped and not counted as completed.
+  const failedPhaseKey = failedPhase && phases[failedPhase] !== undefined ? failedPhase : null;
   const phasesCompleted = failedPhaseKey ? rawPhasesCompleted - 1 : rawPhasesCompleted;
-  const failedPhase = scriptErrorPhase ?? failStage ?? failedPhaseKey ?? undefined;
 
-  if (failed && !benchError) {
+  if (failed) {
     const detail = summarizeFailure(stdout, stderr);
     const where = failedPhase
-      ? failedPhase === 'bookkeeping'
-        ? `script failed between phases (after ${phaseKeys[rawPhasesCompleted - 1] ?? 'start'})`
-        : `${failedPhase} phase failed`
+      ? `${failedPhase} phase failed`
       : rawPhasesCompleted === 0
         ? 'no benchmark phases ran (script did not start)'
-        : 'script failed';
-    benchError = `${where} (exit code ${exitCode}, ${phasesCompleted}/${phaseKeys.length} phases completed)` + (detail ? `: ${detail}` : '');
-  } else if (benchError) {
-    const detail = summarizeFailure(stdout, stderr.split('\n').filter((l) => !l.startsWith('BENCH_ERROR\t')).join('\n'));
-    if (detail) benchError += `: ${detail}`;
+        : `script failed after ${phaseKeys[rawPhasesCompleted - 1]}`;
+    benchError = `${where} (exit code ${exitCode}, ${phasesCompleted}/${phaseKeys.length} phases completed)` +
+      (benchError ? `: ${benchError}` : '') + (detail ? `: ${detail}` : '');
   }
 
   const output: DaxBuildOutput = { exitCode, stdout, stderr, ...(failedPhase ? { failedPhase } : {}) };
@@ -401,8 +360,8 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
   const steps = daxPhaseSteps(timing);
 
   if (timing.error) {
-    const stdoutTail = output ? tail(output.stdout) : '';
-    const stderrTail = output ? tail(output.stderr) : '';
+    const stdoutTail = output ? tail(output.stdout, OUTPUT_TAIL_LINES) : '';
+    const stderrTail = output ? tail(output.stderr, OUTPUT_TAIL_LINES) : '';
     log('Dax build failed', {
       level: 'error',
       meta: {

--- a/benchmarks/scripts/dax-benchmark.sh
+++ b/benchmarks/scripts/dax-benchmark.sh
@@ -246,7 +246,9 @@ cleanup() {
   fi
   exit "$status"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 total_start="$(timestamp)"
 if ! phase prepare prepare; then

--- a/benchmarks/scripts/dax-benchmark.sh
+++ b/benchmarks/scripts/dax-benchmark.sh
@@ -60,9 +60,6 @@ else
 fi
 
 declare -A PHASE_MS=()
-# Name of the measured phase currently running; cleared once it succeeds so a
-# non-zero exit from bookkeeping between phases is reported as such.
-FAILED_PHASE=""
 
 # Return a nanosecond epoch timestamp. GNU coreutils `date` supports %N and
 # yields a 19-digit value. BusyBox `date` (Alpine) does not expand %N, emitting
@@ -82,7 +79,6 @@ phase() {
   local name="$1"
   shift
   local start end
-  FAILED_PHASE="$name"
   start="$(timestamp)"
   set +e
   "$@"
@@ -91,7 +87,7 @@ phase() {
   end="$(timestamp)"
   PHASE_MS["$name"]="$(( (end - start) / 1000000 ))"
   printf 'BENCH_PHASE\t%s\t%s\n' "$name" "${PHASE_MS[$name]}"
-  if [[ "$status" -eq 0 ]]; then FAILED_PHASE=""; fi
+  if [[ "$status" -ne 0 ]]; then printf 'BENCH_FAIL\t%s\n' "$name"; fi
   return "$status"
 }
 
@@ -238,17 +234,12 @@ clear_caches() {
 
 cleanup() {
   local status=$?
-  if [[ "$status" -ne 0 ]]; then
-    printf 'BENCH_FAIL\t%s\n' "${FAILED_PHASE:-bookkeeping}"
-  fi
   if [[ "$KEEP_ROOT" != "true" ]]; then
     rm -rf "$ROOT"
   fi
   exit "$status"
 }
-trap cleanup EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
+trap cleanup EXIT INT TERM
 
 total_start="$(timestamp)"
 if ! phase prepare prepare; then

--- a/benchmarks/scripts/dax-benchmark.sh
+++ b/benchmarks/scripts/dax-benchmark.sh
@@ -60,6 +60,9 @@ else
 fi
 
 declare -A PHASE_MS=()
+# Name of the measured phase currently running; cleared once it succeeds so a
+# non-zero exit from bookkeeping between phases is reported as such.
+FAILED_PHASE=""
 
 # Return a nanosecond epoch timestamp. GNU coreutils `date` supports %N and
 # yields a 19-digit value. BusyBox `date` (Alpine) does not expand %N, emitting
@@ -79,6 +82,7 @@ phase() {
   local name="$1"
   shift
   local start end
+  FAILED_PHASE="$name"
   start="$(timestamp)"
   set +e
   "$@"
@@ -87,6 +91,7 @@ phase() {
   end="$(timestamp)"
   PHASE_MS["$name"]="$(( (end - start) / 1000000 ))"
   printf 'BENCH_PHASE\t%s\t%s\n' "$name" "${PHASE_MS[$name]}"
+  if [[ "$status" -eq 0 ]]; then FAILED_PHASE=""; fi
   return "$status"
 }
 
@@ -233,6 +238,9 @@ clear_caches() {
 
 cleanup() {
   local status=$?
+  if [[ "$status" -ne 0 ]]; then
+    printf 'BENCH_FAIL\t%s\n' "${FAILED_PHASE:-bookkeeping}"
+  fi
   if [[ "$KEEP_ROOT" != "true" ]]; then
     rm -rf "$ROOT"
   fi

--- a/packages/benchsdk-runner/src/runner.ts
+++ b/packages/benchsdk-runner/src/runner.ts
@@ -438,7 +438,9 @@ function defaultOnResult(record: TaskResultRecord, meta: { iterations: number; p
     const data = record.data && Object.keys(record.data).length > 0 ? ` ${JSON.stringify(record.data)}` : '';
     console.log(`  [${meta.participant}] Task ${n}/${meta.iterations}: success${data}`);
   } else {
-    console.log(`  [${meta.participant}] Task ${n}/${meta.iterations}: FAILED — ${record.errorCode ?? 'unknown error'}`);
+    const detail = record.data?.errorMessage ?? record.data?.error;
+    const suffix = typeof detail === 'string' && detail.length > 0 ? `: ${detail}` : '';
+    console.log(`  [${meta.participant}] Task ${n}/${meta.iterations}: FAILED — ${record.errorCode ?? 'unknown error'}${suffix}`);
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,49 +248,49 @@ importers:
         version: link:../benchsdk-worker
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-api:
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-cli:
@@ -300,25 +300,25 @@ importers:
         version: link:../benchsdk-api
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-runner:
@@ -334,19 +334,19 @@ importers:
         version: link:../benchsdk-worker
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-worker:
@@ -356,43 +356,43 @@ importers:
         version: link:../benchsdk-api
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/create-bench:
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
 packages:


### PR DESCRIPTION
## Summary

Sandbox DAX failures currently surface as e.g. `Script exited with code 1: error: "turbo" exited with code 1` — the real diagnostic (tsc error, bun install failure, apt error) is lost because only 3 stderr lines were kept and build tools print to stdout.

Changes (deliberately kept minimal):

- **`dax-benchmark.sh`**: `phase()` prints `BENCH_FAIL\t<name>` when the measured command fails, so the parser no longer has to guess which phase failed from the last `BENCH_PHASE` line.
- **`dax.bench.ts`**:
  - `error` string is now `<phase> phase failed (exit code N, k/7 phases completed): <last 5 stderr lines | last 5 stdout lines>` (capped at 1200 chars). Without `BENCH_FAIL` (a command between phases tripped `set -e`) it says `script failed after <last phase>` and keeps all emitted timings.
  - On failure, the task log gets a `Dax build failed` entry with `failedPhase`, `exitCode`, and verbatim 40-line `stdoutTail`/`stderrTail` (ends up in `worker.log`/`coordinator.log`), plus the same block via `console.error` for the CI console.
  - `runCommand`/timeout and `sandbox.create` failures include elapsed ms and the formatted cause chain.
- **`runner.ts`**: `FAILED — <code>` line appends `data.errorMessage ?? data.error` when present.
- **`pnpm-lock.yaml`**: restored to the state matching `packages/benchsdk-api/package.json` (an earlier commit pinned specifiers in the lockfile only, breaking `--frozen-lockfile` in CI).

Legacy `results/sandbox-dax` JSON shape is unchanged (writer whitelists fields).

Verified: `pnpm typecheck`, runner tests, `bash -n`, and live Tensorlake runs (baseline, induced typecheck failure, induced post-clone failure) — see PR comment below (done on the earlier, more elaborate version; the simplified version was re-verified with fixtures/typecheck only).

Link to Devin session: https://app.devin.ai/sessions/127ba622f9c442eeb8f0bab51dadfb67
Open in Devin Desktop: https://app.devin.ai/desktop/session/127ba622f9c442eeb8f0bab51dadfb67?variant=devin
Requested by: @kisernl
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->