### PR TITLE
ci: accept trigger_source inputs on weekly benchmark workflows

### DIFF
--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -63,6 +63,18 @@ on:
         required: false
         default: false
         type: boolean
+      trigger_source:
+        description: 'Recorded on platform runs as their trigger (e.g. platform-retrigger); leave empty for a plain manual run'
+        required: false
+        default: ''
+      trigger_requested_by:
+        description: 'Who asked for this run (e.g. the platform org slug); recorded alongside trigger_source'
+        required: false
+        default: ''
+      trigger_request_id:
+        description: 'Platform re-trigger request id; recorded so the platform can link this run back to the request'
+        required: false
+        default: ''
 
 concurrency:
   group: ai-gateway-benchmarks
@@ -75,6 +87,9 @@ permissions:
 
 env:
   BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCH_TRIGGER_SOURCE: ${{ github.event.inputs.trigger_source || '' }}
+  BENCH_TRIGGER_REQUESTED_BY: ${{ github.event.inputs.trigger_requested_by || '' }}
+  BENCH_TRIGGER_REQUEST_ID: ${{ github.event.inputs.trigger_request_id || '' }}
   BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:

--- a/.github/workflows/browser-benchmarks.yml
+++ b/.github/workflows/browser-benchmarks.yml
@@ -29,6 +29,18 @@ on:
         required: false
         default: false
         type: boolean
+      trigger_source:
+        description: 'Recorded on platform runs as their trigger (e.g. platform-retrigger); leave empty for a plain manual run'
+        required: false
+        default: ''
+      trigger_requested_by:
+        description: 'Who asked for this run (e.g. the platform org slug); recorded alongside trigger_source'
+        required: false
+        default: ''
+      trigger_request_id:
+        description: 'Platform re-trigger request id; recorded so the platform can link this run back to the request'
+        required: false
+        default: ''
 
 concurrency:
   group: browser-benchmarks
@@ -41,6 +53,9 @@ permissions:
 
 env:
   BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCH_TRIGGER_SOURCE: ${{ github.event.inputs.trigger_source || '' }}
+  BENCH_TRIGGER_REQUESTED_BY: ${{ github.event.inputs.trigger_requested_by || '' }}
+  BENCH_TRIGGER_REQUEST_ID: ${{ github.event.inputs.trigger_request_id || '' }}
   BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:

--- a/.github/workflows/browser-throughput-benchmarks.yml
+++ b/.github/workflows/browser-throughput-benchmarks.yml
@@ -29,6 +29,18 @@ on:
         required: false
         default: false
         type: boolean
+      trigger_source:
+        description: 'Recorded on platform runs as their trigger (e.g. platform-retrigger); leave empty for a plain manual run'
+        required: false
+        default: ''
+      trigger_requested_by:
+        description: 'Who asked for this run (e.g. the platform org slug); recorded alongside trigger_source'
+        required: false
+        default: ''
+      trigger_request_id:
+        description: 'Platform re-trigger request id; recorded so the platform can link this run back to the request'
+        required: false
+        default: ''
 
 concurrency:
   group: browser-throughput-benchmarks
@@ -41,6 +53,9 @@ permissions:
 
 env:
   BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCH_TRIGGER_SOURCE: ${{ github.event.inputs.trigger_source || '' }}
+  BENCH_TRIGGER_REQUESTED_BY: ${{ github.event.inputs.trigger_requested_by || '' }}
+  BENCH_TRIGGER_REQUEST_ID: ${{ github.event.inputs.trigger_request_id || '' }}
   BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:

--- a/.github/workflows/sandbox-dax-benchmarks.yml
+++ b/.github/workflows/sandbox-dax-benchmarks.yml
@@ -37,6 +37,18 @@ on:
         required: false
         default: false
         type: boolean
+      trigger_source:
+        description: 'Recorded on platform runs as their trigger (e.g. platform-retrigger); leave empty for a plain manual run'
+        required: false
+        default: ''
+      trigger_requested_by:
+        description: 'Who asked for this run (e.g. the platform org slug); recorded alongside trigger_source'
+        required: false
+        default: ''
+      trigger_request_id:
+        description: 'Platform re-trigger request id; recorded so the platform can link this run back to the request'
+        required: false
+        default: ''
 
 concurrency:
   group: dax-benchmarks
@@ -49,6 +61,9 @@ permissions:
 
 env:
   BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCH_TRIGGER_SOURCE: ${{ github.event.inputs.trigger_source || '' }}
+  BENCH_TRIGGER_REQUESTED_BY: ${{ github.event.inputs.trigger_requested_by || '' }}
+  BENCH_TRIGGER_REQUEST_ID: ${{ github.event.inputs.trigger_request_id || '' }}
   BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:

--- a/.github/workflows/sandbox-tti-benchmarks.yml
+++ b/.github/workflows/sandbox-tti-benchmarks.yml
@@ -37,6 +37,18 @@ on:
         required: false
         default: false
         type: boolean
