### PR TITLE
chore: sync pnpm-lock.yaml with benchsdk-api package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,49 +248,49 @@ importers:
         version: link:../benchsdk-worker
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-api:
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-cli:
@@ -300,25 +300,25 @@ importers:
         version: link:../benchsdk-api
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-runner:
@@ -334,19 +334,19 @@ importers:
         version: link:../benchsdk-worker
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/benchsdk-worker:
@@ -356,43 +356,43 @@ importers:
         version: link:../benchsdk-api
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       '@vitest/coverage-v8':
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.43))
       eslint:
-        specifier: ^8.57.1
+        specifier: ^8.37.0
         version: 8.57.1
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
   packages/create-bench:
     devDependencies:
       '@types/node':
-        specifier: ^20.19.43
+        specifier: ^20.0.0
         version: 20.19.43
       rimraf:
-        specifier: ^5.0.10
+        specifier: ^5.0.0
         version: 5.0.10
       tsup:
-        specifier: ^8.5.1
+        specifier: ^8.0.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.28)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.0.0
         version: 5.9.3
       vitest:
-        specifier: ^1.6.1
+        specifier: ^1.0.0
         version: 1.6.1(@types/node@20.19.43)
 
 packages:


### PR DESCRIPTION
## Summary
CI on `master` fails at `pnpm install` with `ERR_PNPM_OUTDATED_LOCKFILE`: the lockfile's importer specifiers for `packages/benchsdk-api` devDependencies (`@types/node`, `@vitest/coverage-v8`, `eslint`, `rimraf`, `tsup`, `typescript`, `vitest`) drifted from `package.json`.

Regenerated with `pnpm install --lockfile-only` (pnpm 10.33.0). Only `specifier:` lines change; resolved versions are untouched, so no dependency actually changes. `pnpm install --frozen-lockfile` passes locally afterwards.

Unblocks #419.

Link to Devin session: https://app.devin.ai/sessions/9356f1d6fbbc46cfa5db98e2be4d4987
Open in Devin Desktop: https://app.devin.ai/desktop/session/9356f1d6fbbc46cfa5db98e2be4d4987?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->