### PR TITLE
Log sandbox id once per task, after destroy

### DIFF
--- a/benchmarks/reliability/sandbox-opencode.bench.ts
+++ b/benchmarks/reliability/sandbox-opencode.bench.ts
@@ -3,7 +3,7 @@ import '../src/env.js';
 import { defineBenchmarkConfig, defineTask, TaskError } from '@benchsdk/runner';
 import { withTimeout } from '../src/util/timeout.js';
 import { formatError } from '../src/util/error.js';
-import { sandboxId as getSandboxId } from '../src/util/sandbox-id.js';
+import { sandboxId } from '../src/util/sandbox-id.js';
 import { providers } from '../sandbox/providers.js';
 import type { ProviderConfig } from '../sandbox/types.js';
 
@@ -38,10 +38,8 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
   const compute = participant.createCompute();
 
   let sandbox: any;
-  let sandboxId: string | null = null;
 
   try {
-    const createStart = Date.now();
     sandbox = await step('create', () =>
       withTimeout(
         compute.sandbox.create({
@@ -52,9 +50,6 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
         'Sandbox creation timed out',
       ),
     );
-    sandboxId = getSandboxId(sandbox);
-    log('Sandbox created', { level: 'info', meta: { provider: participant.name, sandboxId, createMs: Date.now() - createStart } });
-    console.log(`  [${participant.name}] sandbox ${sandboxId ?? '<no id>'} created in ${Date.now() - createStart}ms`);
 
     await step('install', async () => {
       const result = await sandbox.runCommand(
@@ -64,11 +59,11 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
       if (result.exitCode !== 0) {
         log('OpenCode install failed', {
           level: 'error',
-          meta: { sandboxId, exitCode: result.exitCode, stderr: preview(result.stderr) },
+          meta: { exitCode: result.exitCode, stderr: preview(result.stderr) },
         });
         throw new TaskError(`OpenCode install failed (exit ${result.exitCode})`);
       }
-      log('OpenCode install succeeded', { level: 'info', meta: { sandboxId, exitCode: result.exitCode } });
+      log('OpenCode install succeeded', { level: 'info', meta: { exitCode: result.exitCode } });
     });
 
     const output = await step('run', async () =>
@@ -82,7 +77,7 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
     if (output.exitCode !== 0) {
       log('OpenCode run failed', {
         level: 'error',
-        meta: { sandboxId, exitCode: output.exitCode, stdout: preview(stdout), stderr: preview(output.stderr) },
+        meta: { exitCode: output.exitCode, stdout: preview(stdout), stderr: preview(output.stderr) },
       });
       throw new TaskError(`OpenCode run failed (exit ${output.exitCode})`);
     }
@@ -90,7 +85,7 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
     const foundOk = stdout.includes('tensorlake-ok');
     log('OpenCode run completed', {
       level: foundOk ? 'info' : 'error',
-      meta: { sandboxId, exitCode: output.exitCode, outputLength: stdout.length, foundOk, stdout: preview(stdout) },
+      meta: { exitCode: output.exitCode, outputLength: stdout.length, foundOk, stdout: preview(stdout) },
     });
     if (!foundOk) {
       throw new TaskError(`OpenCode output did not include "tensorlake-ok": ${stdout}`.trim());
@@ -106,7 +101,8 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
             'Destroy timeout',
           ),
         { reportConcurrency: false },
-      ).catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { sandboxId, error: formatError(err) } }));
+      ).catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { error: formatError(err) } }));
+      log('sandbox', { level: 'info', meta: { provider: participant.name, sandboxId: sandboxId(sandbox) } });
     }
   }
 });

--- a/benchmarks/sandbox/dax.bench.ts
+++ b/benchmarks/sandbox/dax.bench.ts
@@ -25,7 +25,7 @@ import type { JsonObject, TaskStepRecord } from '@benchsdk/api';
 import { VMTier } from '@codesandbox/sdk';
 import { withTimeout } from '../src/util/timeout.js';
 import { formatError } from '../src/util/error.js';
