### PR TITLE
ci(ai-gateway): move scheduled iterations onto family matrix entries

### DIFF
--- a/.github/workflows/ai-gateway-benchmarks.yml
+++ b/.github/workflows/ai-gateway-benchmarks.yml
@@ -116,6 +116,7 @@ jobs:
             svgScript: generate-ai-gateway-svg
             svgFile: ai-gateway.svg
             timeout: 60
+            scheduleIterations: 50
           - slug: openai
             label: OpenAI
             benchScript: benchmarks/ai-gateway/ai-gateway-openai.bench.ts
@@ -123,6 +124,7 @@ jobs:
             svgScript: generate-ai-gateway-openai-svg
             svgFile: ai-gateway-openai.svg
             timeout: 60
+            scheduleIterations: 50
           - slug: gemini
             label: Gemini
             benchScript: benchmarks/ai-gateway/ai-gateway-gemini.bench.ts
@@ -130,6 +132,7 @@ jobs:
             svgScript: generate-ai-gateway-gemini-svg
             svgFile: ai-gateway-gemini.svg
             timeout: 60
+            scheduleIterations: 50
           - slug: kimi
             label: Kimi
             benchScript: benchmarks/ai-gateway/ai-gateway-kimi.bench.ts
@@ -137,6 +140,7 @@ jobs:
             svgScript: generate-ai-gateway-kimi-svg
             svgFile: ai-gateway-kimi.svg
             timeout: 150
+            scheduleIterations: 25
             iterations: 25
     # Manual runs can scope to one family via the `family` input; push/schedule
     # triggers always run all four.
@@ -182,11 +186,7 @@ jobs:
           fi
 
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            if [ "${{ matrix.family.slug }}" = "kimi" ]; then
-              ITERATIONS="25"
-            else
-              ITERATIONS="50"
-            fi
+            ITERATIONS="${{ matrix.family.scheduleIterations }}"
           elif [ "${{ github.event_name }}" = "push" ]; then
             ITERATIONS="10"
           elif [ -n "$INPUT_ITERATIONS" ]; then


### PR DESCRIPTION
## Summary

Scheduled AI gateway runs now read `ITERATIONS` from a `scheduleIterations` field on each family's matrix entry (`50`, `50`, `50`, kimi `25`) instead of a nested `if [ family = kimi ]` block inside the run step. Values are unchanged — this only moves them onto the matrix so the benchmarks-daily matrix generator can parse the per-family scheduled count from this workflow, the same way it derives iteration defaults for every other benchmark kind. Companion PR: computesdk/benchmarks-daily (derives ai-gateway iterations from these fields).

- Manual `workflow_dispatch` behavior is untouched: `iterations` input → `family.iterations` (kimi's existing manual override, kept) → `50` fallback.
- `scheduleIterations` is a new matrix key consumed by both the run step and the downstream daily parser.

Link to Devin session: https://app.devin.ai/sessions/da3f7ae360c64b3abee3ed321df7615a
Open in Devin Desktop: https://app.devin.ai/desktop/session/da3f7ae360c64b3abee3ed321df7615a?variant=devin
Requested by: @dtice25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->