+      trigger_source:
+        description: 'Recorded on platform runs as their trigger (e.g. platform-retrigger); leave empty for a plain manual run'
+        required: false
+        default: ''
+      trigger_requested_by:
+        description: 'Who asked for this run (e.g. the platform org slug); recorded alongside trigger_source'
+        required: false
+        default: ''
+      trigger_request_id:
+        description: 'Platform re-trigger request id; recorded so the platform can link this run back to the request'
+        required: false
+        default: ''
 
 concurrency:
   group: benchmarks
@@ -49,6 +61,9 @@ permissions:
 
 env:
   BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCH_TRIGGER_SOURCE: ${{ github.event.inputs.trigger_source || '' }}
+  BENCH_TRIGGER_REQUESTED_BY: ${{ github.event.inputs.trigger_requested_by || '' }}
+  BENCH_TRIGGER_REQUEST_ID: ${{ github.event.inputs.trigger_request_id || '' }}
   BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:

--- a/.github/workflows/snapshot-fork-benchmarks.yml
+++ b/.github/workflows/snapshot-fork-benchmarks.yml
@@ -38,6 +38,18 @@ on:
         required: false
         default: false
         type: boolean
+      trigger_source:
+        description: 'Recorded on platform runs as their trigger (e.g. platform-retrigger); leave empty for a plain manual run'
+        required: false
+        default: ''
+      trigger_requested_by:
+        description: 'Who asked for this run (e.g. the platform org slug); recorded alongside trigger_source'
+        required: false
+        default: ''
+      trigger_request_id:
+        description: 'Platform re-trigger request id; recorded so the platform can link this run back to the request'
+        required: false
+        default: ''
 
 concurrency:
   group: snapshot-fork-benchmarks
@@ -50,6 +62,9 @@ permissions:
 
 env:
   BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCH_TRIGGER_SOURCE: ${{ github.event.inputs.trigger_source || '' }}
+  BENCH_TRIGGER_REQUESTED_BY: ${{ github.event.inputs.trigger_requested_by || '' }}
+  BENCH_TRIGGER_REQUEST_ID: ${{ github.event.inputs.trigger_request_id || '' }}
   BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:

--- a/.github/workflows/storage-benchmarks.yml
+++ b/.github/workflows/storage-benchmarks.yml
@@ -44,6 +44,18 @@ on:
         required: false
         default: false
         type: boolean
+      trigger_source:
+        description: 'Recorded on platform runs as their trigger (e.g. platform-retrigger); leave empty for a plain manual run'
+        required: false
+        default: ''
+      trigger_requested_by:
+        description: 'Who asked for this run (e.g. the platform org slug); recorded alongside trigger_source'
+        required: false
+        default: ''
+      trigger_request_id:
+        description: 'Platform re-trigger request id; recorded so the platform can link this run back to the request'
+        required: false
+        default: ''
 
 concurrency:
   group: storage-benchmarks
@@ -56,6 +68,9 @@ permissions:
 
 env:
   BENCHMARK_SLUG: ${{ github.event.inputs.slug || '' }}
+  BENCH_TRIGGER_SOURCE: ${{ github.event.inputs.trigger_source || '' }}
+  BENCH_TRIGGER_REQUESTED_BY: ${{ github.event.inputs.trigger_requested_by || '' }}
+  BENCH_TRIGGER_REQUEST_ID: ${{ github.event.inputs.trigger_request_id || '' }}
   BENCHMARK_NAME: ${{ github.event.inputs.name || '' }}
 
 jobs:


### PR DESCRIPTION
## Summary
Lets the platform re-trigger the weekly benchmark workflows (`storage`, `snapshot-fork`, `browser`, `browser-throughput`, `sandbox-tti`, `sandbox-dax`, `ai-gateway`) the same way it already re-triggers `benchmarks-daily`.

Each workflow gains three optional `workflow_dispatch` inputs — `trigger_source`, `trigger_requested_by`, `trigger_request_id` — forwarded as workflow-level env:

```yaml
env:
  BENCH_TRIGGER_SOURCE: ${{ github.event.inputs.trigger_source || '' }}
  BENCH_TRIGGER_REQUESTED_BY: ${{ github.event.inputs.trigger_requested_by || '' }}
  BENCH_TRIGGER_REQUEST_ID: ${{ github.event.inputs.trigger_request_id || '' }}
```

`benchsdk-runner` (#411) already reads these and records `config.trigger` on the platform run, so no runner change is needed. Empty on `schedule`/`push`, so existing runs are unaffected.

Companion: platform PR adding the weekly slugs as owner-only retrigger targets.

Link to Devin session: https://app.devin.ai/sessions/9356f1d6fbbc46cfa5db98e2be4d4987
Open in Devin Desktop: https://app.devin.ai/desktop/session/9356f1d6fbbc46cfa5db98e2be4d4987?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->