-import { sandboxId as getSandboxId } from '../src/util/sandbox-id.js';
+import { sandboxId } from '../src/util/sandbox-id.js';
 import { providers } from './providers.js';
 import type { ProviderConfig } from './types.js';
 import { BENCH_SCRIPT_PATH } from './dax.js';
@@ -332,9 +332,6 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
     console.error(`  [${p.name}] ${message}`);
     throw new TaskError(message, { code: 'create_failed', data: { error: message } });
   });
-  const sandboxId = getSandboxId(sandbox);
-  log('Sandbox created', { level: 'info', meta: { provider: p.name, sandboxId, createMs: Date.now() - createStart } });
-  console.log(`  [${p.name}] sandbox ${sandboxId ?? '<no id>'} created in ${Date.now() - createStart}ms`);
 
   let timing: DaxTimingResult;
   let output: DaxBuildOutput | undefined;
@@ -357,9 +354,8 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
       .step('destroy', () => withTimeout(sandbox.destroy(), p.destroyTimeoutMs ?? destroyTimeoutMs, 'Destroy timeout'), {
         reportConcurrency: false,
       })
-      .catch((err: unknown) =>
-        log('destroy failed', { level: 'warn', meta: { provider: p.name, sandboxId, error: formatError(err) } }),
-      );
+      .catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { error: formatError(err) } }));
+    log('sandbox', { level: 'info', meta: { provider: p.name, sandboxId: sandboxId(sandbox) } });
   }
 
   const data = { ...(timing as unknown as JsonObject), ...(output?.failedPhase ? { failedPhase: output.failedPhase } : {}) };
@@ -372,7 +368,6 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
       level: 'error',
       meta: {
         provider: p.name,
-        sandboxId,
         totalMs: timing.totalMs,
         phasesCompleted: `${timing.phasesCompleted}/${timing.phasesTotal}`,
         ...(output?.failedPhase ? { failedPhase: output.failedPhase } : {}),
@@ -385,7 +380,7 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
     console.error(
       [
         `  [${p.name}] Dax build failed${output?.failedPhase ? ` in ${output.failedPhase}` : ''}` +
-          ` (sandbox ${sandboxId ?? 'unknown'}, ${timing.phasesCompleted}/${timing.phasesTotal} phases, exit ${output?.exitCode ?? 'n/a'}): ${timing.error}`,
+          ` (${timing.phasesCompleted}/${timing.phasesTotal} phases, exit ${output?.exitCode ?? 'n/a'}): ${timing.error}`,
         ...(stderrTail ? ['  --- stderr (tail) ---', indent(stderrTail)] : []),
         ...(stdoutTail ? ['  --- stdout (tail) ---', indent(stdoutTail)] : []),
       ].join('\n'),
@@ -397,7 +392,6 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
     level: 'info',
     meta: {
       provider: p.name,
-      sandboxId,
       totalMs: timing.totalMs,
       phasesCompleted: `${timing.phasesCompleted}/${timing.phasesTotal}`,
       ...(timing.commit ? { commit: timing.commit } : {}),

--- a/benchmarks/sandbox/tti.bench.ts
+++ b/benchmarks/sandbox/tti.bench.ts
@@ -24,7 +24,7 @@ import { fileURLToPath } from 'node:url';
 import { defineBenchmarkConfig, defineTask } from '@benchsdk/runner';
 import { withTimeout } from '../src/util/timeout.js';
 import { formatError } from '../src/util/error.js';
-import { sandboxId as getSandboxId } from '../src/util/sandbox-id.js';
+import { sandboxId } from '../src/util/sandbox-id.js';
 import { providers } from './providers.js';
 import type { ProviderConfig } from './types.js';
 import { writeSandboxLegacyResults } from './legacy-results.js';
@@ -77,7 +77,6 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
   let sandbox: TtiSandbox | undefined;
   let createMs: number | undefined;
   let ttiMs: number | undefined;
-  let sandboxId: string | null = null;
 
   try {
     sandbox = await step('create', async () => {
@@ -92,15 +91,7 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
     if (sandbox === undefined) {
       throw new Error('create step did not return a sandbox');
     }
-    sandboxId = getSandboxId(sandbox);
     const commandSandbox = sandbox;
-
-    // Creation is logged only after the first command so no I/O sits inside
-    // the measured create-to-command window.
-    const logCreated = () => {
-      log('Sandbox created', { level: 'info', meta: { provider: participant.name, sandboxId, createMs: Math.round(createMs ?? 0) } });
-      console.log(`  [${participant.name}] sandbox ${sandboxId ?? '<no id>'} created in ${Math.round(createMs ?? 0)}ms`);
-    };
 
     const commandStart = performance.now();
     const result = await step('exec.task', async () => {
@@ -110,7 +101,7 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
         'First command execution timed out',
       );
       if (r.exitCode !== 0) {
-        log('node -v failed', { level: 'error', meta: { sandboxId, exitCode: r.exitCode, stderr: r.stderr ?? null } });
+        log('node -v failed', { level: 'error', meta: { exitCode: r.exitCode, stderr: r.stderr ?? null } });
         throw new Error(`Command failed with exit code ${r.exitCode}: ${r.stderr || 'Unknown error'}`);
       }
       if (createMs === undefined) {
@@ -118,18 +109,19 @@ export const task = defineTask<ProviderConfig>(async (ctx) => {
       }
       ttiMs = createMs + (performance.now() - commandStart);
       return r;
-    }).finally(logCreated);
+    });
     if (ttiMs === undefined) {
       throw new Error('exec.task did not produce a ttiMs measurement');
     }
     measure({ ttiMs });
-    log('node -v succeeded', { level: 'info', meta: { sandboxId, version: result.stdout?.trim() ?? null, exitCode: result.exitCode } });
+    log('node -v succeeded', { level: 'info', meta: { version: result.stdout?.trim() ?? null, exitCode: result.exitCode } });
   } finally {
     if (sandbox) {
       await step('destroy', () =>
         withTimeout(sandbox!.destroy(), participant.destroyTimeoutMs ?? DESTROY_TIMEOUT_MS, 'Destroy timeout'),
         { reportConcurrency: false },
-      ).catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { sandboxId, error: formatError(err) } }));
+      ).catch((err: unknown) => log('destroy failed', { level: 'warn', meta: { error: formatError(err) } }));
+      log('sandbox', { level: 'info', meta: { provider: participant.name, sandboxId: sandboxId(sandbox) } });
     }
   }
 


### PR DESCRIPTION
## Summary
Follow-up to #425. Providers raised concern that the sandbox-id logging added in #425 (a "Sandbox created" `ctx.log` + `console.log` between create and the first measured step, plus `sandboxId` threaded through every success/failure log line) could add time to the benchmark.

This reverts all of that and replaces it with a single line per task in each benchmark's `finally`, emitted after the `destroy` step so it runs on both the success and error paths and strictly after every measured step:

```ts
} finally {
  await step('destroy', ...).catch(...);
  log('sandbox', { level: 'info', meta: { provider, sandboxId: sandboxId(sandbox) } });
}
```

DAX, TTI and the Tensorlake OpenCode reliability bench are all otherwise back to their pre-#425 shape. `sandboxId()` helper (reads only `sandbox.sandboxId`) is unchanged.

Link to Devin session: https://app.devin.ai/sessions/dfe2c1850e5b40808ff94970325e907f
Open in Devin Desktop: https://app.devin.ai/desktop/session/dfe2c1850e5b40808ff94970325e907f?variant=devin
Requested by: @HeyGarrison
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/computesdk/benchmarks/pull/426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->